### PR TITLE
chore: add scripts/e2e-reset.sh (Epic 7 retro Action 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,11 @@ cd tests/e2e && npx playwright test specs/journeys/catalog-title.spec.ts  # Sing
 cd tests/e2e && docker compose -f docker-compose.test.yml up -d
 cd tests/e2e && npm test
 
+# E2E stack reset — single-command teardown + rebuild + wait-for-ready.
+# Use when local DB state is polluted and tests expect a fresh baseline
+# (see Epic 7 retrospective Action 4 for the backstory).
+./scripts/e2e-reset.sh
+
 # Flake gate (run before committing E2E changes) — enforced by CI in the e2e job
 grep -rE "waitForTimeout\(" tests/e2e/specs/ tests/e2e/helpers/ && exit 1 || true
 

--- a/scripts/e2e-reset.sh
+++ b/scripts/e2e-reset.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Reset the E2E docker stack to a pristine state.
+#
+# Epic 7 retrospective Action 4 (2026-04-17) — introduced after story 7-5
+# discovery that an 11-hour-old stack with accumulated DB data broke 51
+# tests on a single run. This script gives the dev-loop a one-shot reset
+# equivalent to what CI does on every PR.
+#
+# Usage:
+#     ./scripts/e2e-reset.sh
+#
+# What it does:
+#   1. Takes down the E2E stack AND its volumes (-v), so the DB is wiped.
+#   2. Rebuilds the `mybibli` image from the current working tree.
+#   3. Brings the stack back up detached.
+#   4. Waits for the app to answer `GET /login` before returning 0.
+#
+# Safe to run at any time. Does NOT touch the dev stack (docker-compose.yml
+# in project root) — only tests/e2e/docker-compose.test.yml. Local dev DB
+# state is preserved.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${PROJECT_ROOT}/tests/e2e/docker-compose.test.yml"
+APP_URL="${E2E_APP_URL:-http://localhost:8080/login}"
+WAIT_TIMEOUT="${E2E_WAIT_TIMEOUT:-120}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+    echo "error: ${COMPOSE_FILE} not found — run from the project tree."
+    exit 1
+fi
+
+echo "→ Tearing down E2E stack and removing volumes..."
+docker compose -f "${COMPOSE_FILE}" down -v
+
+echo "→ Rebuilding mybibli image + starting stack..."
+docker compose -f "${COMPOSE_FILE}" up -d --build mybibli
+
+echo "→ Waiting for app at ${APP_URL} (timeout ${WAIT_TIMEOUT}s)..."
+elapsed=0
+until curl -sf "${APP_URL}" > /dev/null 2>&1; do
+    if (( elapsed >= WAIT_TIMEOUT )); then
+        echo "error: app did not become ready within ${WAIT_TIMEOUT}s."
+        echo "     Last compose state:"
+        docker compose -f "${COMPOSE_FILE}" ps
+        exit 1
+    fi
+    sleep 2
+    elapsed=$(( elapsed + 2 ))
+done
+
+echo "✓ E2E stack reset — app ready at ${APP_URL%/login}"


### PR DESCRIPTION
## Summary

One-shot E2E stack reset: teardown + rebuild + wait-for-ready.

- \`scripts/e2e-reset.sh\` wraps \`docker compose down -v\` + \`up -d --build mybibli\` + \`curl\` poll on \`/login\`.
- Does NOT touch the dev \`docker-compose.yml\` stack — only \`tests/e2e/docker-compose.test.yml\`.
- \`E2E_APP_URL\` and \`E2E_WAIT_TIMEOUT\` env overrides for CI / non-standard ports.
- \`CLAUDE.md\` "Build & Test Commands" gets a new entry.

Closes **Epic 7 retro Action 4** — prevents the next dev session from rediscovering the 51-false-failure DB-pollution footgun that cost story 7-5 a full suite run.

## Test plan

- [x] \`bash -n scripts/e2e-reset.sh\` — no syntax errors
- [ ] Manual: run \`./scripts/e2e-reset.sh\` locally, verify 3-cycle Playwright green against the fresh stack (user can validate)
- [x] Script is executable (\`chmod +x\` committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)