### PR TITLE
Epic 6 retrospective + sprint status → done

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-6-retro-2026-04-14.md
+++ b/_bmad-output/implementation-artifacts/epic-6-retro-2026-04-14.md
@@ -1,0 +1,113 @@
+# Epic 6 Retrospective — Pipeline CI/CD et fiabilité
+
+**Date:** 2026-04-14
+**Facilitator:** Bob (Scrum Master)
+**Project Lead:** Guy
+**Epic status:** ✅ done (4/4 stories)
+
+---
+
+## 1. Delivery summary
+
+4/4 stories done: 6-1, 6-2, 6-3, 6-4. Inserted mid-flight (2026-04-13) between Epic 5 and Epic 7 to repay retro debt before auth work begins.
+
+**Scope shipped:**
+- **6-1** — Reusable `_gates.yml` workflow with 3 parallel gates (`rust-tests`, `db-integration`, `e2e`); semver-only Docker Hub publishing via `release.yml`; branch protection on `main`; `docs/ci-cd.md` maintainer guide.
+- **6-2** — Seeded librarian user + typed `loginAs(page, role?)` with `"admin" | "librarian"` union; `tsc --noEmit` gate in the e2e job; dedicated `librarian-smoke.spec.ts`; new `tests/seeded_users.rs` integration test.
+- **6-3** — Server-side fix for the `manually_edited_fields` background-fetch race (version + per-field guards) + flag-wipe fix in all 12 `final_<field>` blocks of `confirm_metadata`; 9 new unit tests + 3 new DB-integration tests.
+- **6-4** — All 20 `page.waitForTimeout` calls removed across 8 specs; CI grep gate in `e2e` job; enforcement documented in CLAUDE.md.
+
+**Gate state at epic close:** 336 unit tests, 21+ DB integration tests, 134/134 E2E on fresh Docker — all green. CI on PR #4 ran green with the new grep + typecheck gates active.
+
+---
+
+## 2. Epic 5 retro follow-through
+
+| Epic 5 action | Status | Evidence |
+|---|---|---|
+| Action 1: seed librarian + `loginAs(role)` | ✅ | Story 6-2 — migration `20260414000001_seed_librarian_user.sql`, typed union, `librarian-smoke.spec.ts` |
+| Action 2: fix `manually_edited_fields` + fetch race | ✅ | Story 6-3 — `do_update` with version+guard, `confirm_metadata` `should_clear_flag` helper |
+| Action 3: eliminate `waitForTimeout` + CI gate | ✅ | Story 6-4 — 20→0 occurrences, grep step in `e2e` job between tsc and Playwright install |
+| Bonus: stub `/admin` or role-gate the nav link | ❌ | Still a dead link. Carry forward to Epic 7 or Epic 8 kickoff. |
+
+**Score: 3/3 primary actions complete, 1 bonus deferred.** Highest follow-through rate of the project so far — Epic 6's existence was specifically designed as retro payback before Epic 7, and it delivered.
+
+---
+
+## 3. What went well
+
+- **Retro debt paid with interest.** The "insert Epic 6 between 5 and 7" decision (2026-04-13) kept Epic 7 from inheriting 32 `waitForTimeout` remnants, a missing role, and a landmine race condition. Each 6-x story was scoped tight and shipped clean.
+- **Code-review discipline held.** Every story went through adversarial review (Blind + Edge Case + Acceptance) with Medium+ findings fixed before merge. 6-3 caught `should_clear_flag` ambiguities, 6-4 caught weakened-wait replacements (see §4, item 2).
+- **Integration tests proved the race fix.** 6-3's `metadata_fetch_race.rs` (3 tests) demonstrated both the per-field guard AND the version-check branch — AC #2 and #8 proven deterministically rather than via timing-sensitive E2E. Template for future concurrency work.
+- **Typed union for `loginAs(role)`.** `tsc --noEmit` wired into CI means role typos fail at compile, not at runtime. Seed-as-source-of-truth rule for CI passwords documented in CLAUDE.md.
+- **Grep gate is cheap and load-bearing.** 5-line bash step before Playwright install = fast-fail on new `waitForTimeout` regressions forever.
+- **PR #4 bundle landed cleanly.** 28 files across 3 stories + the un-pushed 6-1 patch commit, merged with one follow-up hotfix (see §4, item 2).
+
+---
+
+## 4. Recurring struggles / patterns
+
+1. **Baseline flakes rediscovered mid-epic.** 6-2 Dev-Agent Record and AC #9 flagged 4 pre-existing E2E failures as "known baseline" pending 6-3/6-4. This created an ambiguous merge gate until Guy clarified: *any failing test blocks PRs* (feedback memory confirmed). Lesson: the "known baseline" escape hatch is tempting and should be used sparingly — it was the right call here only because 6-3/6-4 were already on deck.
+2. **Code-review patches can themselves regress.** In story 6-4, my code-review patch tightened `cross-cutting.spec.ts` from a no-op `#feedback-list` visibility to `.feedback-entry[data-feedback-variant="success"]`. It passed local typecheck and fresh-Docker E2E, but failed on CI because ISBN scans land as `.feedback-skeleton` first (success arrives only after BnF resolution). Fixed in commit `629692a` using the established `waitForSelector(".feedback-skeleton, .feedback-entry")` pattern. **Lesson:** when tightening a wait, verify the DOM transitions under the actual async flow, not just under local timing.
+3. **Entangled working-tree commits.** Stories 6-2 and 6-3 were implemented with `sprint-status.yaml` and `CLAUDE.md` edits that never got committed. By the time 6-4 ran its code review, the working tree carried 3 stories' worth of uncommitted files. Single bundled PR was the pragmatic exit, but clean per-story PRs would have been better. **Lesson:** commit + push per story at `review` transition, not just at `done`.
+4. **Role-guard surprise in `create_location`.** Story 6-2 discovered `POST /locations` requires `Role::Admin` (not Librarian). The intended scope — migrate an `epic2-smoke` test to librarian — was blocked by a real permission gap. Correctly deferred to Epic 7 as a role-model re-evaluation. Not a struggle so much as a *finding surfaced early*, which is exactly what canary migrations are for.
+5. **Main-branch local divergence after squash-merge.** Local `main` got ahead of `origin/main` by 2 commits pre-PR, then GitHub squash-merged PR #4. Required `git reset --hard origin/main` to resync. Not a problem, but a standing habit worth keeping: after each PR merge, `git checkout main && git pull --ff-only` or reset hard if divergent.
+
+---
+
+## 5. Technical debt incurred / surfaced in Epic 6
+
+Tracked in `deferred-work.md`. Epic-6-specific items:
+
+- **6-1 deferred (3):** Cargo.toml version parsing fragile vs workspace/BOM/CRLF; `_gates.yml` callers missing `secrets: inherit` footgun; Task 3.5 tag-mismatch smoke test.
+- **6-2 deferred (2):** `INSERT ... WHERE NOT EXISTS` seed pattern ignores hash/role drift; `tsconfig.json` lacks `noUncheckedIndexedAccess` / `exactOptionalPropertyTypes` — broader E2E TS hygiene pass.
+- **6-2 Epic 7 carry-over:** Re-evaluate whether Librarian should have `create_location` / edit permissions, or document the Admin-only decision.
+- **6-3:** None deferred (all 12 field blocks fixed, all 9 + 3 tests covering branches).
+- **6-4:** None deferred (Foundation Rule #3 test-only refactor waiver; full suite is the regression guard).
+
+**Cross-story/carry-forward:**
+- `/admin` dead nav link (Epic 5 retro bonus, still open).
+- CSRF still missing (deferred since 1-2; Epic 7 is the natural home).
+- Per-user language preference model (FR77, requires schema addition).
+- Soft-delete lacks version check (Epic 5 carry-forward).
+
+---
+
+## 6. Epic 7 preview — dependencies & risks
+
+**Epic 7 scope:** FR65–FR67 (anonymous browse + Librarian + Admin auth paths), FR69 (inactivity timeout + Toast), FR77 (FR/EN language switch), NFR13/NFR15 (security), UX-DR14 (Toast), UX-DR25 (scanner-guard.js), AR13/AR15/AR19.
+
+**Dependencies satisfied by Epic 6:**
+1. ✅ Seeded librarian user + typed `loginAs(page, "librarian")` — 6-2.
+2. ✅ Race-free background metadata fetch (safe under concurrent sessions) — 6-3.
+3. ✅ Stable parallel E2E suite without `waitForTimeout` flake surface — 6-4.
+4. ✅ Required-status-check gates on `main` — 6-1.
+
+**Residual risks / gaps for Epic 7:**
+- ⚠️ **Role model is inconsistent.** `create_location` / edit-location require Admin (6-2 finding). Epic 7 must audit every write route and decide: Librarian-or-Admin, or Admin-only with UX rationale.
+- ⚠️ **CSRF still missing.** Multi-role auth without CSRF is an obvious gap. Land before or during Epic 7.
+- ⚠️ **Per-user language preference** (FR77) requires schema + settings UI. Not trivial — budget for it in Epic 7 or split off.
+- ⚠️ **`/admin` dead link** — fix in Epic 7 kickoff (role-gate the nav link or return 403 placeholder).
+
+**No blockers** to starting Epic 7 story decomposition.
+
+---
+
+## 7. Action items for Epic 7 kickoff
+
+- [ ] **Action 1 (quick win):** Role-gate the `/admin` nav link in `templates/components/nav_bar.html` — show only when `role == "admin"`. Or stub `/admin` with a 403 + "coming in Epic 8" message. Closes Epic 5's bonus carry-over.
+- [ ] **Action 2 (scope decision):** During Epic 7 story decomposition, audit every `POST`/`DELETE` route's role guard. Produce a one-page role matrix (route × role × allowed) as input to stories 7-x. Blocks ambiguous "which role can do what" questions during dev.
+- [ ] **Action 3 (land with auth):** Add CSRF protection as part of the first Epic 7 story that touches auth middleware. Don't defer further — this is the right context window.
+- [ ] **Habit:** Commit + push per story at the `review` transition (not at `done`), to avoid the 3-story working-tree tangle observed this epic.
+
+---
+
+## 8. Overall assessment
+
+**Success level:** Very high. Epic 6 was a one-week, 4-story bridge built entirely out of Epic 5 retro action items, and every item was delivered with code-review-clean implementations, integration tests, and CI wiring. The epic's *purpose* — keep Epic 7 from inheriting Epic 5's flake surface and landmine race — was achieved.
+
+**Team dynamics:** Guy's "failing tests block PRs" feedback (feedback memory `failing_tests_block_pr`) was correctly applied in 6-2 to reject the "known baseline" escape hatch as a long-term practice, even while accepting it for one story's gate. The test-reliability-over-new-features preference continues to be a load-bearing project value.
+
+**Retrospective meta-observation:** This is the first epic whose scope *was* a retrospective action list. The model works — when retro debt is large enough to compete with feature work, inserting a dedicated epic is cleaner than grinding debt-payment stories inside a feature epic. Keep this pattern available for future inflection points.
+
+**Epic 7 readiness:** Green. Ready for story decomposition.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-04-14 # Story 6-4 → done (code-review patches applied)
+last_updated: 2026-04-14 # Epic 6 → done + retrospective done
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -118,12 +118,12 @@ development_status:
   # Epic 6: Pipeline CI/CD et fiabilité (inserted 2026-04-13)
   # Groups infrastructure + Epic 5 retro action items before Epic 7 auth work.
   # No FR/NFR mapping — tooling + test-debt work.
-  epic-6: in-progress
+  epic-6: done
   6-1-github-and-ci-cd-pipeline: done
   6-2-seed-librarian-and-loginas-role: done
   6-3-fix-manually-edited-fields-race: done
   6-4-cleanup-waitfortimeout-and-grep-gate: done
-  epic-6-retrospective: optional
+  epic-6-retrospective: done
 
   # Epic 7: Accès multi-rôle & Sécurité
   # FRs: FR65-FR67, FR69(timeout+Toast), FR77


### PR DESCRIPTION
## Summary
- Rétrospective Epic 6 rédigée : `epic-6-retro-2026-04-14.md`
- `sprint-status.yaml` : `epic-6` → done, `epic-6-retrospective` → done

## Highlights
- 3/3 actions Epic 5 retro livrées (6-2, 6-3, 6-4)
- Actions Epic 7 : role-gate `/admin`, matrice rôles/routes, CSRF avec la première story auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)