### PR TITLE
chore: GitHub issue templates (CR / Bug / KF / Code Review Finding)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: 🐛 Bug Report
+description: Report a defect or regression in the app.
+title: "[Bug] "
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for **defects** — something that should work and doesn't, or used to work and regressed. Attach a screenshot or copy a browser console error when helpful. For accepted-risk quirks, use Known Failure instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: One or two sentence summary of what's broken.
+      placeholder: "Clicking a genre pill on `/` with an empty query duplicates the full page layout."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list — what the user did, in order.
+      placeholder: |
+        1. Log in as admin and navigate to `/`.
+        2. Leave the search field empty.
+        3. Click the "BD" genre pill.
+        4. Observe the page.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "The browse-results area updates to show titles in the BD genre; the rest of the page stays unchanged."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happens. Attach a screenshot if visual.
+      placeholder: "The full page layout (nav, hero, search, pills, sort-by) is rendered a second time inside `#browse-results`."
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser / OS / app commit or Docker tag (if relevant).
+      placeholder: "Chromium on Linux, dev stack at commit 5b209e7"
+
+  - type: input
+    id: related
+    attributes:
+      label: Related story, PR, or commit
+      placeholder: "e.g. story 7-5, commit 772bd27, PR #7"
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - High (blocks a core workflow)
+        - Medium (degrades a workflow but workaround exists)
+        - Low (cosmetic or edge case)
+      default: 1
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/change_request.yml
+++ b/.github/ISSUE_TEMPLATE/change_request.yml
@@ -1,0 +1,64 @@
+name: 🔀 Change Request
+description: Propose a change to the product requirements, architecture, or implementation.
+title: "[CR] "
+labels: ["type:change-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for **product / architectural shifts** — a Change Request is a proposed change to the PRD, architecture, data model, or cross-cutting concern. For defects, use the Bug Report template; for accepted-risk quirks, use Known Failure.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to change and why. Include motivation, user signal, or UX rationale.
+      placeholder: |
+        Librarian can undo the last scan action (detach volume, cancel location assignment) from the feedback list within a 30-second window. Acts as a safety net for accidental associations.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: impacts
+    attributes:
+      label: Impacts
+      description: Check every area the change touches.
+      options:
+        - label: PRD (new FR / NFR / refinement)
+        - label: Architecture
+        - label: Data model / migration
+        - label: API / route
+        - label: UI / UX
+        - label: Tests
+        - label: Documentation / CLAUDE.md
+
+  - type: input
+    id: requested_by
+    attributes:
+      label: Requested by
+      placeholder: "e.g. UX Design session, Guy, code review of story 7-5"
+
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Target milestone
+      options:
+        - M1 (foundation)
+        - M2
+        - M3
+        - M4
+        - M5
+        - M6
+        - Post-MVP / Growth
+        - N/A
+      default: 7
+    validations:
+      required: false
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision (fill when resolved)
+      description: Outcome + rationale. Link to the PR, story, or retrospective that resolved it.
+      placeholder: |
+        Deferred to Growth. MVP relies on preventive validation and explicit confirmation. See Epic 2 retro.

--- a/.github/ISSUE_TEMPLATE/code_review_finding.yml
+++ b/.github/ISSUE_TEMPLATE/code_review_finding.yml
@@ -1,0 +1,58 @@
+name: 🔍 Code Review Finding
+description: Track a deferred finding from an adversarial code review (Blind Hunter / Edge Case Hunter / Acceptance Auditor).
+title: "[CR-Review] "
+labels: ["type:code-review-finding"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use for **individual findings** surfaced by a code review that the story chose to defer rather than fix in-line. Each finding gets its own issue so it can be triaged, scheduled, closed, or escalated independently.
+
+        If the finding was fixed in the same story, it belongs in the story's Change Log, not here.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Finding summary
+      description: One-line title + 1–3 sentence context.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - High
+        - Medium
+        - Low
+      default: 1
+    validations:
+      required: true
+
+  - type: input
+    id: source
+    attributes:
+      label: Source review
+      placeholder: "e.g. Story 7-5 review (2026-04-17), Edge Case Hunter pass"
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: File:line (if applicable)
+      placeholder: "e.g. src/services/search.rs:82, static/js/scanner-guard.js:89"
+
+  - type: textarea
+    id: resolution
+    attributes:
+      label: Resolution approach
+      description: Defer permanently, accept-with-rationale, schedule for story X, or fix-now with issue closure.
+      placeholder: "Defer until UX-DR8 Modal ships in Epic 9 — no current DOM modal exists so this is a latent concern, not an active bug."
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Why the reviewer flagged it, what breaks if ignored, dependencies on other work.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Disable blank issues to force contributors through a typed template.
+# Templates cover the current migration scope (Change Request, Bug, Known
+# Failure, Code Review Finding). Add new templates here when new issue
+# categories emerge — do NOT re-enable blank issues.
+blank_issues_enabled: false
+
+contact_links:
+  - name: 📚 Project documentation
+    url: https://github.com/guycorbaz/mybibli/blob/main/CLAUDE.md
+    about: Coding standards, architecture overview, project conventions, and known app quirks.
+  - name: 🗺️ Epics & PRD
+    url: https://github.com/guycorbaz/mybibli/tree/main/_bmad-output/planning-artifacts
+    about: Product requirements, epic breakdowns, and UX design specifications.

--- a/.github/ISSUE_TEMPLATE/known_failure.yml
+++ b/.github/ISSUE_TEMPLATE/known_failure.yml
@@ -1,0 +1,58 @@
+name: ⚠️ Known Failure
+description: Document a known, non-blocking issue or app quirk (accepted risk).
+title: "[KF] "
+labels: ["type:known-failure"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use for **accepted-risk items, documented quirks, or non-blocking failures** that the team has decided not to fix immediately — but that need to stay visible. Examples: duplicate `#session-counter` IDs, Google Books HTTPS upgrade cosmetic, MariaDB deadlock retry under parallel load.
+
+        For actionable defects, use Bug Report. For product change proposals, use Change Request.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What fails, in what scenario, and why we know about it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: Concrete symptoms. Include error messages, test flake signatures, or observable UX artifacts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround (if any)
+      description: What the team does to live with it. Leave empty if none.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - High (functional but demands attention)
+        - Medium (degrades a non-critical path)
+        - Low (cosmetic / extremely rare)
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Mitigation / acceptance rationale
+      description: Why this is accepted as-is, OR conditions under which we would fix it.
+      placeholder: "Acceptable for single-user NAS; revisit if multi-user support is added."
+
+  - type: input
+    id: related
+    attributes:
+      label: Related files, commits, or docs
+      placeholder: "e.g. src/services/cover.rs:103, CLAUDE.md §Known app quirks, commit e2ab07b"


### PR DESCRIPTION
## Summary

Prepare the repo for migrating `docs/change_request.md`, `deferred-work.md`, and CLAUDE.md §"Known app quirks" into GitHub Issues. Adds 4 YAML form templates and disables blank issues.

- `change_request.yml` — auto-label \`type:change-request\`, for product / architectural shifts.
- `bug_report.yml` — auto-label \`type:bug\`, structured steps-to-reproduce + severity.
- `known_failure.yml` — auto-label \`type:known-failure\`, for accepted-risk quirks.
- `code_review_finding.yml` — auto-label \`type:code-review-finding\`, one issue per deferred review finding.
- `config.yml` disables blank issues; contact links point at CLAUDE.md and planning-artifacts/.

## Test plan

- [x] All 5 YAML files parse as valid GitHub issue forms (checked locally by structure).
- [x] Auto-applied labels will be created by GitHub on first issue if missing — templates work today.
- [ ] Post-merge: \`gh label create\` the type/status/severity/epic labels referenced in follow-up migration PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)