### PR TITLE
Fix #81: session cookie collision after login

### DIFF
--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -138,21 +138,43 @@ pub async fn session_resolve_middleware(
     let mut response = next.run(request).await;
 
     if let Some(new_token) = new_cookie_token {
-        // Match cookie lifetime to the 7-day anonymous-purge window so the
-        // browser discards a cookie whose DB row the purge task will have
-        // deleted. Without Max-Age the cookie persists until browser close
-        // and a week-old tab can submit a form against a purged session
-        // row — a 403 the user has no signal to recover from.
-        let cookie = Cookie::build(("session", new_token))
-            .http_only(true)
-            .path("/")
-            .same_site(SameSite::Lax)
-            .max_age(time::Duration::days(7))
-            .build();
-        if let Ok(value) = cookie.to_string().parse() {
-            response
-                .headers_mut()
-                .append(axum::http::header::SET_COOKIE, value);
+        // Issue #81 fix: skip the anonymous cookie append if the handler
+        // already emitted a `session=` Set-Cookie via its own CookieJar
+        // (login, logout, etc.). Without this guard the middleware's anon
+        // cookie lands AFTER the handler's auth cookie in the response,
+        // and clients (browsers + curl, per RFC 6265 §5.4 "later cookie
+        // wins for same name/domain/path") pick up the anon one — pointing
+        // at a session row the login handler just soft-deleted, so every
+        // subsequent request resolves as anonymous and authentication
+        // appears to silently fail.
+        let handler_already_set_session_cookie = response
+            .headers()
+            .get_all(axum::http::header::SET_COOKIE)
+            .iter()
+            .any(|v| {
+                v.to_str()
+                    .map(|s| s.starts_with("session=") || s.starts_with("session ="))
+                    .unwrap_or(false)
+            });
+
+        if !handler_already_set_session_cookie {
+            // Match cookie lifetime to the 7-day anonymous-purge window so
+            // the browser discards a cookie whose DB row the purge task
+            // will have deleted. Without Max-Age the cookie persists until
+            // browser close and a week-old tab can submit a form against a
+            // purged session row — a 403 the user has no signal to recover
+            // from.
+            let cookie = Cookie::build(("session", new_token))
+                .http_only(true)
+                .path("/")
+                .same_site(SameSite::Lax)
+                .max_age(time::Duration::days(7))
+                .build();
+            if let Ok(value) = cookie.to_string().parse() {
+                response
+                    .headers_mut()
+                    .append(axum::http::header::SET_COOKIE, value);
+            }
         }
     }
 
@@ -248,6 +270,15 @@ fn extract_session_cookie(headers: &axum::http::HeaderMap) -> Option<String> {
     // outright so the resolver mints a fresh anonymous row instead of
     // promoting the attacker's value. Also unquotes RFC6265 quoted
     // values (`session="abc"`) and trims inner whitespace.
+    //
+    // Issue #81 follow-up: percent-decode the cookie value. `axum_extra`'s
+    // `Cookie::encoded()` URL-encodes base64 special chars (`/` → `%2F`,
+    // `+` → `%2B`, `=` → `%3D`) when serializing the Set-Cookie header.
+    // Browsers store the encoded form and send it back verbatim in the
+    // Cookie header. The session token in the DB is the raw base64, so
+    // without decoding here the lookup misses and every authenticated
+    // request lands as anonymous. (The pre-fix #81 cookie collision
+    // masked this with a second cookie that happened to be raw.)
     let mut matches: Vec<String> = Vec::new();
     for raw in headers
         .get_all("cookie")
@@ -263,7 +294,10 @@ fn extract_session_cookie(headers: &axum::http::HeaderMap) -> Option<String> {
                     .unwrap_or(raw_value)
                     .trim();
                 if !unquoted.is_empty() {
-                    matches.push(unquoted.to_string());
+                    let decoded = percent_encoding::percent_decode_str(unquoted)
+                        .decode_utf8_lossy()
+                        .into_owned();
+                    matches.push(decoded);
                 }
             }
         }
@@ -622,5 +656,32 @@ mod tests {
         let mut h = axum::http::HeaderMap::new();
         h.insert("cookie", "session=\"abc123\"".parse().unwrap());
         assert_eq!(extract_session_cookie(&h), Some("abc123".to_string()));
+    }
+
+    /// Issue #81 follow-up: `axum_extra`'s `Cookie::encoded()` URL-encodes
+    /// base64 chars (`/` → `%2F`, `+` → `%2B`, `=` → `%3D`) when serializing
+    /// Set-Cookie. Browsers store and replay the encoded form. The session
+    /// token in the DB is the raw base64, so the cookie value MUST be
+    /// percent-decoded before lookup or every authenticated request hits a
+    /// missing-row → anonymous path.
+    #[test]
+    fn test_extract_session_cookie_percent_decodes_value() {
+        let mut h = axum::http::HeaderMap::new();
+        // Real-world example: a base64 token containing `/`, `+`, `=`.
+        h.insert(
+            "cookie",
+            "session=ppIIvusnO9b017C7r9dLM2nOl0Yp9uqZMpFuhrNdbG8%3D".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_session_cookie(&h),
+            Some("ppIIvusnO9b017C7r9dLM2nOl0Yp9uqZMpFuhrNdbG8=".to_string())
+        );
+
+        let mut h2 = axum::http::HeaderMap::new();
+        h2.insert(
+            "cookie",
+            "session=a%2Fb%2Bc%3D".parse().unwrap(),
+        );
+        assert_eq!(extract_session_cookie(&h2), Some("a/b+c=".to_string()));
     }
 }

--- a/tests/session_cookie_collision.rs
+++ b/tests/session_cookie_collision.rs
@@ -1,0 +1,158 @@
+//! Issue #81 regression: session cookie collision after login.
+//!
+//! `session_resolve_middleware` minted an anonymous session on every first
+//! hit AND unconditionally appended the matching `Set-Cookie: session=...`
+//! to the response — even when the handler that just ran (login, logout)
+//! had already set its own `session=...` via `CookieJar`. The middleware's
+//! anon cookie landed AFTER the handler's auth cookie in the response, and
+//! per RFC 6265 §5.4 ("later cookie wins for same name/domain/path"),
+//! browsers and curl picked up the anon cookie pointing at a row the
+//! login handler had just soft-deleted.
+//!
+//! Effect on `main` (commit `d7af023`, story 8-3 CSRF fixes): every login
+//! left the client looking anonymous on the next request — silent auth
+//! failure. 121 of 173 E2E tests cascade-fail on this single root cause.
+//!
+//! These tests pin: POST /login emits exactly ONE `session=` Set-Cookie,
+//! and that cookie matches the authenticated session row in DB (not the
+//! soft-deleted anonymous predecessor).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use mybibli::db::DbPool;
+use std::sync::{Arc, RwLock};
+use tower::ServiceExt;
+
+fn state_with_pool(pool: DbPool) -> mybibli::AppState {
+    mybibli::AppState {
+        pool,
+        settings: Arc::new(RwLock::new(mybibli::config::AppSettings::default())),
+        http_client: reqwest::Client::new(),
+        registry: Arc::new(mybibli::metadata::registry::ProviderRegistry::new()),
+        covers_dir: std::path::PathBuf::from("/tmp"),
+        provider_health: mybibli::tasks::provider_health::new_provider_health_map(),
+        mariadb_version_cache: mybibli::services::admin_health::new_mariadb_version_cache(),
+    }
+}
+
+fn app(state: mybibli::AppState) -> axum::Router {
+    mybibli::routes::build_router(state)
+}
+
+async fn seed_user(pool: &DbPool) -> String {
+    let username = "issue81_test_user";
+    // Argon2 hash for the password literal "librarian" — same hash the
+    // existing csrf_integration tests use against `password=librarian`.
+    let password_hash = "$argon2id$v=19$m=19456,t=2,p=1$NfI9SYT0huhcqAanQWa9pw$mSEHLW8Wl8wlk504MRpzyS42JlcU9w2CXYVVFMFvbcU";
+    sqlx::query("INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'librarian')")
+        .bind(username)
+        .bind(password_hash)
+        .execute(pool)
+        .await
+        .unwrap();
+    username.to_string()
+}
+
+fn count_session_set_cookies(headers: &axum::http::HeaderMap) -> usize {
+    headers
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter(|v| {
+            v.to_str()
+                .map(|s| s.starts_with("session=") || s.starts_with("session ="))
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+fn extract_session_cookie_value(headers: &axum::http::HeaderMap) -> Option<String> {
+    for v in headers.get_all(axum::http::header::SET_COOKIE).iter() {
+        let s = v.to_str().ok()?;
+        if let Some(rest) = s.strip_prefix("session=") {
+            // Take up to the first `;` (cookie value).
+            let value = rest.split(';').next()?.to_string();
+            return Some(value);
+        }
+    }
+    None
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn login_emits_exactly_one_session_set_cookie(pool: DbPool) {
+    let username = seed_user(&pool).await;
+    let app = app(state_with_pool(pool.clone()));
+
+    let body = format!("username={}&password=librarian", username);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/login")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(Body::from(body))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::SEE_OTHER,
+        "successful POST /login → 303"
+    );
+
+    // Issue #81 fix: exactly ONE session= Set-Cookie. Pre-fix this was 2
+    // (handler auth cookie + middleware anon cookie), and the anon one
+    // landed last so clients picked the anon-soft-deleted cookie.
+    let count = count_session_set_cookies(resp.headers());
+    assert_eq!(
+        count, 1,
+        "expected exactly 1 session= Set-Cookie after login, got {count} (issue #81 regression)"
+    );
+
+    // The single cookie must match the authenticated session row in DB
+    // (user_id NOT NULL, deleted_at NULL).
+    let cookie_value = extract_session_cookie_value(resp.headers())
+        .expect("session= Set-Cookie value");
+    // Cookie values are %-encoded by axum_extra::Cookie when special chars
+    // are present; the DB stores the raw token. Decode for comparison.
+    let decoded = percent_encoding::percent_decode_str(&cookie_value)
+        .decode_utf8_lossy()
+        .into_owned();
+
+    let row: Option<(Option<u64>, Option<chrono::NaiveDateTime>)> = sqlx::query_as(
+        "SELECT user_id, deleted_at FROM sessions WHERE token = ?",
+    )
+    .bind(&decoded)
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+
+    let (user_id, deleted_at) = row.expect("cookie token must reference a sessions row");
+    assert!(
+        user_id.is_some(),
+        "cookie's session row must be authenticated (user_id IS NOT NULL)"
+    );
+    assert!(
+        deleted_at.is_none(),
+        "cookie's session row must be active (deleted_at IS NULL) — issue #81: pre-fix the cookie pointed at the soft-deleted anonymous row"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn anonymous_first_hit_still_emits_exactly_one_session_cookie(pool: DbPool) {
+    // Sanity: when no handler sets its own cookie, the middleware's anon
+    // cookie still lands. We pin the count at 1 so a future regression
+    // that emits 0 (broken anonymous flow) or 2 (collision returns) is
+    // caught.
+    let app = app(state_with_pool(pool.clone()));
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let count = count_session_set_cookies(resp.headers());
+    assert_eq!(
+        count, 1,
+        "anonymous GET / → exactly 1 session= Set-Cookie (the middleware-minted anon cookie)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #81. `session_resolve_middleware` was unconditionally appending an anonymous `Set-Cookie: session=...` to the response even when the handler (login, logout) had already set its own auth cookie via `CookieJar`. The middleware's anon cookie landed last and won per RFC 6265 §5.4 — pointing clients at a session row the login handler had just soft-deleted.

A second issue surfaced during validation: `extract_session_cookie` did not percent-decode the cookie value. `axum_extra::Cookie::encoded()` URL-encodes base64 chars (`/`/`+`/`=`) on Set-Cookie; browsers replay the encoded form in the Cookie header; the server stored the raw form in DB, so the lookup missed every authenticated request.

The original #81 cookie collision had been masking the encoding mismatch — once the middleware stopped emitting a duplicate cookie, the encoded-vs-raw bug surfaced.

## Changes

- `src/middleware/auth.rs::session_resolve_middleware` — skip the anon cookie append when the response already carries a `session=` Set-Cookie. O(n) over Set-Cookie headers; n is typically 0 or 1.
- `src/middleware/auth.rs::extract_session_cookie` — percent-decode the cookie value before returning. Round-trips encoded base64 (e.g. `%2F` → `/`) so the DB lookup finds the row.
- `tests/session_cookie_collision.rs` — new integration test (uses `tower::oneshot` against the full router):
  - `login_emits_exactly_one_session_set_cookie`: POST /login → exactly 1 `session=` Set-Cookie + cookie's token references the authenticated session row in DB (user_id NOT NULL, deleted_at NULL).
  - `anonymous_first_hit_still_emits_exactly_one_session_cookie`: pins the legitimate anon-mint path against future regressions in the opposite direction.
- `src/middleware/auth.rs` unit test `test_extract_session_cookie_percent_decodes_value` — locks the decode behavior with a real-world base64 token.

## Test plan

- [x] `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 511 passed
- [x] `cargo test --test session_cookie_collision` — 2 passed
- [x] `cargo test --test csrf_integration` — 13 passed (regression check on the existing csrf integration suite)
- [x] `cargo sqlx prepare --check --workspace -- --all-targets` clean
- [x] Manual curl smoke: librarian → /admin → 403 (was 303 pre-fix)
- [x] E2E `admin-smoke.spec.ts` + `csrf.spec.ts` — 9 passed, 1 failed (failure is pre-existing test drift from story 8-3 that updated the users panel without updating the `toContainText("8-2")` smoke assertion — unrelated to #81)

## Affected stories

- Story 8-4 (reference data management) — blocked V5 E2E run before this fix
- Story 8-7 (permanent delete + auto-purge, PR #59) — also affected; should rebase on this fix before merge

## Notes

The bug was latent on `main` since commit `d7af023` (story 8-3 CSRF fixes, 2026-04-19). It was never caught because the full E2E suite was not run on recent branches per the sprint-status note *"E2E 3-cycle deferred to pre-push gate"*. Surfaced 2026-04-28 during story 8-4 V5 E2E run via the Playwright Docker container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)