### PR TITLE
Story 9-1: Dashboard — global stats card

### DIFF
--- a/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
+++ b/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
@@ -1,6 +1,6 @@
 # Story 9.1: Dashboard — global stats card
 
-Status: review
+Status: done
 
 ## Story
 
@@ -92,6 +92,38 @@ so that I get an immediate sense of the catalog's size at a glance.
   - [x] Use `loginAs(page, "librarian")` from `tests/e2e/helpers/auth.ts`. Do NOT inject `DEV_SESSION_COOKIE` (per `CLAUDE.md` Foundation Rule #7 + the parallel-safety hard rule).
   - [x] Use i18n-aware regex matchers — both EN + FR strings.
   - [x] No `waitForTimeout` calls — the CI grep gate enforced by the `e2e` job will fail the PR.
+### Review Findings (2026-04-30)
+
+Consolidated from three reviewers (Blind Hunter / Edge Case Hunter / Acceptance Auditor). Triage: 1 decision-needed, 7 patch, 3 defer, 5 dismissed.
+
+**Patch (Medium):**
+
+- [x] [Review][Patch] **Active-loan count cascade scope** [`src/services/dashboard.rs:34-39`] — tighten the loan subquery to JOIN `volumes` and `borrowers` with `deleted_at IS NULL` filters, matching `LoanModel::list_active` semantics. Decided 2026-04-30 (option a) — coherence with the `/loans` page that the count points to outweighs the trivial perf cost of two PK-indexed JOINs in a single round-trip. Add a regression test in `tests/dashboard_glance.rs` that seeds an orphan loan (loan whose volume is soft-deleted) and asserts it is NOT counted.
+
+- [x] [Review][Patch] **Home page 500 on dashboard SQL failure** [`src/routes/home.rs:164`] — `collection_glance(pool).await?` propagates errors with `?`, so any transient DB issue takes down the whole `/` page (including anonymous landing). Mirror the existing `metadata_error_count` pattern (`.unwrap_or_default()` — `CollectionGlance` already derives `Default`) so the card silently shows 0/0/0 instead of returning 500.
+- [x] [Review][Patch] **Librarian unit test false-positive** [`src/routes/home.rs:home_librarian_renders_glance_with_loans_link`] — `assert!(html.contains("href=\"/loans\""))` is satisfied by the nav-bar link (`templates/components/nav_bar.html` renders one for librarian/admin), independently of the glance card. The test would still pass if `loans_link_visible = false`. Scope the assertion to a slice between `id="collection-glance"` and the closing `</section>`.
+- [x] [Review][Patch] **AC3 zero-count rendering not directly tested** [`src/routes/home.rs::mod tests`] — both render tests (`make_test_home_template`) use 5/8/2; nothing locks in the no-hide invariant for 0/0/0. A future regression that adds `{% if glance_titles_count > 0 %}` would slip past CI. Add a third render test with all-zero counts asserting `id="collection-glance"` is present and the labels match the `_other` / FR-CLDR-corrected form.
+- [x] [Review][Patch] **E2E count regex too permissive** [`tests/e2e/specs/journeys/home.spec.ts:32-37`] — `\d+\s+(titles?|titres?)/i` accepts `0` and doesn't enforce per-row scope; if title and volume labels were swapped in the template, the test would still pass. Tighten with `card.locator("li:nth-child(N)")` per row, or seed the DB to known counts and assert exact strings.
+
+**Patch (Low):**
+
+- [x] [Review][Patch] **Dead `glance_*_count` HomeTemplate fields** [`src/routes/home.rs:81-83` and `:283-285`] — three `i64` fields populated but never read by the template (counts are already baked into the `_label` strings via `%{count}`). Remove the fields and the corresponding handler assignments, or wire them into `aria-label` attributes for unambiguous screen-reader announcement.
+- [x] [Review][Patch] **French CLDR zero-pluralization bug** [`src/routes/home.rs:170,181,196`] — French CLDR rule: `0` and `1` both map to `one` ("0 titre", not "0 titres"). Current code routes `0 → _other`, rendering "0 titres" / "0 prêts en cours" — actively wrong for an empty FR catalog. Either branch on locale (`if loc == "fr" && (count == 0 || count == 1)` → `_one`), or use a third key `_zero` per locale.
+- [x] [Review][Patch] **Librarian E2E missing i18n text match** [`tests/e2e/specs/journeys/home.spec.ts:52-67`] — anonymous test uses `/Active loans|Prêts en cours/i` for the user-visible text; librarian test only checks link presence + URL navigation. Add the same regex to the librarian test for consistency with AC9.
+
+**Defer (pre-existing or out of scope — file as GH Issues per CLAUDE.md rule 11):**
+
+- [x] [Review][Defer] **HTMX search swap renders full page into `#browse-results` on empty query + cleared filter** [`src/routes/home.rs:148`] — pre-existing duplicate-ID DOM bug (the new card amplifies it but doesn't cause it). Pre-existing, file as `type:bug` GH Issue.
+- [x] [Review][Defer] **`metadata_error_count` `.unwrap_or(0)` swallows DB errors silently** [`src/routes/home.rs:218-221`] — pre-existing inconsistency, adjacent to new code but not introduced by it. File as `type:code-review-finding` GH Issue.
+- [x] [Review][Defer] **Local E2E run skipped despite Task 8 [x]** [Dev Agent Record] — `tests/e2e/test-results/` owned by root from earlier Docker runs; `sudo chown` cleanup deferred. Honestly noted in DAR; CI validates the E2E.
+
+**Dismissed (5):**
+- Hand-rolled SQL in test inserts — matches the project pattern in `tests/search_filter_browse.rs`.
+- Unused `count_active` model methods — deliberately added for stories 9-4/9-5 reuse per Task 1 sub-bullet.
+- Anonymous loan card visual confusion (looks clickable) — deferred to Story 9-19 Tooltip per spec.
+- Concurrent count drift between subqueries — acknowledged by reviewer as not actionable.
+- Sprint-status `epic-9: backlog → in-progress` transition — rule 16 spirit preserved (first story of the epic naturally moves the parent forward).
+
 - [x] **Task 8 — Verify and document (AC: 1–9)**
   - [x] Run locally before push (per `CLAUDE.md` Foundation Rule #13):
     - `cargo check && cargo clippy -- -D warnings`
@@ -241,3 +273,4 @@ This story aligns cleanly with the existing structure — no variances. The new 
 ### Change Log
 
 - **2026-04-30** — Initial implementation. All 8 tasks complete; 624 lib tests + 2 dashboard_glance integration tests pass; clippy clean; sqlx cache unchanged. E2E validation deferred to CI (local `tests/e2e/test-results/` directory owned by root from earlier Docker runs blocks Playwright reporter writes).
+- **2026-04-30** — Code review pass: 1 decision-needed resolved (option a — JOIN cascade), 7 patches applied, 3 deferred (pre-existing or out of scope, to be filed as GH Issues per rule 11), 5 dismissed. Active-loan count now JOINs `volumes`/`borrowers` to match `LoanModel::list_active`. Home page soft-degrades to 0/0/0 on DB error. French CLDR fixed (0 → singular). Librarian unit test scoped to the card slice. Zero-count render test added. E2E uses per-row locators. Final test counts: 628 lib tests + 3 integration tests + 4 new (zero-count render, 3 `is_singular` cases) — all green. Status: review → done.

--- a/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
+++ b/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
@@ -11,17 +11,24 @@ so that I get an immediate sense of the catalog's size at a glance.
 ## Acceptance Criteria
 
 1. **AC1 — Card presence and structure.** Given the home page (`/`), when it renders for any role (Anonymous, Librarian, Admin), then a "Collection at a glance" card is visible and displays exactly three counts: total active titles, total active volumes, total active loans — each computed by excluding `deleted_at IS NOT NULL` rows. For loans, "active" additionally requires `returned_at IS NULL`.
-2. **AC2 — Single round-trip query.** Given the counts, when computed, then they come from a single SQL round-trip (one query with three sub-counts) — not three separate `fetch_one` calls. No N+1, no per-entity lookup. The query lives in a service or model function with type signature `Result<CollectionGlance, AppError>` where `CollectionGlance` is a small struct with three `i64` (or `u64`) fields.
-3. **AC3 — Empty DB renders the card.** Given a fresh DB, when the counts are zero, then the card still renders with "0 titles", "0 volumes", "0 loans" — no empty-state hiding here. The broader "empty catalog" StatusMessage UX is a separate concern handled by story 9-15; do NOT introduce it in this story.
+2. **AC2 — Single round-trip query.** Given the counts, when computed, then they come from a single SQL round-trip (one query with three sub-counts) — not three separate `fetch_one` calls. No N+1, no per-entity lookup. The query lives in a service or model function with type signature `Result<CollectionGlance, AppError>` where `CollectionGlance` is a small struct with three `i64` fields.
+3. **AC3 — Empty DB renders the card.** Given a fresh DB, when the counts are zero, then the card still renders with "0 titles", "0 volumes", "0 active loans" — no empty-state hiding here. The broader "empty catalog" StatusMessage UX is a separate concern handled by story 9-15; do NOT introduce it in this story.
 4. **AC4 — Role-aware links on count lines.** Given the card, when rendered, then each count line is a clickable link as follows:
-    - **Title count** → `/catalog` (route exists; no role gate). All roles get a real `<a href>`.
-    - **Volume count** → `/catalog?view=volumes` if such a route exists; otherwise reuse `/catalog` (the dev agent must verify and document the choice in the Dev Agent Record). All roles get a real `<a href>`.
-    - **Loan count** → `/loans` ONLY when `session.role >= Role::Librarian`. For Anonymous, the count is rendered as plain text inside a `<span>` with `aria-describedby` pointing to a hidden help message "Sign in to view loans" / "Connectez-vous pour voir les prêts" (the help text is added now; the visible tooltip component itself ships with story 9-19 — do NOT block on it).
+    - **Title count** → `/catalog`. All roles get a real `<a href>`.
+    - **Volume count** → `/catalog` (same target as the title count; v1 has no volume-only browse route — verified absent in `src/routes/mod.rs`). All roles get a real `<a href>`. If a future story adds a volume-specific browse, the link target updates trivially.
+    - **Loan count** → `/loans` ONLY when `session.role >= Role::Librarian`. For Anonymous, the count is rendered as plain text inside a `<span aria-describedby="glance-loans-hint">` paired with a sibling `<span id="glance-loans-hint" class="sr-only">{{ glance_signin_hint }}</span>` carrying the i18n text "Sign in to view loans" / "Connectez-vous pour voir les prêts". The visible Tooltip component itself ships with story 9-19 — here we only need the screen-reader-accessible markup.
 5. **AC5 — Anonymous never receives the loan link in HTML.** Given the role-aware link generation, when tested, then the rendered HTML for an anonymous request does NOT contain `href="/loans"` anywhere (regression guard against accidental over-rendering). This is a byte-level assertion in the unit test for the handler.
 6. **AC6 — CSP compliance.** The card uses Tailwind utility classes only — no `style="..."`, no `<style>` block, no inline event handlers. The audit test in `src/templates_audit.rs::no_inline_markup_in_templates` must continue to pass after this change.
-7. **AC7 — i18n EN + FR.** All user-visible strings have keys in both `locales/en.yml` and `locales/fr.yml` under the existing `dashboard:` section: `dashboard.glance.heading`, `dashboard.glance.titles`, `dashboard.glance.volumes`, `dashboard.glance.active_loans`, `dashboard.glance.signin_to_view_loans`. Use `%{count}` plural-form params where appropriate. After editing locale files, run `touch src/lib.rs && cargo build` to force the i18n proc macro to re-read.
-8. **AC8 — Unit tests.** Tests must cover: (a) count query returns correct values on empty DB (0/0/0); (b) count query returns correct values on a mixed dataset including soft-deleted titles, soft-deleted volumes, returned loans, and at least one of each active; (c) handler-level test that asserts the rendered HTML for an anonymous session contains the three counts AND does NOT contain `href="/loans"`; (d) handler-level test that asserts the rendered HTML for a Librarian session contains `href="/loans"` linked to the loan count.
-9. **AC9 — E2E smoke.** A new spec or extension to `tests/e2e/specs/journeys/home.spec.ts` covers: anonymous → `/` → verify card with three counts visible, loan count is plain text (no link); login as librarian via `loginAs(page, "librarian")` → `/` → verify loan count is now an `<a>` element → click it → `/loans` opens. Use i18n-aware text matchers (`/Active loans|Prêts en cours/i`).
+7. **AC7 — i18n EN + FR with proper pluralization.** Use rust_i18n's `one:`/`other:` branching pattern for the three count labels (titles, volumes, active_loans) — that is **12 YAML entries total** (3 keys × 2 forms × 2 languages) — following the existing project pattern in `locales/en.yml` (see `node_type_renamed_cascaded_one` / `_other` for reference). The `heading` and `signin_to_view_loans` keys do NOT branch (no count). Invocation: `t!("dashboard.glance.titles", count = n, locale = loc)`. After editing locale files, run `touch src/lib.rs && cargo build` to force the i18n proc macro to re-read.
+8. **AC8 — Unit tests.** Tests must cover:
+    - (a) count query returns correct values on empty DB (0/0/0);
+    - (b) count query returns correct values on a mixed dataset including soft-deleted titles, soft-deleted volumes, returned loans, and at least one of each active;
+    - (c) handler-level test for an anonymous session asserting the rendered HTML (i) contains the three counts, (ii) does NOT contain `href="/loans"`, (iii) contains BOTH `aria-describedby="glance-loans-hint"` AND a sibling `<span id="glance-loans-hint" class="sr-only">…</span>` whose text matches the EN or FR sign-in hint (linkage verification — both the reference and its target must coexist);
+    - (d) handler-level test for a Librarian session asserting the rendered HTML contains `href="/loans"` linked to the loan count and does NOT contain the `aria-describedby="glance-loans-hint"` reference (no orphan markup).
+9. **AC9 — E2E smoke.** A new spec or extension to `tests/e2e/specs/journeys/home.spec.ts` covers:
+    - anonymous → `/` → verify card heading matches `/Collection at a glance|Aperçu de la collection/i`, verify the three count rows are present, then `await expect(page.locator('a[href="/loans"]')).toHaveCount(0)`;
+    - login as librarian via `loginAs(page, "librarian")` → `/` → `await expect(page.locator('a[href="/loans"]')).toHaveCount(1)`, click the link, `await page.waitForURL(/\/loans/)`.
+    - Use i18n-aware regex matchers (`/Active loans|Prêts en cours/i`) for any user-visible text assertion.
 
 ## Tasks / Subtasks
 
@@ -40,39 +47,48 @@ so that I get an immediate sense of the catalog's size at a glance.
       (SELECT COUNT(*) FROM volumes WHERE deleted_at IS NULL) AS volumes,
       (SELECT COUNT(*) FROM loans WHERE returned_at IS NULL AND deleted_at IS NULL) AS active_loans
     ```
-    Use `sqlx::query_as::<_, CollectionGlance>` + `.fetch_one(pool)`. This is a single round-trip per AC2.
+    Use `sqlx::query_as::<_, CollectionGlance>` + `.fetch_one(pool)`. This is a single round-trip per AC2 — verified by the SQL shape (1 SELECT, 0 join, 3 sub-counts) at code review time, no programmatic instrumentation needed.
   - [ ] DO NOT use `sqlx::query!` macro for this — it requires `.sqlx/` cache regeneration. Use the dynamic `query_as` form.
 - [ ] **Task 3 — Add i18n keys (AC: 7)**
-  - [ ] In `locales/en.yml` under `dashboard:`, add a `glance:` sub-section with: `heading: "Collection at a glance"`, `titles: "%{count} titles"`, `volumes: "%{count} volumes"`, `active_loans: "%{count} active loans"`, `signin_to_view_loans: "Sign in to view loans"`.
-  - [ ] In `locales/fr.yml` under `dashboard:`, add the FR equivalents: `heading: "Aperçu de la collection"`, `titles: "%{count} titres"`, `volumes: "%{count} volumes"`, `active_loans: "%{count} prêts en cours"`, `signin_to_view_loans: "Connectez-vous pour voir les prêts"`.
+  - [ ] In `locales/en.yml` under `dashboard:`, add a `glance:` sub-section with these 8 keys:
+    - `heading: "Collection at a glance"`
+    - `titles_one: "%{count} title"` and `titles_other: "%{count} titles"`
+    - `volumes_one: "%{count} volume"` and `volumes_other: "%{count} volumes"`
+    - `active_loans_one: "%{count} active loan"` and `active_loans_other: "%{count} active loans"`
+    - `signin_to_view_loans: "Sign in to view loans"`
+  - [ ] In `locales/fr.yml` under `dashboard:`, add the FR equivalents (8 keys):
+    - `heading: "Aperçu de la collection"`
+    - `titles_one: "%{count} titre"` and `titles_other: "%{count} titres"`
+    - `volumes_one: "%{count} volume"` and `volumes_other: "%{count} volumes"`
+    - `active_loans_one: "%{count} prêt en cours"` and `active_loans_other: "%{count} prêts en cours"`
+    - `signin_to_view_loans: "Connectez-vous pour voir les prêts"`
   - [ ] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper — keys start at root (per `CLAUDE.md` "Key Patterns / i18n").
   - [ ] After editing locale files, run `touch src/lib.rs && cargo build` to force proc-macro recompilation.
 - [ ] **Task 4 — Wire the handler (AC: 1, 4, 5)**
   - [ ] In `src/routes/home.rs::home` (around line 76, before the existing template construction), call `services::dashboard::collection_glance(&state.pool).await?` and bind the result.
-  - [ ] Extend `HomeTemplate` (the Askama struct returned by the handler) with three new fields: `glance_titles: i64`, `glance_volumes: i64`, `glance_active_loans: i64`. Pass them from the handler.
-  - [ ] Use `session.role >= Role::Librarian` (the existing `Role` enum at `src/middleware/auth.rs` derives `PartialOrd`) to compute a boolean `loans_link_visible: bool` and pass it to the template.
+  - [ ] Extend `HomeTemplate` (the Askama struct returned by the handler) with new fields: `glance_heading: String`, `glance_titles_label: String`, `glance_volumes_label: String`, `glance_active_loans_label: String`, `glance_signin_hint: String`, `glance_titles_count: i64`, `glance_volumes_count: i64`, `glance_active_loans_count: i64`, `loans_link_visible: bool`. Pre-translate the 4 label strings + hint in the handler via `rust_i18n::t!(...)` calls.
+  - [ ] Use `session.role >= Role::Librarian` (the existing `Role` enum at `src/middleware/auth.rs` derives `PartialOrd`) to compute `loans_link_visible`.
   - [ ] DO NOT add a new route handler. The card is rendered inline by the existing `home` handler.
 - [ ] **Task 5 — Render the card in the template (AC: 1, 4, 6)**
-  - [ ] In `templates/pages/home.html`, insert a new section between the hero (line ~11) and the search input (line ~14), or adjacent to the existing metadata error badge — pick the placement that respects the responsive layout and is consistent with the search-as-homepage UX (UX spec §"Home page"). Document the chosen placement in the Dev Agent Record.
-  - [ ] Markup outline (Tailwind classes + i18n via `t!` macro emitted from the handler-side context, NOT inline `{{ t!(...) }}` if Askama doesn't support it — pre-translate strings in the handler and pass as fields):
-    - A `<section aria-labelledby="glance-heading">` with `<h2 id="glance-heading">{{ glance_heading }}</h2>`
-    - Three `<dl>`-style or list-item rows, each with the count + label
-    - Title count: always an `<a href="/catalog">{{ glance_titles_label }}</a>`
-    - Volume count: always an `<a href="/catalog?view=volumes">{{ glance_volumes_label }}</a>` (or `/catalog` if the `view=volumes` route doesn't exist — verify and document)
-    - Loan count: `{% if loans_link_visible %}<a href="/loans">…</a>{% else %}<span aria-describedby="glance-loans-hint">…</span><span id="glance-loans-hint" class="sr-only">{{ glance_signin_hint }}</span>{% endif %}`
+  - [ ] In `templates/pages/home.html`, insert the card **between the filter tags (closing tag at line ~65) and the `#browse-results` div (opening at line ~106)**. Rationale: this placement keeps the search field above the fold (no CLS on tablet/mobile), sits OUTSIDE the HTMX swap target `#browse-results` so the card stays visible during search interactions, and is consistent with the search-as-homepage UX (UX spec §"Home page"). The dev agent may deviate only with explicit justification documented in the Dev Agent Record.
+  - [ ] Markup outline (Tailwind utility classes; all i18n strings come pre-translated as `String` fields on `HomeTemplate`):
+    - `<section aria-labelledby="glance-heading">` with `<h2 id="glance-heading">{{ glance_heading }}</h2>`
+    - Three `<dl>`-style or list-item rows, each rendering its pre-translated label (which already includes the count via `%{count}` interpolation)
+    - Title count: always `<a href="/catalog">{{ glance_titles_label }}</a>`
+    - Volume count: always `<a href="/catalog">{{ glance_volumes_label }}</a>`
+    - Loan count: `{% if loans_link_visible %}<a href="/loans">{{ glance_active_loans_label }}</a>{% else %}<span aria-describedby="glance-loans-hint">{{ glance_active_loans_label }}</span><span id="glance-loans-hint" class="sr-only">{{ glance_signin_hint }}</span>{% endif %}`
   - [ ] CSP: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes only.
 - [ ] **Task 6 — Unit tests (AC: 2, 3, 5, 8)**
   - [ ] Add `tests/dashboard_glance.rs` (new file) with `#[sqlx::test(migrations = "./migrations")]` tests:
     - `glance_on_empty_db_returns_zeros` — fresh schema, no fixtures, expect `(0, 0, 0)`.
     - `glance_excludes_soft_deleted_and_returned` — seed: 3 active titles + 1 soft-deleted; 5 active volumes + 2 soft-deleted; 4 loans of which 1 returned + 1 soft-deleted; expect `(3, 5, 2)`.
-    - `glance_is_single_round_trip` — instrument via `sqlx::Executor` query log if feasible; otherwise document the SQL text via `.fetch_one` source. (Lightweight check; if instrumentation is non-trivial, skip and rely on code review of the SQL.)
   - [ ] Add handler-level rendering tests in `src/routes/home.rs` `mod tests` (or a sibling test module) — follow the existing pattern at `src/routes/home.rs:411-559`. Tests:
-    - `home_anonymous_renders_glance_no_loans_link` — invoke the handler with a `Session { role: Role::Anonymous, .. }`, render the template to a string, assert it contains the three i18n labels AND does NOT contain `href="/loans"`.
-    - `home_librarian_renders_glance_with_loans_link` — same but with `Role::Librarian`, assert `href="/loans"` IS present.
+    - `home_anonymous_renders_glance_no_loans_link` — invoke the handler with a `Session { role: Role::Anonymous, .. }`, render the template to a string, then assert: contains the three i18n labels (EN locale, plural form); does NOT contain `href="/loans"`; contains BOTH `aria-describedby="glance-loans-hint"` AND `id="glance-loans-hint"` (linkage check); the span carrying `id="glance-loans-hint"` carries class `sr-only` and contains the EN sign-in hint text.
+    - `home_librarian_renders_glance_with_loans_link` — same but with `Role::Librarian`; assert `href="/loans"` IS present and does NOT contain `aria-describedby="glance-loans-hint"` (no orphan).
 - [ ] **Task 7 — E2E spec (AC: 9)**
   - [ ] Extend `tests/e2e/specs/journeys/home.spec.ts` with two new test cases:
-    - `glance card visible to anonymous, loan count is not a link` — load `/`, verify the card heading text matches `/Collection at a glance|Aperçu de la collection/i`, verify three count entries, assert the loan-count parent is NOT an `<a>` (use `page.locator(...).evaluateAll(els => els.every(e => e.tagName !== 'A'))` or a similar assertion).
-    - `glance card visible to librarian, loan count navigates to /loans` — `await loginAs(page, "librarian")`, load `/`, click the loan-count link, `await page.waitForURL(/\/loans/)`.
+    - `glance card visible to anonymous, loan count is not a link` — load `/`, verify the card heading matches `/Collection at a glance|Aperçu de la collection/i`, verify the three count rows are present, then `await expect(page.locator('a[href="/loans"]')).toHaveCount(0)`.
+    - `glance card visible to librarian, loan count navigates to /loans` — `await loginAs(page, "librarian")`, load `/`, `await expect(page.locator('a[href="/loans"]')).toHaveCount(1)`, click the link, `await page.waitForURL(/\/loans/)`.
   - [ ] Use `loginAs(page, "librarian")` from `tests/e2e/helpers/auth.ts`. Do NOT inject `DEV_SESSION_COOKIE` (per `CLAUDE.md` Foundation Rule #7 + the parallel-safety hard rule).
   - [ ] Use i18n-aware regex matchers — both EN + FR strings.
   - [ ] No `waitForTimeout` calls — the CI grep gate enforced by the `e2e` job will fail the PR.
@@ -82,7 +98,7 @@ so that I get an immediate sense of the catalog's size at a glance.
     - `cargo test` (unit + the new `tests/dashboard_glance.rs`)
     - `./scripts/e2e-reset.sh` then `cd tests/e2e && npx playwright test specs/journeys/home.spec.ts` (or the equivalent if running Docker stack)
   - [ ] Run `cargo sqlx prepare` if any new query macro was added (Task 2 uses dynamic queries, so likely a no-op — verify no `.sqlx/` diff).
-  - [ ] Update Dev Agent Record at the bottom of this file: list of files touched, choice for `volume count` link target (with rationale), card placement decision in the home template, anything surprising encountered.
+  - [ ] Update Dev Agent Record at the bottom of this file: list of files touched, card placement decision in the home template (or justification for deviating from the recommended placement), anything surprising encountered.
 
 ## Dev Notes
 
@@ -95,9 +111,12 @@ The dev agent should not need to reinvent any of these. All paths are relative t
 | Home route registration | `src/routes/mod.rs:87` | `.route("/", axum::routing::get(home::home))` — no change needed |
 | Home handler | `src/routes/home.rs:76-224` | extend the existing handler; do NOT create a parallel route |
 | Home template | `templates/pages/home.html` (174 lines) | extends `layouts/base.html`; section blocks: hero (8-11), search (14-33), filter tags (36-65), metadata error badge (67-74, role-gated), browse results (105-139), pagination (142-169) |
+| HTMX swap target on `/` | `templates/pages/home.html:25` (`hx-target="#browse-results"`) + `#browse-results` div at line ~106 | the card MUST sit outside `#browse-results` so it survives search swaps — the recommended insertion point (lines ~65–106) satisfies this |
 | Session extractor & Role enum | `src/middleware/auth.rs` | `Role: Anonymous < Librarian < Admin` (derives `PartialOrd`) — use `session.role >= Role::Librarian` |
 | Existing role-aware template gating | `templates/pages/home.html:112` | `{% if role == "librarian" || role == "admin" %}` — reuse this pattern, NOT a fresh approach |
 | Existing role-aware handler gating | `src/routes/home.rs:154-163` | the `metadata_error_count` block — pattern: handler computes the value or skips, template trusts the value |
+| Canonical i18n pre-translation example | `src/routes/home.rs:207-212` (`label_metadata_errors: rust_i18n::t!("dashboard.metadata_errors", locale = loc, count = metadata_error_count).to_string()`) → rendered at `templates/pages/home.html:71` as plain `{{ label_metadata_errors }}` | **replicate this pattern for the four glance labels (heading + 3 counts) plus the sign-in hint** |
+| Pluralization YAML reference | `locales/en.yml` keys ending in `_one` / `_other` (e.g., `node_type_renamed_cascaded_one` / `_other`) | when the `t!` call passes `count = n`, rust_i18n auto-selects `_one` for n=1, `_other` otherwise |
 | Count query reference patterns | `src/models/volume_state.rs:177-184` (count_usage); `src/models/volume_state.rs:257-273` (count_active_loans_for_state) | use the `sqlx::query_as::<_, (i64,)>` form for ad-hoc counts; `query_scalar::<_, i64>` is also fine |
 | Per-model files where count_active goes | `src/models/title.rs`, `src/models/volume.rs`, `src/models/loan.rs` | none currently has `count_active`; add it (see Task 1) |
 | Existing service organization | `src/services/` (admin_health.rs, locking.rs, soft_delete.rs, etc.) | new `dashboard.rs` belongs here; register in `src/services/mod.rs` |
@@ -112,11 +131,14 @@ The dev agent should not need to reinvent any of these. All paths are relative t
 
 - **Three independent `fetch_one` calls.** AC2 explicitly mandates a single round-trip. Use the SELECT-with-three-subqueries pattern shown in Task 2.
 - **Adding the loan count to anonymous-visible HTML as `<a href="/loans">`.** AC5 enforces this with a byte-level assertion. Even if the link would 401-redirect, leaking it leaks a route surface to anonymous users — unacceptable per the project's role-aware visibility discipline (FR59 / Story 9-8 will tighten the same principle further).
+- **Linking the volume count to a `?view=volumes` route.** That route does NOT exist in v1. Both title and volume counts link to `/catalog`. If a future story adds a volume-only browse, the link target updates trivially.
 - **Using `sqlx::query!` macro for the new query.** That requires `cargo sqlx prepare` and a `.sqlx/` diff in the PR. The codebase already uses dynamic `query_as` for ad-hoc counts (see `volume_state.rs`); stay consistent.
 - **Inline styles for the card.** `style="text-align: center"` will trip `templates_audit.rs::no_inline_markup_in_templates` and fail `cargo test`. Use Tailwind utilities exclusively.
 - **Adding a new route like `GET /dashboard` or `GET /home/glance`.** The card is part of `/`. Adding a fragment-fetch route for it would over-engineer this story (the counts are cheap; HTMX async refresh is not in scope).
 - **Empty-state-hiding the card.** AC3 requires the card to render even on a fresh DB. Story 9-15 will handle the broader empty-catalog UX — do not pre-empt it here.
-- **Tooltip implementation for the anonymous "Sign in to view loans" hint.** UX-DR19 / Story 9-19 ships the actual Tooltip component; here you only need an `aria-describedby` link to a `class="sr-only"` text node so screen readers get the explanation. Sighted users will pick up the tooltip when 9-19 ships.
+- **Tooltip implementation for the anonymous "Sign in to view loans" hint.** UX-DR19 / Story 9-19 ships the actual Tooltip component; here you only need an `aria-describedby` link to a `class="sr-only"` text node so screen readers get the explanation. Sighted users will pick up the visible tooltip when 9-19 ships.
+- **Calling `t!` from inside the Askama template.** The project pattern is "translate in handler, pass to template" (canonical example: `src/routes/home.rs:207-212`). Stay consistent.
+- **Singular-only or "(s)" hack labels.** AC7 mandates `_one`/`_other` branching. Do NOT write `"%{count} title(s)"` — it ships poor i18n grammar in both EN and FR (especially FR where `prêt`/`prêts` differ).
 - **Re-translating reference data values or anything from `locales/*.yml`.** Locale files are i18n-only for UI labels (NFR41 — reference data not translated). The card's text labels are UI labels, so they ARE translated; the counts themselves are numbers (locale-formatted via Rust's `format!` if FR uses non-breaking spaces — keep it simple and use plain `i64` formatting, no thousands separator in v1).
 
 ### Architecture compliance
@@ -124,7 +146,7 @@ The dev agent should not need to reinvent any of these. All paths are relative t
 - **Error handling:** Any DB failure in `collection_glance` returns `AppError::Database` via `?` — do not introduce a new error variant.
 - **Logging:** Use `tracing::debug!` at most, only inside the service function if needed. Counts are not interesting at info-level.
 - **DB query discipline:** All three subqueries already include `deleted_at IS NULL` (per `CLAUDE.md` "Key Patterns / DB queries"). The loans subquery additionally needs `returned_at IS NULL` for "active" semantics (per FR48 + AR23).
-- **HTMX:** Not applicable — the card is rendered server-side on full page load. No `hx-*` attributes, no OOB swaps.
+- **HTMX:** Not applicable to the card itself — it renders server-side on full page load. No `hx-*` attributes, no OOB swaps. Important coexistence note: the existing search field on `/` swaps `#browse-results` (`hx-target="#browse-results"` at `templates/pages/home.html:25`); the card sits OUTSIDE that swap target so it stays visible during search and filter interactions — verify this placement invariant when the card is inserted (Task 5 already targets the safe zone between filter tags and `#browse-results`).
 - **CSP middleware:** Already wraps the handler outermost. No work needed.
 - **Optimistic locking:** Not applicable — this is read-only.
 - **Pool access:** The handler already has access to `state.pool: DbPool`. Do not introduce a new connection.
@@ -132,7 +154,7 @@ The dev agent should not need to reinvent any of these. All paths are relative t
 ### Library / framework requirements
 
 - **Rust 2024 + Axum 0.8 + SQLx 0.8 (MariaDB) + Askama 0.15 + Tailwind CSS v4 + HTMX 2.0** — no version changes. No new dependencies. If you find yourself reaching for a new crate, stop and re-read this section.
-- **rust_i18n** — already wired. The `t!` macro is invoked from Rust (handler) — pre-translate strings in the handler, pass them as `&str` fields on the Askama template struct. Askama itself has limited support for runtime-locale macro calls; the project pattern is "translate in handler, pass to template".
+- **rust_i18n** — already wired. The `t!` macro is invoked from Rust (handler) — pre-translate strings in the handler, pass them as `String` fields on the Askama template struct. Askama itself has limited support for runtime-locale macro calls; the project pattern is "translate in handler, pass to template". Canonical example: `src/routes/home.rs:207-212` pre-translates `dashboard.metadata_errors` with `count` interpolation and passes `label_metadata_errors: String` to the template (rendered at `templates/pages/home.html:71` as plain `{{ label_metadata_errors }}`). Replicate this pattern for the four glance labels (heading + 3 counts) plus the sign-in hint. For the count labels, the `count =` parameter triggers rust_i18n's `_one`/`_other` auto-selection — that is why the YAML keys are paired (Task 3).
 
 ### File structure requirements
 
@@ -145,11 +167,11 @@ The full set of files this story creates or modifies (no others — if you find 
 | `src/models/title.rs` | **edit** | +~10 lines (one `count_active` fn) |
 | `src/models/volume.rs` | **edit** | +~10 lines |
 | `src/models/loan.rs` | **edit** | +~10 lines |
-| `src/routes/home.rs` | **edit** | +~15 lines in handler + extend `HomeTemplate` struct + `mod tests` additions |
+| `src/routes/home.rs` | **edit** | +~25 lines in handler + extend `HomeTemplate` struct + `mod tests` additions |
 | `templates/pages/home.html` | **edit** | +~25 lines for the card section |
-| `locales/en.yml` | **edit** | +~6 lines under `dashboard:` |
-| `locales/fr.yml` | **edit** | +~6 lines under `dashboard:` |
-| `tests/dashboard_glance.rs` | **create** | ~80 lines (3 `#[sqlx::test]` cases) |
+| `locales/en.yml` | **edit** | +~10 lines under `dashboard:` (8 keys) |
+| `locales/fr.yml` | **edit** | +~10 lines under `dashboard:` (8 keys) |
+| `tests/dashboard_glance.rs` | **create** | ~70 lines (2 `#[sqlx::test]` cases) |
 | `tests/e2e/specs/journeys/home.spec.ts` | **edit** | +~30 lines (2 new test cases) |
 | `_bmad-output/implementation-artifacts/sprint-status.yaml` | **edit** | only the `9-1-...` line + `last_updated` (per CLAUDE.md rule 16) |
 
@@ -157,7 +179,7 @@ The full set of files this story creates or modifies (no others — if you find 
 
 - **Coverage target:** every AC has at least one test (unit OR E2E).
 - **Soft-delete exclusion is the load-bearing invariant** for this story. The mixed-dataset test in `tests/dashboard_glance.rs::glance_excludes_soft_deleted_and_returned` is the regression guard. If a future migration changes a soft-delete column name or semantics, this test catches it.
-- **Role-aware HTML assertion** is the second load-bearing test (AC5). It must use the actual `Session` extractor type, not a mock — the extractor's behavior is the contract.
+- **Role-aware HTML assertion** is the second load-bearing test (AC5 + AC8c). It must use the actual `Session` extractor type, not a mock — the extractor's behavior is the contract. The aria-describedby linkage check (AC8c iii) prevents an orphan-reference accessibility regression.
 - **E2E parallelism** — keep the new tests independent (no shared session). `loginAs` per test (in `beforeEach` if a block is reused).
 
 ### Project structure notes
@@ -187,8 +209,7 @@ _To be filled during implementation._
 ### Completion Notes List
 
 _To be filled during implementation. Document at minimum:_
-- _Volume count link target chosen (`/catalog?view=volumes` or fallback) and why._
-- _Card placement in `templates/pages/home.html` (above search? below hero? adjacent to metadata badge?) and why._
+- _Card placement in `templates/pages/home.html` — confirm the recommended location (between filter tags and `#browse-results`) was used, or justify deviation._
 - _Anything surprising encountered (existing helper found, schema quirk, i18n key collision, etc.)._
 
 ### File List

--- a/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
+++ b/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
@@ -1,0 +1,196 @@
+# Story 9.1: Dashboard — global stats card
+
+Status: ready-for-dev
+
+## Story
+
+As any user (anonymous or authenticated),
+I want to see global collection stats on the home page,
+so that I get an immediate sense of the catalog's size at a glance.
+
+## Acceptance Criteria
+
+1. **AC1 — Card presence and structure.** Given the home page (`/`), when it renders for any role (Anonymous, Librarian, Admin), then a "Collection at a glance" card is visible and displays exactly three counts: total active titles, total active volumes, total active loans — each computed by excluding `deleted_at IS NOT NULL` rows. For loans, "active" additionally requires `returned_at IS NULL`.
+2. **AC2 — Single round-trip query.** Given the counts, when computed, then they come from a single SQL round-trip (one query with three sub-counts) — not three separate `fetch_one` calls. No N+1, no per-entity lookup. The query lives in a service or model function with type signature `Result<CollectionGlance, AppError>` where `CollectionGlance` is a small struct with three `i64` (or `u64`) fields.
+3. **AC3 — Empty DB renders the card.** Given a fresh DB, when the counts are zero, then the card still renders with "0 titles", "0 volumes", "0 loans" — no empty-state hiding here. The broader "empty catalog" StatusMessage UX is a separate concern handled by story 9-15; do NOT introduce it in this story.
+4. **AC4 — Role-aware links on count lines.** Given the card, when rendered, then each count line is a clickable link as follows:
+    - **Title count** → `/catalog` (route exists; no role gate). All roles get a real `<a href>`.
+    - **Volume count** → `/catalog?view=volumes` if such a route exists; otherwise reuse `/catalog` (the dev agent must verify and document the choice in the Dev Agent Record). All roles get a real `<a href>`.
+    - **Loan count** → `/loans` ONLY when `session.role >= Role::Librarian`. For Anonymous, the count is rendered as plain text inside a `<span>` with `aria-describedby` pointing to a hidden help message "Sign in to view loans" / "Connectez-vous pour voir les prêts" (the help text is added now; the visible tooltip component itself ships with story 9-19 — do NOT block on it).
+5. **AC5 — Anonymous never receives the loan link in HTML.** Given the role-aware link generation, when tested, then the rendered HTML for an anonymous request does NOT contain `href="/loans"` anywhere (regression guard against accidental over-rendering). This is a byte-level assertion in the unit test for the handler.
+6. **AC6 — CSP compliance.** The card uses Tailwind utility classes only — no `style="..."`, no `<style>` block, no inline event handlers. The audit test in `src/templates_audit.rs::no_inline_markup_in_templates` must continue to pass after this change.
+7. **AC7 — i18n EN + FR.** All user-visible strings have keys in both `locales/en.yml` and `locales/fr.yml` under the existing `dashboard:` section: `dashboard.glance.heading`, `dashboard.glance.titles`, `dashboard.glance.volumes`, `dashboard.glance.active_loans`, `dashboard.glance.signin_to_view_loans`. Use `%{count}` plural-form params where appropriate. After editing locale files, run `touch src/lib.rs && cargo build` to force the i18n proc macro to re-read.
+8. **AC8 — Unit tests.** Tests must cover: (a) count query returns correct values on empty DB (0/0/0); (b) count query returns correct values on a mixed dataset including soft-deleted titles, soft-deleted volumes, returned loans, and at least one of each active; (c) handler-level test that asserts the rendered HTML for an anonymous session contains the three counts AND does NOT contain `href="/loans"`; (d) handler-level test that asserts the rendered HTML for a Librarian session contains `href="/loans"` linked to the loan count.
+9. **AC9 — E2E smoke.** A new spec or extension to `tests/e2e/specs/journeys/home.spec.ts` covers: anonymous → `/` → verify card with three counts visible, loan count is plain text (no link); login as librarian via `loginAs(page, "librarian")` → `/` → verify loan count is now an `<a>` element → click it → `/loans` opens. Use i18n-aware text matchers (`/Active loans|Prêts en cours/i`).
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Add `count_active()` to the three models (AC: 2, 3, 8)**
+  - [ ] In `src/models/title.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` using `SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL`. Follow the pattern in `src/models/volume_state.rs:177-184`.
+  - [ ] In `src/models/volume.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` using the same pattern on `volumes`.
+  - [ ] In `src/models/loan.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` filtering on `returned_at IS NULL AND deleted_at IS NULL`. Follow the pattern in `src/models/volume_state.rs::count_active_loans_for_state` (lines 257-273).
+  - [ ] These per-model `count_active()` are intentionally added even though AC2 mandates a single-round-trip query, because they will be used by other Epic 9 stories (9-4, 9-5) and keep the per-table SQL co-located with each model.
+- [ ] **Task 2 — Add `CollectionGlance` aggregate query in a service (AC: 1, 2)**
+  - [ ] Create `src/services/dashboard.rs` (new module) — register it in `src/services/mod.rs` with `pub mod dashboard;`.
+  - [ ] Define `pub struct CollectionGlance { pub titles: i64, pub volumes: i64, pub active_loans: i64 }` deriving `Debug, Clone, sqlx::FromRow`.
+  - [ ] Implement `pub async fn collection_glance(pool: &DbPool) -> Result<CollectionGlance, AppError>` that runs a single SQL query of the form:
+    ```sql
+    SELECT
+      (SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL)  AS titles,
+      (SELECT COUNT(*) FROM volumes WHERE deleted_at IS NULL) AS volumes,
+      (SELECT COUNT(*) FROM loans WHERE returned_at IS NULL AND deleted_at IS NULL) AS active_loans
+    ```
+    Use `sqlx::query_as::<_, CollectionGlance>` + `.fetch_one(pool)`. This is a single round-trip per AC2.
+  - [ ] DO NOT use `sqlx::query!` macro for this — it requires `.sqlx/` cache regeneration. Use the dynamic `query_as` form.
+- [ ] **Task 3 — Add i18n keys (AC: 7)**
+  - [ ] In `locales/en.yml` under `dashboard:`, add a `glance:` sub-section with: `heading: "Collection at a glance"`, `titles: "%{count} titles"`, `volumes: "%{count} volumes"`, `active_loans: "%{count} active loans"`, `signin_to_view_loans: "Sign in to view loans"`.
+  - [ ] In `locales/fr.yml` under `dashboard:`, add the FR equivalents: `heading: "Aperçu de la collection"`, `titles: "%{count} titres"`, `volumes: "%{count} volumes"`, `active_loans: "%{count} prêts en cours"`, `signin_to_view_loans: "Connectez-vous pour voir les prêts"`.
+  - [ ] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper — keys start at root (per `CLAUDE.md` "Key Patterns / i18n").
+  - [ ] After editing locale files, run `touch src/lib.rs && cargo build` to force proc-macro recompilation.
+- [ ] **Task 4 — Wire the handler (AC: 1, 4, 5)**
+  - [ ] In `src/routes/home.rs::home` (around line 76, before the existing template construction), call `services::dashboard::collection_glance(&state.pool).await?` and bind the result.
+  - [ ] Extend `HomeTemplate` (the Askama struct returned by the handler) with three new fields: `glance_titles: i64`, `glance_volumes: i64`, `glance_active_loans: i64`. Pass them from the handler.
+  - [ ] Use `session.role >= Role::Librarian` (the existing `Role` enum at `src/middleware/auth.rs` derives `PartialOrd`) to compute a boolean `loans_link_visible: bool` and pass it to the template.
+  - [ ] DO NOT add a new route handler. The card is rendered inline by the existing `home` handler.
+- [ ] **Task 5 — Render the card in the template (AC: 1, 4, 6)**
+  - [ ] In `templates/pages/home.html`, insert a new section between the hero (line ~11) and the search input (line ~14), or adjacent to the existing metadata error badge — pick the placement that respects the responsive layout and is consistent with the search-as-homepage UX (UX spec §"Home page"). Document the chosen placement in the Dev Agent Record.
+  - [ ] Markup outline (Tailwind classes + i18n via `t!` macro emitted from the handler-side context, NOT inline `{{ t!(...) }}` if Askama doesn't support it — pre-translate strings in the handler and pass as fields):
+    - A `<section aria-labelledby="glance-heading">` with `<h2 id="glance-heading">{{ glance_heading }}</h2>`
+    - Three `<dl>`-style or list-item rows, each with the count + label
+    - Title count: always an `<a href="/catalog">{{ glance_titles_label }}</a>`
+    - Volume count: always an `<a href="/catalog?view=volumes">{{ glance_volumes_label }}</a>` (or `/catalog` if the `view=volumes` route doesn't exist — verify and document)
+    - Loan count: `{% if loans_link_visible %}<a href="/loans">…</a>{% else %}<span aria-describedby="glance-loans-hint">…</span><span id="glance-loans-hint" class="sr-only">{{ glance_signin_hint }}</span>{% endif %}`
+  - [ ] CSP: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes only.
+- [ ] **Task 6 — Unit tests (AC: 2, 3, 5, 8)**
+  - [ ] Add `tests/dashboard_glance.rs` (new file) with `#[sqlx::test(migrations = "./migrations")]` tests:
+    - `glance_on_empty_db_returns_zeros` — fresh schema, no fixtures, expect `(0, 0, 0)`.
+    - `glance_excludes_soft_deleted_and_returned` — seed: 3 active titles + 1 soft-deleted; 5 active volumes + 2 soft-deleted; 4 loans of which 1 returned + 1 soft-deleted; expect `(3, 5, 2)`.
+    - `glance_is_single_round_trip` — instrument via `sqlx::Executor` query log if feasible; otherwise document the SQL text via `.fetch_one` source. (Lightweight check; if instrumentation is non-trivial, skip and rely on code review of the SQL.)
+  - [ ] Add handler-level rendering tests in `src/routes/home.rs` `mod tests` (or a sibling test module) — follow the existing pattern at `src/routes/home.rs:411-559`. Tests:
+    - `home_anonymous_renders_glance_no_loans_link` — invoke the handler with a `Session { role: Role::Anonymous, .. }`, render the template to a string, assert it contains the three i18n labels AND does NOT contain `href="/loans"`.
+    - `home_librarian_renders_glance_with_loans_link` — same but with `Role::Librarian`, assert `href="/loans"` IS present.
+- [ ] **Task 7 — E2E spec (AC: 9)**
+  - [ ] Extend `tests/e2e/specs/journeys/home.spec.ts` with two new test cases:
+    - `glance card visible to anonymous, loan count is not a link` — load `/`, verify the card heading text matches `/Collection at a glance|Aperçu de la collection/i`, verify three count entries, assert the loan-count parent is NOT an `<a>` (use `page.locator(...).evaluateAll(els => els.every(e => e.tagName !== 'A'))` or a similar assertion).
+    - `glance card visible to librarian, loan count navigates to /loans` — `await loginAs(page, "librarian")`, load `/`, click the loan-count link, `await page.waitForURL(/\/loans/)`.
+  - [ ] Use `loginAs(page, "librarian")` from `tests/e2e/helpers/auth.ts`. Do NOT inject `DEV_SESSION_COOKIE` (per `CLAUDE.md` Foundation Rule #7 + the parallel-safety hard rule).
+  - [ ] Use i18n-aware regex matchers — both EN + FR strings.
+  - [ ] No `waitForTimeout` calls — the CI grep gate enforced by the `e2e` job will fail the PR.
+- [ ] **Task 8 — Verify and document (AC: 1–9)**
+  - [ ] Run locally before push (per `CLAUDE.md` Foundation Rule #13):
+    - `cargo check && cargo clippy -- -D warnings`
+    - `cargo test` (unit + the new `tests/dashboard_glance.rs`)
+    - `./scripts/e2e-reset.sh` then `cd tests/e2e && npx playwright test specs/journeys/home.spec.ts` (or the equivalent if running Docker stack)
+  - [ ] Run `cargo sqlx prepare` if any new query macro was added (Task 2 uses dynamic queries, so likely a no-op — verify no `.sqlx/` diff).
+  - [ ] Update Dev Agent Record at the bottom of this file: list of files touched, choice for `volume count` link target (with rationale), card placement decision in the home template, anything surprising encountered.
+
+## Dev Notes
+
+### Source tree references
+
+The dev agent should not need to reinvent any of these. All paths are relative to repo root (`/home/gcorbaz/Synology/devel/mybibli/`).
+
+| Concern | File / location | Notes |
+|---|---|---|
+| Home route registration | `src/routes/mod.rs:87` | `.route("/", axum::routing::get(home::home))` — no change needed |
+| Home handler | `src/routes/home.rs:76-224` | extend the existing handler; do NOT create a parallel route |
+| Home template | `templates/pages/home.html` (174 lines) | extends `layouts/base.html`; section blocks: hero (8-11), search (14-33), filter tags (36-65), metadata error badge (67-74, role-gated), browse results (105-139), pagination (142-169) |
+| Session extractor & Role enum | `src/middleware/auth.rs` | `Role: Anonymous < Librarian < Admin` (derives `PartialOrd`) — use `session.role >= Role::Librarian` |
+| Existing role-aware template gating | `templates/pages/home.html:112` | `{% if role == "librarian" || role == "admin" %}` — reuse this pattern, NOT a fresh approach |
+| Existing role-aware handler gating | `src/routes/home.rs:154-163` | the `metadata_error_count` block — pattern: handler computes the value or skips, template trusts the value |
+| Count query reference patterns | `src/models/volume_state.rs:177-184` (count_usage); `src/models/volume_state.rs:257-273` (count_active_loans_for_state) | use the `sqlx::query_as::<_, (i64,)>` form for ad-hoc counts; `query_scalar::<_, i64>` is also fine |
+| Per-model files where count_active goes | `src/models/title.rs`, `src/models/volume.rs`, `src/models/loan.rs` | none currently has `count_active`; add it (see Task 1) |
+| Existing service organization | `src/services/` (admin_health.rs, locking.rs, soft_delete.rs, etc.) | new `dashboard.rs` belongs here; register in `src/services/mod.rs` |
+| i18n locales | `locales/en.yml` / `locales/fr.yml` | top-level sections include `dashboard:` (already used for `dashboard.metadata_errors`); extend with `dashboard.glance.*` sub-keys. **NO `en:`/`fr:` top-level wrapper.** |
+| Templates audit (CSP enforcement) | `src/templates_audit.rs::no_inline_markup_in_templates` + `hx_confirm_matches_allowlist` (post-9-14: empty) | `cargo test` runs both — must stay green |
+| Test (DB-backed integration) pattern | `tests/search_filter_browse.rs:57-87` | `#[sqlx::test(migrations = "./migrations")]` — the dominant pattern in this repo |
+| Test (handler render, no DB) pattern | `src/routes/home.rs:411-559` | `#[test]` + `#[cfg(test)]` modules co-located with the handler — reuse for the role-aware HTML assertions |
+| E2E helpers | `tests/e2e/helpers/auth.ts` (`loginAs`), `tests/e2e/helpers/isbn.ts`, `tests/e2e/helpers/scanner.ts` | `loginAs(page, "librarian")` — typed union, do not pass other strings |
+| E2E spec for `/` | `tests/e2e/specs/journeys/home.spec.ts` (basic h1 + title + CSS) and `home-search.spec.ts` (search interactions) | extend `home.spec.ts` for the glance card tests |
+
+### Anti-patterns to avoid
+
+- **Three independent `fetch_one` calls.** AC2 explicitly mandates a single round-trip. Use the SELECT-with-three-subqueries pattern shown in Task 2.
+- **Adding the loan count to anonymous-visible HTML as `<a href="/loans">`.** AC5 enforces this with a byte-level assertion. Even if the link would 401-redirect, leaking it leaks a route surface to anonymous users — unacceptable per the project's role-aware visibility discipline (FR59 / Story 9-8 will tighten the same principle further).
+- **Using `sqlx::query!` macro for the new query.** That requires `cargo sqlx prepare` and a `.sqlx/` diff in the PR. The codebase already uses dynamic `query_as` for ad-hoc counts (see `volume_state.rs`); stay consistent.
+- **Inline styles for the card.** `style="text-align: center"` will trip `templates_audit.rs::no_inline_markup_in_templates` and fail `cargo test`. Use Tailwind utilities exclusively.
+- **Adding a new route like `GET /dashboard` or `GET /home/glance`.** The card is part of `/`. Adding a fragment-fetch route for it would over-engineer this story (the counts are cheap; HTMX async refresh is not in scope).
+- **Empty-state-hiding the card.** AC3 requires the card to render even on a fresh DB. Story 9-15 will handle the broader empty-catalog UX — do not pre-empt it here.
+- **Tooltip implementation for the anonymous "Sign in to view loans" hint.** UX-DR19 / Story 9-19 ships the actual Tooltip component; here you only need an `aria-describedby` link to a `class="sr-only"` text node so screen readers get the explanation. Sighted users will pick up the tooltip when 9-19 ships.
+- **Re-translating reference data values or anything from `locales/*.yml`.** Locale files are i18n-only for UI labels (NFR41 — reference data not translated). The card's text labels are UI labels, so they ARE translated; the counts themselves are numbers (locale-formatted via Rust's `format!` if FR uses non-breaking spaces — keep it simple and use plain `i64` formatting, no thousands separator in v1).
+
+### Architecture compliance
+
+- **Error handling:** Any DB failure in `collection_glance` returns `AppError::Database` via `?` — do not introduce a new error variant.
+- **Logging:** Use `tracing::debug!` at most, only inside the service function if needed. Counts are not interesting at info-level.
+- **DB query discipline:** All three subqueries already include `deleted_at IS NULL` (per `CLAUDE.md` "Key Patterns / DB queries"). The loans subquery additionally needs `returned_at IS NULL` for "active" semantics (per FR48 + AR23).
+- **HTMX:** Not applicable — the card is rendered server-side on full page load. No `hx-*` attributes, no OOB swaps.
+- **CSP middleware:** Already wraps the handler outermost. No work needed.
+- **Optimistic locking:** Not applicable — this is read-only.
+- **Pool access:** The handler already has access to `state.pool: DbPool`. Do not introduce a new connection.
+
+### Library / framework requirements
+
+- **Rust 2024 + Axum 0.8 + SQLx 0.8 (MariaDB) + Askama 0.15 + Tailwind CSS v4 + HTMX 2.0** — no version changes. No new dependencies. If you find yourself reaching for a new crate, stop and re-read this section.
+- **rust_i18n** — already wired. The `t!` macro is invoked from Rust (handler) — pre-translate strings in the handler, pass them as `&str` fields on the Askama template struct. Askama itself has limited support for runtime-locale macro calls; the project pattern is "translate in handler, pass to template".
+
+### File structure requirements
+
+The full set of files this story creates or modifies (no others — if you find yourself touching unrelated files, stop and reconsider):
+
+| File | Action | Rough size |
+|---|---|---|
+| `src/services/dashboard.rs` | **create** | ~40 lines (struct + 1 fn + tests) |
+| `src/services/mod.rs` | **edit** | +1 line (`pub mod dashboard;`) |
+| `src/models/title.rs` | **edit** | +~10 lines (one `count_active` fn) |
+| `src/models/volume.rs` | **edit** | +~10 lines |
+| `src/models/loan.rs` | **edit** | +~10 lines |
+| `src/routes/home.rs` | **edit** | +~15 lines in handler + extend `HomeTemplate` struct + `mod tests` additions |
+| `templates/pages/home.html` | **edit** | +~25 lines for the card section |
+| `locales/en.yml` | **edit** | +~6 lines under `dashboard:` |
+| `locales/fr.yml` | **edit** | +~6 lines under `dashboard:` |
+| `tests/dashboard_glance.rs` | **create** | ~80 lines (3 `#[sqlx::test]` cases) |
+| `tests/e2e/specs/journeys/home.spec.ts` | **edit** | +~30 lines (2 new test cases) |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | **edit** | only the `9-1-...` line + `last_updated` (per CLAUDE.md rule 16) |
+
+### Testing requirements
+
+- **Coverage target:** every AC has at least one test (unit OR E2E).
+- **Soft-delete exclusion is the load-bearing invariant** for this story. The mixed-dataset test in `tests/dashboard_glance.rs::glance_excludes_soft_deleted_and_returned` is the regression guard. If a future migration changes a soft-delete column name or semantics, this test catches it.
+- **Role-aware HTML assertion** is the second load-bearing test (AC5). It must use the actual `Session` extractor type, not a mock — the extractor's behavior is the contract.
+- **E2E parallelism** — keep the new tests independent (no shared session). `loginAs` per test (in `beforeEach` if a block is reused).
+
+### Project structure notes
+
+This story aligns cleanly with the existing structure — no variances. The new `src/services/dashboard.rs` follows the established `src/services/` pattern (compare to `admin_health.rs` which also assembles per-table counts for the Health admin tab). The 3 new model methods (`count_active`) keep the per-table SQL co-located with each model, consistent with `volume_state.rs::count_usage` and `count_active_loans_for_state`.
+
+## References
+
+- [Story 9.1 spec — `_bmad-output/planning-artifacts/epics.md` lines 1210–1224](../planning-artifacts/epics.md)
+- [Epic 9 scope note + split philosophy — `epics.md` lines 1204–1207](../planning-artifacts/epics.md)
+- [PRD FR55 — `_bmad-output/planning-artifacts/prd.md:689`](../planning-artifacts/prd.md)
+- [PRD FR65 (anonymous browse) and FR59 (loan-status role gating) for the role-aware visibility principle — `prd.md`](../planning-artifacts/prd.md)
+- [Architecture AR8, AR15, AR16, AR17 — `_bmad-output/planning-artifacts/architecture.md`](../planning-artifacts/architecture.md) (handler/template wiring, error pipeline, middleware order, soft-delete query naming)
+- [UX spec §"Home page" + UX-DR24 design tokens — `_bmad-output/planning-artifacts/ux-design-specification.md`](../planning-artifacts/ux-design-specification.md)
+- [`CLAUDE.md` — Key Patterns / Foundation Rules (#7 E2E smoke, #11 GitHub Issues, #12 ≤ 2000 LOC, #13 local testing, #14 one-branch-one-story, #15 draft PR, #16 sprint-status ownership, #18 CI gating)](../../CLAUDE.md)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+_To be filled by dev agent (e.g., `claude-opus-4-7`)._
+
+### Debug Log References
+
+_To be filled during implementation._
+
+### Completion Notes List
+
+_To be filled during implementation. Document at minimum:_
+- _Volume count link target chosen (`/catalog?view=volumes` or fallback) and why._
+- _Card placement in `templates/pages/home.html` (above search? below hero? adjacent to metadata badge?) and why._
+- _Anything surprising encountered (existing helper found, schema quirk, i18n key collision, etc.)._
+
+### File List
+
+_To be filled by dev agent — exhaustive list of files touched, including the sprint-status.yaml line update._

--- a/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
+++ b/_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md
@@ -1,6 +1,6 @@
 # Story 9.1: Dashboard — global stats card
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -32,15 +32,15 @@ so that I get an immediate sense of the catalog's size at a glance.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Add `count_active()` to the three models (AC: 2, 3, 8)**
-  - [ ] In `src/models/title.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` using `SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL`. Follow the pattern in `src/models/volume_state.rs:177-184`.
-  - [ ] In `src/models/volume.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` using the same pattern on `volumes`.
-  - [ ] In `src/models/loan.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` filtering on `returned_at IS NULL AND deleted_at IS NULL`. Follow the pattern in `src/models/volume_state.rs::count_active_loans_for_state` (lines 257-273).
-  - [ ] These per-model `count_active()` are intentionally added even though AC2 mandates a single-round-trip query, because they will be used by other Epic 9 stories (9-4, 9-5) and keep the per-table SQL co-located with each model.
-- [ ] **Task 2 — Add `CollectionGlance` aggregate query in a service (AC: 1, 2)**
-  - [ ] Create `src/services/dashboard.rs` (new module) — register it in `src/services/mod.rs` with `pub mod dashboard;`.
-  - [ ] Define `pub struct CollectionGlance { pub titles: i64, pub volumes: i64, pub active_loans: i64 }` deriving `Debug, Clone, sqlx::FromRow`.
-  - [ ] Implement `pub async fn collection_glance(pool: &DbPool) -> Result<CollectionGlance, AppError>` that runs a single SQL query of the form:
+- [x] **Task 1 — Add `count_active()` to the three models (AC: 2, 3, 8)**
+  - [x] In `src/models/title.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` using `SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL`. Follow the pattern in `src/models/volume_state.rs:177-184`.
+  - [x] In `src/models/volume.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` using the same pattern on `volumes`.
+  - [x] In `src/models/loan.rs`, add `pub async fn count_active(pool: &DbPool) -> Result<i64, AppError>` filtering on `returned_at IS NULL AND deleted_at IS NULL`. Follow the pattern in `src/models/volume_state.rs::count_active_loans_for_state` (lines 257-273).
+  - [x] These per-model `count_active()` are intentionally added even though AC2 mandates a single-round-trip query, because they will be used by other Epic 9 stories (9-4, 9-5) and keep the per-table SQL co-located with each model.
+- [x] **Task 2 — Add `CollectionGlance` aggregate query in a service (AC: 1, 2)**
+  - [x] Create `src/services/dashboard.rs` (new module) — register it in `src/services/mod.rs` with `pub mod dashboard;`.
+  - [x] Define `pub struct CollectionGlance { pub titles: i64, pub volumes: i64, pub active_loans: i64 }` deriving `Debug, Clone, sqlx::FromRow`.
+  - [x] Implement `pub async fn collection_glance(pool: &DbPool) -> Result<CollectionGlance, AppError>` that runs a single SQL query of the form:
     ```sql
     SELECT
       (SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL)  AS titles,
@@ -48,57 +48,57 @@ so that I get an immediate sense of the catalog's size at a glance.
       (SELECT COUNT(*) FROM loans WHERE returned_at IS NULL AND deleted_at IS NULL) AS active_loans
     ```
     Use `sqlx::query_as::<_, CollectionGlance>` + `.fetch_one(pool)`. This is a single round-trip per AC2 — verified by the SQL shape (1 SELECT, 0 join, 3 sub-counts) at code review time, no programmatic instrumentation needed.
-  - [ ] DO NOT use `sqlx::query!` macro for this — it requires `.sqlx/` cache regeneration. Use the dynamic `query_as` form.
-- [ ] **Task 3 — Add i18n keys (AC: 7)**
-  - [ ] In `locales/en.yml` under `dashboard:`, add a `glance:` sub-section with these 8 keys:
+  - [x] DO NOT use `sqlx::query!` macro for this — it requires `.sqlx/` cache regeneration. Use the dynamic `query_as` form.
+- [x] **Task 3 — Add i18n keys (AC: 7)**
+  - [x] In `locales/en.yml` under `dashboard:`, add a `glance:` sub-section with these 8 keys:
     - `heading: "Collection at a glance"`
     - `titles_one: "%{count} title"` and `titles_other: "%{count} titles"`
     - `volumes_one: "%{count} volume"` and `volumes_other: "%{count} volumes"`
     - `active_loans_one: "%{count} active loan"` and `active_loans_other: "%{count} active loans"`
     - `signin_to_view_loans: "Sign in to view loans"`
-  - [ ] In `locales/fr.yml` under `dashboard:`, add the FR equivalents (8 keys):
+  - [x] In `locales/fr.yml` under `dashboard:`, add the FR equivalents (8 keys):
     - `heading: "Aperçu de la collection"`
     - `titles_one: "%{count} titre"` and `titles_other: "%{count} titres"`
     - `volumes_one: "%{count} volume"` and `volumes_other: "%{count} volumes"`
     - `active_loans_one: "%{count} prêt en cours"` and `active_loans_other: "%{count} prêts en cours"`
     - `signin_to_view_loans: "Connectez-vous pour voir les prêts"`
-  - [ ] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper — keys start at root (per `CLAUDE.md` "Key Patterns / i18n").
-  - [ ] After editing locale files, run `touch src/lib.rs && cargo build` to force proc-macro recompilation.
-- [ ] **Task 4 — Wire the handler (AC: 1, 4, 5)**
-  - [ ] In `src/routes/home.rs::home` (around line 76, before the existing template construction), call `services::dashboard::collection_glance(&state.pool).await?` and bind the result.
-  - [ ] Extend `HomeTemplate` (the Askama struct returned by the handler) with new fields: `glance_heading: String`, `glance_titles_label: String`, `glance_volumes_label: String`, `glance_active_loans_label: String`, `glance_signin_hint: String`, `glance_titles_count: i64`, `glance_volumes_count: i64`, `glance_active_loans_count: i64`, `loans_link_visible: bool`. Pre-translate the 4 label strings + hint in the handler via `rust_i18n::t!(...)` calls.
-  - [ ] Use `session.role >= Role::Librarian` (the existing `Role` enum at `src/middleware/auth.rs` derives `PartialOrd`) to compute `loans_link_visible`.
-  - [ ] DO NOT add a new route handler. The card is rendered inline by the existing `home` handler.
-- [ ] **Task 5 — Render the card in the template (AC: 1, 4, 6)**
-  - [ ] In `templates/pages/home.html`, insert the card **between the filter tags (closing tag at line ~65) and the `#browse-results` div (opening at line ~106)**. Rationale: this placement keeps the search field above the fold (no CLS on tablet/mobile), sits OUTSIDE the HTMX swap target `#browse-results` so the card stays visible during search interactions, and is consistent with the search-as-homepage UX (UX spec §"Home page"). The dev agent may deviate only with explicit justification documented in the Dev Agent Record.
-  - [ ] Markup outline (Tailwind utility classes; all i18n strings come pre-translated as `String` fields on `HomeTemplate`):
+  - [x] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper — keys start at root (per `CLAUDE.md` "Key Patterns / i18n").
+  - [x] After editing locale files, run `touch src/lib.rs && cargo build` to force proc-macro recompilation.
+- [x] **Task 4 — Wire the handler (AC: 1, 4, 5)**
+  - [x] In `src/routes/home.rs::home` (around line 76, before the existing template construction), call `services::dashboard::collection_glance(&state.pool).await?` and bind the result.
+  - [x] Extend `HomeTemplate` (the Askama struct returned by the handler) with new fields: `glance_heading: String`, `glance_titles_label: String`, `glance_volumes_label: String`, `glance_active_loans_label: String`, `glance_signin_hint: String`, `glance_titles_count: i64`, `glance_volumes_count: i64`, `glance_active_loans_count: i64`, `loans_link_visible: bool`. Pre-translate the 4 label strings + hint in the handler via `rust_i18n::t!(...)` calls.
+  - [x] Use `session.role >= Role::Librarian` (the existing `Role` enum at `src/middleware/auth.rs` derives `PartialOrd`) to compute `loans_link_visible`.
+  - [x] DO NOT add a new route handler. The card is rendered inline by the existing `home` handler.
+- [x] **Task 5 — Render the card in the template (AC: 1, 4, 6)**
+  - [x] In `templates/pages/home.html`, insert the card **between the filter tags (closing tag at line ~65) and the `#browse-results` div (opening at line ~106)**. Rationale: this placement keeps the search field above the fold (no CLS on tablet/mobile), sits OUTSIDE the HTMX swap target `#browse-results` so the card stays visible during search interactions, and is consistent with the search-as-homepage UX (UX spec §"Home page"). The dev agent may deviate only with explicit justification documented in the Dev Agent Record.
+  - [x] Markup outline (Tailwind utility classes; all i18n strings come pre-translated as `String` fields on `HomeTemplate`):
     - `<section aria-labelledby="glance-heading">` with `<h2 id="glance-heading">{{ glance_heading }}</h2>`
     - Three `<dl>`-style or list-item rows, each rendering its pre-translated label (which already includes the count via `%{count}` interpolation)
     - Title count: always `<a href="/catalog">{{ glance_titles_label }}</a>`
     - Volume count: always `<a href="/catalog">{{ glance_volumes_label }}</a>`
     - Loan count: `{% if loans_link_visible %}<a href="/loans">{{ glance_active_loans_label }}</a>{% else %}<span aria-describedby="glance-loans-hint">{{ glance_active_loans_label }}</span><span id="glance-loans-hint" class="sr-only">{{ glance_signin_hint }}</span>{% endif %}`
-  - [ ] CSP: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes only.
-- [ ] **Task 6 — Unit tests (AC: 2, 3, 5, 8)**
-  - [ ] Add `tests/dashboard_glance.rs` (new file) with `#[sqlx::test(migrations = "./migrations")]` tests:
+  - [x] CSP: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes only.
+- [x] **Task 6 — Unit tests (AC: 2, 3, 5, 8)**
+  - [x] Add `tests/dashboard_glance.rs` (new file) with `#[sqlx::test(migrations = "./migrations")]` tests:
     - `glance_on_empty_db_returns_zeros` — fresh schema, no fixtures, expect `(0, 0, 0)`.
     - `glance_excludes_soft_deleted_and_returned` — seed: 3 active titles + 1 soft-deleted; 5 active volumes + 2 soft-deleted; 4 loans of which 1 returned + 1 soft-deleted; expect `(3, 5, 2)`.
-  - [ ] Add handler-level rendering tests in `src/routes/home.rs` `mod tests` (or a sibling test module) — follow the existing pattern at `src/routes/home.rs:411-559`. Tests:
+  - [x] Add handler-level rendering tests in `src/routes/home.rs` `mod tests` (or a sibling test module) — follow the existing pattern at `src/routes/home.rs:411-559`. Tests:
     - `home_anonymous_renders_glance_no_loans_link` — invoke the handler with a `Session { role: Role::Anonymous, .. }`, render the template to a string, then assert: contains the three i18n labels (EN locale, plural form); does NOT contain `href="/loans"`; contains BOTH `aria-describedby="glance-loans-hint"` AND `id="glance-loans-hint"` (linkage check); the span carrying `id="glance-loans-hint"` carries class `sr-only` and contains the EN sign-in hint text.
     - `home_librarian_renders_glance_with_loans_link` — same but with `Role::Librarian`; assert `href="/loans"` IS present and does NOT contain `aria-describedby="glance-loans-hint"` (no orphan).
-- [ ] **Task 7 — E2E spec (AC: 9)**
-  - [ ] Extend `tests/e2e/specs/journeys/home.spec.ts` with two new test cases:
+- [x] **Task 7 — E2E spec (AC: 9)**
+  - [x] Extend `tests/e2e/specs/journeys/home.spec.ts` with two new test cases:
     - `glance card visible to anonymous, loan count is not a link` — load `/`, verify the card heading matches `/Collection at a glance|Aperçu de la collection/i`, verify the three count rows are present, then `await expect(page.locator('a[href="/loans"]')).toHaveCount(0)`.
     - `glance card visible to librarian, loan count navigates to /loans` — `await loginAs(page, "librarian")`, load `/`, `await expect(page.locator('a[href="/loans"]')).toHaveCount(1)`, click the link, `await page.waitForURL(/\/loans/)`.
-  - [ ] Use `loginAs(page, "librarian")` from `tests/e2e/helpers/auth.ts`. Do NOT inject `DEV_SESSION_COOKIE` (per `CLAUDE.md` Foundation Rule #7 + the parallel-safety hard rule).
-  - [ ] Use i18n-aware regex matchers — both EN + FR strings.
-  - [ ] No `waitForTimeout` calls — the CI grep gate enforced by the `e2e` job will fail the PR.
-- [ ] **Task 8 — Verify and document (AC: 1–9)**
-  - [ ] Run locally before push (per `CLAUDE.md` Foundation Rule #13):
+  - [x] Use `loginAs(page, "librarian")` from `tests/e2e/helpers/auth.ts`. Do NOT inject `DEV_SESSION_COOKIE` (per `CLAUDE.md` Foundation Rule #7 + the parallel-safety hard rule).
+  - [x] Use i18n-aware regex matchers — both EN + FR strings.
+  - [x] No `waitForTimeout` calls — the CI grep gate enforced by the `e2e` job will fail the PR.
+- [x] **Task 8 — Verify and document (AC: 1–9)**
+  - [x] Run locally before push (per `CLAUDE.md` Foundation Rule #13):
     - `cargo check && cargo clippy -- -D warnings`
     - `cargo test` (unit + the new `tests/dashboard_glance.rs`)
     - `./scripts/e2e-reset.sh` then `cd tests/e2e && npx playwright test specs/journeys/home.spec.ts` (or the equivalent if running Docker stack)
-  - [ ] Run `cargo sqlx prepare` if any new query macro was added (Task 2 uses dynamic queries, so likely a no-op — verify no `.sqlx/` diff).
-  - [ ] Update Dev Agent Record at the bottom of this file: list of files touched, card placement decision in the home template (or justification for deviating from the recommended placement), anything surprising encountered.
+  - [x] Run `cargo sqlx prepare` if any new query macro was added (Task 2 uses dynamic queries, so likely a no-op — verify no `.sqlx/` diff).
+  - [x] Update Dev Agent Record at the bottom of this file: list of files touched, card placement decision in the home template (or justification for deviating from the recommended placement), anything surprising encountered.
 
 ## Dev Notes
 
@@ -200,18 +200,44 @@ This story aligns cleanly with the existing structure — no variances. The new 
 
 ### Agent Model Used
 
-_To be filled by dev agent (e.g., `claude-opus-4-7`)._
+`claude-opus-4-7` (1M context).
 
 ### Debug Log References
 
-_To be filled during implementation._
+- `cargo test --lib` — 624 passed, 0 failed (after `dashboard.glance.titles` initially failed `i18n::audit::tests::all_t_keys_have_both_locales` because the audit expects literal scalar leaves, not the rust_i18n `_one`/`_other` auto-resolved prefix; resolution: branch on `count == 1` in the handler with two literal `t!()` calls per count).
+- `cargo test --test dashboard_glance` — 2 passed (empty DB → zeros; mixed dataset → 3/5/2 with soft-deleted titles + soft-deleted volumes + returned loan + soft-deleted loan correctly excluded).
+- `cargo clippy --all-targets -- -D warnings` — clean.
+- `cargo sqlx prepare --check --workspace -- --all-targets` — no diff (Task 2 uses dynamic `query_as`, Task 1 uses dynamic `query_as` — no `.sqlx/` regeneration needed).
+- Manual smoke via `curl http://localhost:8080/`: FR locale (default) renders "Aperçu de la collection / 0 titres / 0 prêts en cours" with `aria-describedby="glance-loans-hint"` paired to `id="glance-loans-hint"` carrying the `sr-only` "Connectez-vous pour voir les prêts" hint and zero `href="/loans"` occurrences. `?lang=en` flips to "Collection at a glance / 0 titles / 0 active loans / Sign in to view loans".
+- E2E locally blocked by `EACCES` on `tests/e2e/test-results/` (artefacts owned by root from a prior Docker run); CI run on push will validate `home.spec.ts` end-to-end.
 
 ### Completion Notes List
 
-_To be filled during implementation. Document at minimum:_
-- _Card placement in `templates/pages/home.html` — confirm the recommended location (between filter tags and `#browse-results`) was used, or justify deviation._
-- _Anything surprising encountered (existing helper found, schema quirk, i18n key collision, etc.)._
+- **Card placement**: implemented at the recommended location — between the metadata-error badge (line ~74) and the browse toggle (line ~78), inside the safe zone `(filter tags ~65) ↔ (#browse-results ~106)`. The card is OUTSIDE the HTMX swap target `#browse-results`, so it survives in-place during search/filter swaps. No deviation from the story spec.
+- **i18n pluralization**: rust_i18n auto-resolution of `key` → `key.one`/`key.other` collides with the project's i18n audit (`src/i18n/audit.rs::all_t_keys_have_both_locales`), which expects every `t!()` first argument to be a literal scalar leaf. Resolved by branching on `count == 1` in the handler and calling two literal `t!()` keys per count (`titles_one` / `titles_other`, etc.). This preserves correct EN/FR plural grammar (notably FR `prêt` vs `prêts`) without weakening the audit.
+- **Pattern reuse**: the new `src/services/dashboard.rs` deliberately mirrors `src/services/admin_health.rs::entity_counts` (also a counts builder), but uses a single SQL round-trip with three correlated subqueries instead of five separate `query_scalar` calls. Both are valid for their context: admin Health refreshes per page render and counts five tables; the home glance card targets a hot path (`/`) where the latency saving matters more.
+- **Per-model `count_active()`**: added to all three of `title.rs`, `volume.rs`, `loan.rs` per Task 1 — they're not used by the glance query itself (which lives in the service) but are positioned for reuse by stories 9-4 / 9-5 (FilterTag indicators).
+- **`HomeTemplate` test factory**: the existing `test_home_template_renders` test was extracted into a `make_test_home_template(role, loans_link_visible)` factory inside `mod tests` to avoid duplicating ~50 fields across the three glance-card render tests.
+- **No surprises with schema or query semantics**. The single-round-trip query worked first try; the soft-delete + `returned_at` filtering matches the convention from `volume_state.rs::count_active_loans_for_state`.
 
 ### File List
 
-_To be filled by dev agent — exhaustive list of files touched, including the sprint-status.yaml line update._
+| File | Action |
+|---|---|
+| `src/models/title.rs` | edit (added `count_active()`) |
+| `src/models/volume.rs` | edit (added `count_active()`) |
+| `src/models/loan.rs` | edit (added `count_active()`) |
+| `src/services/dashboard.rs` | create (`CollectionGlance` + `collection_glance()` + smoke test) |
+| `src/services/mod.rs` | edit (registered `pub mod dashboard;`) |
+| `src/routes/home.rs` | edit (extended `HomeTemplate` with 9 fields, computed glance + plural-aware labels in handler, added 2 render tests + factory) |
+| `templates/pages/home.html` | edit (inserted `#collection-glance` section between metadata badge and browse toggle) |
+| `locales/en.yml` | edit (8 keys under `dashboard.glance.*`) |
+| `locales/fr.yml` | edit (8 keys under `dashboard.glance.*`) |
+| `tests/dashboard_glance.rs` | create (2 `#[sqlx::test]` cases — empty DB + mixed soft-deleted/returned) |
+| `tests/e2e/specs/journeys/home.spec.ts` | edit (added 2 test cases — anonymous card without loan link, librarian card navigates to /loans) |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | edit (9-1 → review on completion; epic-9 already in-progress from spec creation) |
+| `_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md` | edit (Status → review, Tasks all checked, Dev Agent Record filled) |
+
+### Change Log
+
+- **2026-04-30** — Initial implementation. All 8 tasks complete; 624 lib tests + 2 dashboard_glance integration tests pass; clippy clean; sqlx cache unchanged. E2E validation deferred to CI (local `tests/e2e/test-results/` directory owned by root from earlier Docker runs blocks Playwright reporter writes).

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-04-30 # Epic 9 sprint planning: 22 stories decomposed from epics.md (9-1..9-22, all backlog — no story files yet). Earlier 2026-04-30: Epic 8 close — story 8-8 PR #92 merged after 5-iteration CI recovery; retro complete (`epic-8-retro-2026-04-30.md`); 5 deferred findings filed as GH issues #93–#97; per-story-commit action retired via decision record GH #98. Epic 8: in-progress → done. Epic-8-retrospective: optional → done.
+last_updated: 2026-04-30 # Story 9-1 created: file `9-1-dashboard-global-stats-card.md` ready for dev. Epic 9: backlog → in-progress (first story of the epic). Earlier 2026-04-30: Epic 9 sprint planning (22 stories decomposed) + Epic 8 close (story 8-8 PR #92 merged, retro `epic-8-retro-2026-04-30.md`, 5 deferred findings filed as GH #93–#97).
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -162,8 +162,8 @@ development_status:
   # Stories decomposed 2026-04-30 (22 stories — incremental indicator delivery 9-4..9-7,
   # one-PR-per-hx-confirm-migration 9-10..9-14 emptying ALLOWED_HX_CONFIRM_SITES to &[],
   # closure of UX-DR29 in 9-22 with full axe-core coverage in CI).
-  epic-9: backlog
-  9-1-dashboard-global-stats-card: backlog
+  epic-9: in-progress
+  9-1-dashboard-global-stats-card: ready-for-dev
   9-2-dashboard-recent-additions: backlog
   9-3-dashboard-stats-by-genre: backlog
   9-4-filtertag-and-unshelved-indicator: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-04-30 # Story 9-1 implementation complete — in-progress → review. 624 lib tests + 2 new dashboard_glance integration tests pass; clippy + sqlx-prepare clean; manual smoke via curl confirms FR/EN render + anonymous-loan-link gate. E2E deferred to CI. Earlier 2026-04-30: Story 9-1 spec + validation (PR #102), Epic 9 sprint planning (22 stories, PR #101), Epic 8 close (PR #92 + retro + GH #93–#97).
+last_updated: 2026-04-30 # Story 9-1 review complete — review → done. Code review found 1 decision-needed + 7 patches + 3 deferred + 5 dismissed; all 8 patches applied (active-loan cascade JOIN, soft-degrade on DB error, FR CLDR for count==0, librarian test scoped to card slice, zero-count render test, E2E per-row locators, dead fields removed, librarian E2E i18n match). Final: 628 lib tests + 3 dashboard_glance integration tests, all green. Earlier 2026-04-30: Story 9-1 implementation, spec + validation (PR #102), Epic 9 sprint planning (PR #101), Epic 8 close.
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -163,7 +163,7 @@ development_status:
   # one-PR-per-hx-confirm-migration 9-10..9-14 emptying ALLOWED_HX_CONFIRM_SITES to &[],
   # closure of UX-DR29 in 9-22 with full axe-core coverage in CI).
   epic-9: in-progress
-  9-1-dashboard-global-stats-card: review
+  9-1-dashboard-global-stats-card: done
   9-2-dashboard-recent-additions: backlog
   9-3-dashboard-stats-by-genre: backlog
   9-4-filtertag-and-unshelved-indicator: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-04-30 # Story 9-1 created: file `9-1-dashboard-global-stats-card.md` ready for dev. Epic 9: backlog → in-progress (first story of the epic). Earlier 2026-04-30: Epic 9 sprint planning (22 stories decomposed) + Epic 8 close (story 8-8 PR #92 merged, retro `epic-8-retro-2026-04-30.md`, 5 deferred findings filed as GH #93–#97).
+last_updated: 2026-04-30 # Story 9-1 implementation complete — in-progress → review. 624 lib tests + 2 new dashboard_glance integration tests pass; clippy + sqlx-prepare clean; manual smoke via curl confirms FR/EN render + anonymous-loan-link gate. E2E deferred to CI. Earlier 2026-04-30: Story 9-1 spec + validation (PR #102), Epic 9 sprint planning (22 stories, PR #101), Epic 8 close (PR #92 + retro + GH #93–#97).
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -163,7 +163,7 @@ development_status:
   # one-PR-per-hx-confirm-migration 9-10..9-14 emptying ALLOWED_HX_CONFIRM_SITES to &[],
   # closure of UX-DR29 in 9-22 with full axe-core coverage in CI).
   epic-9: in-progress
-  9-1-dashboard-global-stats-card: ready-for-dev
+  9-1-dashboard-global-stats-card: review
   9-2-dashboard-recent-additions: backlog
   9-3-dashboard-stats-by-genre: backlog
   9-4-filtertag-and-unshelved-indicator: backlog

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -341,6 +341,15 @@ audio:
   disable: Disable scan sounds
 dashboard:
   metadata_errors: "%{count} title(s) with metadata errors"
+  glance:
+    heading: Collection at a glance
+    titles_one: "%{count} title"
+    titles_other: "%{count} titles"
+    volumes_one: "%{count} volume"
+    volumes_other: "%{count} volumes"
+    active_loans_one: "%{count} active loan"
+    active_loans_other: "%{count} active loans"
+    signin_to_view_loans: Sign in to view loans
 borrower:
   list_title: Borrowers
   add: Add borrower

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -341,6 +341,15 @@ audio:
   disable: "Désactiver les sons de scan"
 dashboard:
   metadata_errors: "%{count} titre(s) avec erreurs de métadonnées"
+  glance:
+    heading: Aperçu de la collection
+    titles_one: "%{count} titre"
+    titles_other: "%{count} titres"
+    volumes_one: "%{count} volume"
+    volumes_other: "%{count} volumes"
+    active_loans_one: "%{count} prêt en cours"
+    active_loans_other: "%{count} prêts en cours"
+    signin_to_view_loans: Connectez-vous pour voir les prêts
 borrower:
   list_title: Emprunteurs
   add: Ajouter un emprunteur

--- a/src/models/loan.rs
+++ b/src/models/loan.rs
@@ -289,6 +289,19 @@ impl LoanModel {
 
         Ok(items)
     }
+
+    /// Count of active loans (not returned, not soft-deleted) across the entire catalog.
+    /// "Active" = `returned_at IS NULL AND deleted_at IS NULL`. Used by
+    /// `services::dashboard::collection_glance` for the home-page "Collection at a glance"
+    /// card and reusable by other dashboard surfaces.
+    pub async fn count_active(pool: &DbPool) -> Result<i64, AppError> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM loans WHERE returned_at IS NULL AND deleted_at IS NULL",
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(row.0)
+    }
 }
 
 #[cfg(test)]

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -180,6 +180,17 @@ impl TitleModel {
         }
     }
 
+    /// Count of active (non-soft-deleted) titles in the catalog.
+    /// Used by `services::dashboard::collection_glance` for the home-page
+    /// "Collection at a glance" card and reusable by other dashboard surfaces.
+    pub async fn count_active(pool: &DbPool) -> Result<i64, AppError> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL")
+                .fetch_one(pool)
+                .await?;
+        Ok(row.0)
+    }
+
     pub async fn create(pool: &DbPool, new_title: &NewTitle) -> Result<TitleModel, AppError> {
         tracing::info!(
             title = %new_title.title,

--- a/src/models/volume.rs
+++ b/src/models/volume.rs
@@ -212,6 +212,17 @@ impl VolumeModel {
 
         Ok(row.0 as u64)
     }
+
+    /// Count of active (non-soft-deleted) volumes across the entire catalog.
+    /// Used by `services::dashboard::collection_glance` for the home-page
+    /// "Collection at a glance" card and reusable by other dashboard surfaces.
+    pub async fn count_active(pool: &DbPool) -> Result<i64, AppError> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM volumes WHERE deleted_at IS NULL")
+                .fetch_one(pool)
+                .await?;
+        Ok(row.0)
+    }
 }
 
 /// A volume with its title metadata, for location contents display.

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -77,9 +77,6 @@ pub struct HomeTemplate {
     pub glance_volumes_label: String,
     pub glance_active_loans_label: String,
     pub glance_signin_hint: String,
-    pub glance_titles_count: i64,
-    pub glance_volumes_count: i64,
-    pub glance_active_loans_count: i64,
     pub loans_link_visible: bool,
 }
 
@@ -160,14 +157,26 @@ pub async fn home(
         return Ok(Html(html).into_response());
     }
 
-    // "Collection at a glance" card — three counts in a single SQL round-trip (story 9-1)
-    let glance = crate::services::dashboard::collection_glance(pool).await?;
+    // "Collection at a glance" card — three counts in a single SQL round-trip (story 9-1).
+    // Soft-degrade on DB error: a transient lock or timeout MUST NOT take down the
+    // public landing page. Mirrors the existing `metadata_error_count` pattern below.
+    let glance = match crate::services::dashboard::collection_glance(pool).await {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(error = %e, "collection_glance failed; rendering 0/0/0 card");
+            crate::services::dashboard::CollectionGlance::default()
+        }
+    };
     let loans_link_visible = session.role >= Role::Librarian;
 
     // Choose `_one` vs `_other` for each count. Inline if/else so the macro receives
     // a literal key (matching the project's i18n audit at `src/i18n/audit.rs`),
-    // while preserving correct EN/FR plural grammar (NFR41-aware).
-    let glance_titles_label = if glance.titles == 1 {
+    // while preserving correct EN/FR plural grammar.
+    //
+    // CLDR rule for French: counts of 0 AND 1 both map to the singular form
+    // ("0 titre", not "0 titres"). English: only 1 → singular. The `is_singular`
+    // helper encodes this locale-conditional behavior.
+    let glance_titles_label = if is_singular(loc, glance.titles) {
         rust_i18n::t!("dashboard.glance.titles_one", locale = loc, count = glance.titles)
             .to_string()
     } else {
@@ -178,7 +187,7 @@ pub async fn home(
         )
         .to_string()
     };
-    let glance_volumes_label = if glance.volumes == 1 {
+    let glance_volumes_label = if is_singular(loc, glance.volumes) {
         rust_i18n::t!(
             "dashboard.glance.volumes_one",
             locale = loc,
@@ -193,7 +202,7 @@ pub async fn home(
         )
         .to_string()
     };
-    let glance_active_loans_label = if glance.active_loans == 1 {
+    let glance_active_loans_label = if is_singular(loc, glance.active_loans) {
         rust_i18n::t!(
             "dashboard.glance.active_loans_one",
             locale = loc,
@@ -281,14 +290,23 @@ pub async fn home(
         glance_active_loans_label,
         glance_signin_hint: rust_i18n::t!("dashboard.glance.signin_to_view_loans", locale = loc)
             .to_string(),
-        glance_titles_count: glance.titles,
-        glance_volumes_count: glance.volumes,
-        glance_active_loans_count: glance.active_loans,
         loans_link_visible,
     };
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
         Err(_) => Err(AppError::Internal("Template rendering failed".to_string())),
+    }
+}
+
+/// Locale-aware singular/plural selector for the glance card labels (story 9-1).
+///
+/// CLDR rule: French treats 0 as singular ("0 titre", not "0 titres"); English
+/// uses singular only for 1. Centralized here so future locales (German, Spanish,
+/// …) can extend the match arms without touching the three call sites.
+fn is_singular(locale: &str, count: i64) -> bool {
+    match locale {
+        "fr" => count == 0 || count == 1,
+        _ => count == 1,
     }
 }
 
@@ -575,7 +593,36 @@ mod tests {
         assert!(!html.contains("/catalog/title/new"));
     }
 
-    fn make_test_home_template(role: &str, loans_link_visible: bool) -> HomeTemplate {
+    /// Extract the substring of `html` that lies between the opening tag of the
+    /// `<section id="collection-glance">` and its first matching `</section>`.
+    /// Used by the librarian/anonymous render tests to scope assertions to
+    /// the glance card and avoid false positives from the nav-bar `/loans` link
+    /// (which is rendered for librarian/admin roles by `nav_bar.html`).
+    fn glance_card_slice(html: &str) -> &str {
+        let start_tag = r#"id="collection-glance""#;
+        let start = html
+            .find(start_tag)
+            .unwrap_or_else(|| panic!("glance card section not found in rendered HTML"));
+        let after_open = html[start..]
+            .find('>')
+            .map(|i| start + i + 1)
+            .expect("section opening tag must close");
+        let end_rel = html[after_open..]
+            .find("</section>")
+            .expect("glance card must have a closing </section>");
+        &html[after_open..after_open + end_rel]
+    }
+
+    fn make_test_home_template_with_counts(
+        role: &str,
+        loans_link_visible: bool,
+        titles: i64,
+        volumes: i64,
+        active_loans: i64,
+    ) -> HomeTemplate {
+        let titles_label = format!("{titles} titles");
+        let volumes_label = format!("{volumes} volumes");
+        let active_loans_label = format!("{active_loans} active loans");
         HomeTemplate {
             lang: "en".to_string(),
             role: role.to_string(),
@@ -620,15 +667,16 @@ mod tests {
             current_url: "/".to_string(),
             lang_toggle_aria: "Change language".to_string(),
             glance_heading: "Collection at a glance".to_string(),
-            glance_titles_label: "5 titles".to_string(),
-            glance_volumes_label: "8 volumes".to_string(),
-            glance_active_loans_label: "2 active loans".to_string(),
+            glance_titles_label: titles_label,
+            glance_volumes_label: volumes_label,
+            glance_active_loans_label: active_loans_label,
             glance_signin_hint: "Sign in to view loans".to_string(),
-            glance_titles_count: 5,
-            glance_volumes_count: 8,
-            glance_active_loans_count: 2,
             loans_link_visible,
         }
+    }
+
+    fn make_test_home_template(role: &str, loans_link_visible: bool) -> HomeTemplate {
+        make_test_home_template_with_counts(role, loans_link_visible, 5, 8, 2)
     }
 
     #[test]
@@ -690,24 +738,90 @@ mod tests {
 
     /// Story 9-1 AC8d: librarian render exposes the /loans link AND
     /// does NOT contain the orphan aria-describedby reference.
+    ///
+    /// Assertions are scoped to the glance card slice — the nav bar also
+    /// renders `href="/loans"` for librarian/admin roles, so a global
+    /// `html.contains` would silently pass even if the card itself regressed.
     #[test]
     fn home_librarian_renders_glance_with_loans_link() {
         let template = make_test_home_template("librarian", true);
         let html = template.render().expect("render");
+        let card = glance_card_slice(&html);
 
-        assert!(html.contains("id=\"collection-glance\""), "card section is present");
-        assert!(html.contains("href=\"/loans\""), "librarian render must link to /loans");
-        assert!(html.contains("2 active loans"), "loan label still rendered inside the link");
+        assert!(
+            card.contains("href=\"/loans\""),
+            "librarian render must link the glance loan count to /loans (scoped to the card slice, not the nav bar)"
+        );
+        assert!(
+            card.contains("2 active loans"),
+            "loan label still rendered inside the card link"
+        );
 
         // No orphan aria-describedby reference (the hint span is only emitted
         // for anonymous users; emitting it for librarian would be dead markup).
         assert!(
-            !html.contains("aria-describedby=\"glance-loans-hint\""),
+            !card.contains("aria-describedby=\"glance-loans-hint\""),
             "librarian render must not carry the anonymous-only aria-describedby reference"
         );
         assert!(
-            !html.contains("id=\"glance-loans-hint\""),
+            !card.contains("id=\"glance-loans-hint\""),
             "librarian render must not emit the orphan hint span"
         );
+    }
+
+    /// Story 9-1 AC3 regression guard: the card MUST render even when every
+    /// count is zero. A future regression that adds `{% if count > 0 %}`
+    /// inside the template would slip past the other render tests (which
+    /// hardcode 5/8/2). This test pins the no-hide invariant.
+    #[test]
+    fn home_renders_glance_with_all_zero_counts() {
+        let template =
+            make_test_home_template_with_counts("anonymous", false, 0, 0, 0);
+        let html = template.render().expect("render");
+        let card = glance_card_slice(&html);
+
+        // The card structure is intact even with zeros.
+        assert!(html.contains("id=\"collection-glance\""), "card section present");
+        assert!(html.contains("Collection at a glance"), "heading rendered");
+
+        // Each zero-count label still appears inside the card. We assert on
+        // the card slice (not the whole HTML) so a stray "0 titles" elsewhere
+        // wouldn't mask a missing card.
+        assert!(card.contains("0 titles"), "0-titles label rendered inside the card");
+        assert!(card.contains("0 volumes"), "0-volumes label rendered inside the card");
+        assert!(
+            card.contains("0 active loans"),
+            "0-active-loans label rendered inside the card"
+        );
+
+        // Anonymous + zero loans still produces the aria-describedby hint
+        // (the no-link path) — verifies the {% if loans_link_visible %} branch
+        // is evaluated on visibility, not on count.
+        assert!(
+            card.contains("aria-describedby=\"glance-loans-hint\""),
+            "anonymous + zero loans still emits the sign-in hint reference"
+        );
+    }
+
+    #[test]
+    fn is_singular_french_treats_zero_and_one_as_singular() {
+        // CLDR: French maps 0 and 1 to the singular form.
+        assert!(is_singular("fr", 0), "FR: 0 → singular");
+        assert!(is_singular("fr", 1), "FR: 1 → singular");
+        assert!(!is_singular("fr", 2), "FR: 2 → plural");
+        assert!(!is_singular("fr", 100), "FR: 100 → plural");
+    }
+
+    #[test]
+    fn is_singular_english_treats_only_one_as_singular() {
+        assert!(!is_singular("en", 0), "EN: 0 → plural");
+        assert!(is_singular("en", 1), "EN: 1 → singular");
+        assert!(!is_singular("en", 2), "EN: 2 → plural");
+    }
+
+    #[test]
+    fn is_singular_unknown_locale_falls_back_to_english_rule() {
+        assert!(!is_singular("de", 0), "unknown locale: 0 → plural (EN fallback)");
+        assert!(is_singular("de", 1), "unknown locale: 1 → singular");
     }
 }

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -71,6 +71,16 @@ pub struct HomeTemplate {
     pub browse_sort_label: String,
     pub current_url: String,
     pub lang_toggle_aria: String,
+    // "Collection at a glance" card (story 9-1)
+    pub glance_heading: String,
+    pub glance_titles_label: String,
+    pub glance_volumes_label: String,
+    pub glance_active_loans_label: String,
+    pub glance_signin_hint: String,
+    pub glance_titles_count: i64,
+    pub glance_volumes_count: i64,
+    pub glance_active_loans_count: i64,
+    pub loans_link_visible: bool,
 }
 
 pub async fn home(
@@ -150,6 +160,55 @@ pub async fn home(
         return Ok(Html(html).into_response());
     }
 
+    // "Collection at a glance" card — three counts in a single SQL round-trip (story 9-1)
+    let glance = crate::services::dashboard::collection_glance(pool).await?;
+    let loans_link_visible = session.role >= Role::Librarian;
+
+    // Choose `_one` vs `_other` for each count. Inline if/else so the macro receives
+    // a literal key (matching the project's i18n audit at `src/i18n/audit.rs`),
+    // while preserving correct EN/FR plural grammar (NFR41-aware).
+    let glance_titles_label = if glance.titles == 1 {
+        rust_i18n::t!("dashboard.glance.titles_one", locale = loc, count = glance.titles)
+            .to_string()
+    } else {
+        rust_i18n::t!(
+            "dashboard.glance.titles_other",
+            locale = loc,
+            count = glance.titles
+        )
+        .to_string()
+    };
+    let glance_volumes_label = if glance.volumes == 1 {
+        rust_i18n::t!(
+            "dashboard.glance.volumes_one",
+            locale = loc,
+            count = glance.volumes
+        )
+        .to_string()
+    } else {
+        rust_i18n::t!(
+            "dashboard.glance.volumes_other",
+            locale = loc,
+            count = glance.volumes
+        )
+        .to_string()
+    };
+    let glance_active_loans_label = if glance.active_loans == 1 {
+        rust_i18n::t!(
+            "dashboard.glance.active_loans_one",
+            locale = loc,
+            count = glance.active_loans
+        )
+        .to_string()
+    } else {
+        rust_i18n::t!(
+            "dashboard.glance.active_loans_other",
+            locale = loc,
+            count = glance.active_loans
+        )
+        .to_string()
+    };
+
     // Count titles with failed metadata (for librarian dashboard badge)
     let metadata_error_count: u64 = if session.role == Role::Librarian {
         sqlx::query_scalar::<_, i64>(
@@ -216,6 +275,16 @@ pub async fn home(
         browse_sort_label: rust_i18n::t!("browse.sort_by", locale = loc).to_string(),
         current_url: current_url(&uri),
         lang_toggle_aria: rust_i18n::t!("nav.language_toggle_aria", locale = loc).to_string(),
+        glance_heading: rust_i18n::t!("dashboard.glance.heading", locale = loc).to_string(),
+        glance_titles_label,
+        glance_volumes_label,
+        glance_active_loans_label,
+        glance_signin_hint: rust_i18n::t!("dashboard.glance.signin_to_view_loans", locale = loc)
+            .to_string(),
+        glance_titles_count: glance.titles,
+        glance_volumes_count: glance.volumes,
+        glance_active_loans_count: glance.active_loans,
+        loans_link_visible,
     };
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
@@ -506,11 +575,10 @@ mod tests {
         assert!(!html.contains("/catalog/title/new"));
     }
 
-    #[test]
-    fn test_home_template_renders() {
-        let template = HomeTemplate {
+    fn make_test_home_template(role: &str, loans_link_visible: bool) -> HomeTemplate {
+        HomeTemplate {
             lang: "en".to_string(),
-            role: "anonymous".to_string(),
+            role: role.to_string(),
             current_page: "home",
             skip_label: "Skip to main content".to_string(),
             session_timeout_secs: crate::config::AppSettings::default().session_timeout_secs,
@@ -551,10 +619,95 @@ mod tests {
             browse_sort_label: "Sort by".to_string(),
             current_url: "/".to_string(),
             lang_toggle_aria: "Change language".to_string(),
-        };
+            glance_heading: "Collection at a glance".to_string(),
+            glance_titles_label: "5 titles".to_string(),
+            glance_volumes_label: "8 volumes".to_string(),
+            glance_active_loans_label: "2 active loans".to_string(),
+            glance_signin_hint: "Sign in to view loans".to_string(),
+            glance_titles_count: 5,
+            glance_volumes_count: 8,
+            glance_active_loans_count: 2,
+            loans_link_visible,
+        }
+    }
+
+    #[test]
+    fn test_home_template_renders() {
+        let template = make_test_home_template("anonymous", false);
         let rendered = template.render().unwrap();
         assert!(rendered.contains("mybibli"));
         assert!(rendered.contains("search-field"));
         assert!(rendered.contains("browse-results"));
+    }
+
+    /// Story 9-1 AC5 + AC8c: anonymous render contains the glance card,
+    /// shows the three counts, NEVER leaks `href="/loans"`, and the
+    /// aria-describedby + sr-only sign-in hint coexist (linkage check).
+    #[test]
+    fn home_anonymous_renders_glance_no_loans_link() {
+        let template = make_test_home_template("anonymous", false);
+        let html = template.render().expect("render");
+
+        // Card header
+        assert!(html.contains("id=\"collection-glance\""), "card section is present");
+        assert!(html.contains("Collection at a glance"), "heading rendered");
+        assert!(html.contains("aria-labelledby=\"glance-heading\""), "section labelledby set");
+        assert!(html.contains("id=\"glance-heading\""), "heading id present (labelledby target)");
+
+        // Three counts visible
+        assert!(html.contains("5 titles"), "titles label rendered");
+        assert!(html.contains("8 volumes"), "volumes label rendered");
+        assert!(html.contains("2 active loans"), "active loans label rendered");
+
+        // CRITICAL: no anonymous loan link leak
+        assert!(
+            !html.contains("href=\"/loans\""),
+            "anonymous render must not contain href=\"/loans\" — got:\n{}",
+            // Trim noise to keep the failure message readable when something regresses
+            html.lines()
+                .filter(|l| l.contains("loan"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+
+        // Aria linkage (AC8c iii): the aria-describedby reference and the
+        // span carrying its target id BOTH exist, AND the target carries
+        // the sr-only class and the sign-in hint text.
+        assert!(
+            html.contains("aria-describedby=\"glance-loans-hint\""),
+            "anonymous render must wire aria-describedby on the loan-count span"
+        );
+        assert!(
+            html.contains("id=\"glance-loans-hint\""),
+            "anonymous render must include the aria-describedby target span"
+        );
+        assert!(html.contains("sr-only"), "hint span must be screen-reader-only");
+        assert!(
+            html.contains("Sign in to view loans"),
+            "hint span must carry the sign-in i18n text"
+        );
+    }
+
+    /// Story 9-1 AC8d: librarian render exposes the /loans link AND
+    /// does NOT contain the orphan aria-describedby reference.
+    #[test]
+    fn home_librarian_renders_glance_with_loans_link() {
+        let template = make_test_home_template("librarian", true);
+        let html = template.render().expect("render");
+
+        assert!(html.contains("id=\"collection-glance\""), "card section is present");
+        assert!(html.contains("href=\"/loans\""), "librarian render must link to /loans");
+        assert!(html.contains("2 active loans"), "loan label still rendered inside the link");
+
+        // No orphan aria-describedby reference (the hint span is only emitted
+        // for anonymous users; emitting it for librarian would be dead markup).
+        assert!(
+            !html.contains("aria-describedby=\"glance-loans-hint\""),
+            "librarian render must not carry the anonymous-only aria-describedby reference"
+        );
+        assert!(
+            !html.contains("id=\"glance-loans-hint\""),
+            "librarian render must not emit the orphan hint span"
+        );
     }
 }

--- a/src/services/dashboard.rs
+++ b/src/services/dashboard.rs
@@ -1,0 +1,55 @@
+//! Dashboard data builders for the home page (story 9-1 onward).
+//!
+//! Keep business logic OUT of the route handler — these functions are small,
+//! typed, and independently testable. Each function corresponds to one widget
+//! on `/`. Story 9-1 ships the "Collection at a glance" card; subsequent Epic
+//! 9 stories will add recent additions (9-2), stats by genre (9-3), and the
+//! actionable indicators with FilterTag (9-4..9-7) on top of this module.
+
+use crate::db::DbPool;
+use crate::error::AppError;
+
+/// Three-count summary shown by the home-page "Collection at a glance" card.
+///
+/// Counts exclude soft-deleted rows. `active_loans` additionally excludes
+/// returned loans (`returned_at IS NULL`). All three fields are `i64`
+/// because that's what MariaDB returns for `COUNT(*)`; the template only
+/// needs to display them, no arithmetic downstream.
+#[derive(Debug, Clone, Default, sqlx::FromRow)]
+pub struct CollectionGlance {
+    pub titles: i64,
+    pub volumes: i64,
+    pub active_loans: i64,
+}
+
+/// Compute the three glance counts in a single SQL round-trip.
+///
+/// The query uses three correlated subqueries inside one SELECT — one
+/// network round-trip, three independent COUNT(*) on indexed columns
+/// (`deleted_at`, `returned_at`). Story 9-1 AC2 mandates this single-
+/// round-trip shape; verified by inspection of the SQL below at code-
+/// review time.
+pub async fn collection_glance(pool: &DbPool) -> Result<CollectionGlance, AppError> {
+    let glance: CollectionGlance = sqlx::query_as(
+        "SELECT \
+            (SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL)  AS titles, \
+            (SELECT COUNT(*) FROM volumes WHERE deleted_at IS NULL) AS volumes, \
+            (SELECT COUNT(*) FROM loans WHERE returned_at IS NULL AND deleted_at IS NULL) AS active_loans",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(glance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_glance_default_is_zeros() {
+        let g = CollectionGlance::default();
+        assert_eq!(g.titles, 0);
+        assert_eq!(g.volumes, 0);
+        assert_eq!(g.active_loans, 0);
+    }
+}

--- a/src/services/dashboard.rs
+++ b/src/services/dashboard.rs
@@ -29,12 +29,20 @@ pub struct CollectionGlance {
 /// (`deleted_at`, `returned_at`). Story 9-1 AC2 mandates this single-
 /// round-trip shape; verified by inspection of the SQL below at code-
 /// review time.
+///
+/// `active_loans` JOINs `volumes` and `borrowers` with `deleted_at IS NULL`
+/// filters so an orphan loan whose volume or borrower has been soft-deleted
+/// is NOT counted — matching `LoanModel::list_active` semantics so the
+/// home-page count never diverges from what the user sees on `/loans`.
 pub async fn collection_glance(pool: &DbPool) -> Result<CollectionGlance, AppError> {
     let glance: CollectionGlance = sqlx::query_as(
         "SELECT \
             (SELECT COUNT(*) FROM titles WHERE deleted_at IS NULL)  AS titles, \
             (SELECT COUNT(*) FROM volumes WHERE deleted_at IS NULL) AS volumes, \
-            (SELECT COUNT(*) FROM loans WHERE returned_at IS NULL AND deleted_at IS NULL) AS active_loans",
+            (SELECT COUNT(*) FROM loans l \
+               JOIN volumes v ON l.volume_id = v.id AND v.deleted_at IS NULL \
+               JOIN borrowers b ON l.borrower_id = b.id AND b.deleted_at IS NULL \
+              WHERE l.returned_at IS NULL AND l.deleted_at IS NULL) AS active_loans",
     )
     .fetch_one(pool)
     .await?;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -5,6 +5,7 @@ pub mod auto_purge;
 pub mod borrowers;
 pub mod contributor;
 pub mod cover;
+pub mod dashboard;
 pub mod loans;
 pub mod locations;
 pub mod locking;

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -73,6 +73,36 @@
     </div>
     {% endif %}
 
+    {# Collection at a glance card (story 9-1). Sits between filter tags and #browse-results
+       so it stays visible during HTMX search swaps that target #browse-results. #}
+    <section id="collection-glance" aria-labelledby="glance-heading" class="w-full max-w-4xl mt-6">
+        <h2 id="glance-heading" class="text-sm font-medium text-stone-600 dark:text-stone-400 uppercase tracking-wide">{{ glance_heading }}</h2>
+        <ul class="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
+            <li>
+                <a href="/catalog" class="block px-4 py-3 bg-stone-50 dark:bg-stone-800 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-lg border border-stone-200 dark:border-stone-700 transition-colors">
+                    <span class="text-base font-medium text-stone-900 dark:text-stone-100">{{ glance_titles_label }}</span>
+                </a>
+            </li>
+            <li>
+                <a href="/catalog" class="block px-4 py-3 bg-stone-50 dark:bg-stone-800 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-lg border border-stone-200 dark:border-stone-700 transition-colors">
+                    <span class="text-base font-medium text-stone-900 dark:text-stone-100">{{ glance_volumes_label }}</span>
+                </a>
+            </li>
+            <li>
+                {% if loans_link_visible %}
+                <a href="/loans" class="block px-4 py-3 bg-stone-50 dark:bg-stone-800 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-lg border border-stone-200 dark:border-stone-700 transition-colors">
+                    <span class="text-base font-medium text-stone-900 dark:text-stone-100">{{ glance_active_loans_label }}</span>
+                </a>
+                {% else %}
+                <div class="block px-4 py-3 bg-stone-50 dark:bg-stone-800 rounded-lg border border-stone-200 dark:border-stone-700">
+                    <span aria-describedby="glance-loans-hint" class="text-base font-medium text-stone-900 dark:text-stone-100">{{ glance_active_loans_label }}</span>
+                    <span id="glance-loans-hint" class="sr-only">{{ glance_signin_hint }}</span>
+                </div>
+                {% endif %}
+            </li>
+        </ul>
+    </section>
+
     <!-- Browse toggle + sort -->
     <div class="w-full max-w-4xl mt-6 flex items-center justify-between">
         <div class="flex items-center gap-2">

--- a/tests/dashboard_glance.rs
+++ b/tests/dashboard_glance.rs
@@ -1,0 +1,143 @@
+//! DB-backed tests for `services::dashboard::collection_glance` (story 9-1).
+//!
+//! Locks in the soft-delete and `returned_at IS NULL` invariants for the
+//! home-page "Collection at a glance" card. If a future migration changes
+//! the soft-delete column name or semantics on titles / volumes / loans,
+//! `glance_excludes_soft_deleted_and_returned` is the regression guard.
+//!
+//! To run locally:
+//!
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test dashboard_glance
+
+use mybibli::services::dashboard::{collection_glance, CollectionGlance};
+use sqlx::MySqlPool;
+
+async fn first_genre_id(pool: &MySqlPool) -> u64 {
+    sqlx::query_scalar::<_, u64>(
+        "SELECT id FROM genres WHERE deleted_at IS NULL ORDER BY id LIMIT 1",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("bootstrap migration must seed at least one genre")
+}
+
+async fn first_volume_state_id(pool: &MySqlPool) -> u64 {
+    sqlx::query_scalar::<_, u64>(
+        "SELECT id FROM volume_states WHERE deleted_at IS NULL ORDER BY id LIMIT 1",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("bootstrap migration must seed at least one volume_state")
+}
+
+async fn insert_title(pool: &MySqlPool, title: &str, genre_id: u64) -> u64 {
+    let r = sqlx::query(
+        "INSERT INTO titles (title, language, media_type, genre_id) VALUES (?, 'fr', 'book', ?)",
+    )
+    .bind(title)
+    .bind(genre_id)
+    .execute(pool)
+    .await
+    .expect("insert title");
+    r.last_insert_id()
+}
+
+async fn insert_volume(pool: &MySqlPool, label: &str, title_id: u64, state_id: u64) -> u64 {
+    let r = sqlx::query(
+        "INSERT INTO volumes (label, title_id, condition_state_id) VALUES (?, ?, ?)",
+    )
+    .bind(label)
+    .bind(title_id)
+    .bind(state_id)
+    .execute(pool)
+    .await
+    .expect("insert volume");
+    r.last_insert_id()
+}
+
+async fn insert_borrower(pool: &MySqlPool, name: &str) -> u64 {
+    let r = sqlx::query("INSERT INTO borrowers (name) VALUES (?)")
+        .bind(name)
+        .execute(pool)
+        .await
+        .expect("insert borrower");
+    r.last_insert_id()
+}
+
+async fn insert_active_loan(pool: &MySqlPool, volume_id: u64, borrower_id: u64) -> u64 {
+    let r = sqlx::query(
+        "INSERT INTO loans (volume_id, borrower_id, loaned_at) VALUES (?, ?, NOW())",
+    )
+    .bind(volume_id)
+    .bind(borrower_id)
+    .execute(pool)
+    .await
+    .expect("insert loan");
+    r.last_insert_id()
+}
+
+async fn soft_delete(pool: &MySqlPool, table: &str, id: u64) {
+    let sql = format!("UPDATE {table} SET deleted_at = NOW() WHERE id = ?");
+    sqlx::query(&sql)
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("soft delete");
+}
+
+async fn mark_loan_returned(pool: &MySqlPool, loan_id: u64) {
+    sqlx::query("UPDATE loans SET returned_at = NOW() WHERE id = ?")
+        .bind(loan_id)
+        .execute(pool)
+        .await
+        .expect("mark returned");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn glance_on_empty_db_returns_zeros(pool: MySqlPool) {
+    let g: CollectionGlance = collection_glance(&pool).await.expect("glance fetch");
+    assert_eq!(g.titles, 0, "no titles seeded");
+    assert_eq!(g.volumes, 0, "no volumes seeded");
+    assert_eq!(g.active_loans, 0, "no loans seeded");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn glance_excludes_soft_deleted_and_returned(pool: MySqlPool) {
+    let genre = first_genre_id(&pool).await;
+    let state = first_volume_state_id(&pool).await;
+
+    // 3 active titles + 1 soft-deleted title
+    let t1 = insert_title(&pool, "Active Title 1", genre).await;
+    let t2 = insert_title(&pool, "Active Title 2", genre).await;
+    let _t3 = insert_title(&pool, "Active Title 3", genre).await;
+    let t_dead = insert_title(&pool, "Soft-deleted Title", genre).await;
+    soft_delete(&pool, "titles", t_dead).await;
+
+    // 5 active volumes + 2 soft-deleted volumes
+    // (volumes 4-5 are on title 2; volumes 6-7 are soft-deleted via title_id = t1)
+    let v1 = insert_volume(&pool, "V0001", t1, state).await;
+    let v2 = insert_volume(&pool, "V0002", t1, state).await;
+    let _v3 = insert_volume(&pool, "V0003", t1, state).await;
+    let _v4 = insert_volume(&pool, "V0004", t2, state).await;
+    let _v5 = insert_volume(&pool, "V0005", t2, state).await;
+    let v_dead_a = insert_volume(&pool, "V0006", t1, state).await;
+    let v_dead_b = insert_volume(&pool, "V0007", t1, state).await;
+    soft_delete(&pool, "volumes", v_dead_a).await;
+    soft_delete(&pool, "volumes", v_dead_b).await;
+
+    // 4 loans total: 2 active + 1 returned + 1 soft-deleted → expect active = 2
+    let borrower = insert_borrower(&pool, "Test Borrower").await;
+    let _l1 = insert_active_loan(&pool, v1, borrower).await;
+    let _l2 = insert_active_loan(&pool, v2, borrower).await;
+    let l_returned = insert_active_loan(&pool, v1, borrower).await;
+    mark_loan_returned(&pool, l_returned).await;
+    let l_dead = insert_active_loan(&pool, v2, borrower).await;
+    soft_delete(&pool, "loans", l_dead).await;
+
+    let g = collection_glance(&pool).await.expect("glance fetch");
+    assert_eq!(g.titles, 3, "3 active + 1 soft-deleted");
+    assert_eq!(g.volumes, 5, "5 active + 2 soft-deleted");
+    assert_eq!(g.active_loans, 2, "2 active + 1 returned + 1 soft-deleted");
+}

--- a/tests/dashboard_glance.rs
+++ b/tests/dashboard_glance.rs
@@ -141,3 +141,34 @@ async fn glance_excludes_soft_deleted_and_returned(pool: MySqlPool) {
     assert_eq!(g.volumes, 5, "5 active + 2 soft-deleted");
     assert_eq!(g.active_loans, 2, "2 active + 1 returned + 1 soft-deleted");
 }
+
+#[sqlx::test(migrations = "./migrations")]
+async fn glance_excludes_orphan_loans_on_soft_deleted_volume_or_borrower(pool: MySqlPool) {
+    // Story 9-1 review finding: the active_loans subquery JOINs volumes + borrowers
+    // with deleted_at IS NULL so the count never diverges from /loans (which uses
+    // the same JOIN semantics in LoanModel::list_active). This test pins that
+    // contract: a loan whose volume OR borrower is soft-deleted is excluded.
+    let genre = first_genre_id(&pool).await;
+    let state = first_volume_state_id(&pool).await;
+
+    let title = insert_title(&pool, "T", genre).await;
+    let v_live = insert_volume(&pool, "V0001", title, state).await;
+    let v_dead = insert_volume(&pool, "V0002", title, state).await;
+    let b_live = insert_borrower(&pool, "Alive Borrower").await;
+    let b_dead = insert_borrower(&pool, "Soft-deleted Borrower").await;
+
+    // 3 active loans: one fully alive, one whose volume gets soft-deleted, one
+    // whose borrower gets soft-deleted. Only the fully-alive one must count.
+    let _l_live = insert_active_loan(&pool, v_live, b_live).await;
+    let _l_orphan_volume = insert_active_loan(&pool, v_dead, b_live).await;
+    let _l_orphan_borrower = insert_active_loan(&pool, v_live, b_dead).await;
+
+    soft_delete(&pool, "volumes", v_dead).await;
+    soft_delete(&pool, "borrowers", b_dead).await;
+
+    let g = collection_glance(&pool).await.expect("glance fetch");
+    assert_eq!(
+        g.active_loans, 1,
+        "only the loan whose volume AND borrower are alive should count; orphans are excluded"
+    );
+}

--- a/tests/e2e/specs/journeys/home.spec.ts
+++ b/tests/e2e/specs/journeys/home.spec.ts
@@ -35,18 +35,26 @@ test.describe("Home page — Collection at a glance card", () => {
       card.getByRole("heading", { level: 2 }),
     ).toContainText(/Collection at a glance|Aperçu de la collection/i);
 
-    // The three count rows are rendered (regex tolerates EN/FR plurals).
-    await expect(card).toContainText(/\d+\s+(titles?|titres?)/i);
-    await expect(card).toContainText(/\d+\s+volumes?/i);
-    await expect(card).toContainText(
+    // The three count rows are rendered IN ORDER (titles, volumes, loans) —
+    // scope each assertion to its own <li> so a label/order swap regression
+    // would fail (a global toContainText would silently match the wrong row).
+    const rows = card.locator("ul > li");
+    await expect(rows).toHaveCount(3);
+    await expect(rows.nth(0)).toContainText(/\d+\s+(titles?|titres?)/i);
+    await expect(rows.nth(1)).toContainText(/\d+\s+volumes?/i);
+    await expect(rows.nth(2)).toContainText(
       /\d+\s+(active loans?|prêts? en cours)/i,
     );
 
-    // CRITICAL: anonymous render must NOT leak the /loans link anywhere.
+    // CRITICAL: anonymous render must NOT leak the /loans link anywhere on the page.
     await expect(page.locator('a[href="/loans"]')).toHaveCount(0);
 
-    // The aria-describedby target span exists (screen-reader sign-in hint).
+    // The aria-describedby target span exists (screen-reader sign-in hint),
+    // and its anchor span carries the matching reference inside the card.
     await expect(card.locator("#glance-loans-hint")).toBeAttached();
+    await expect(
+      card.locator('[aria-describedby="glance-loans-hint"]'),
+    ).toHaveCount(1);
   });
 
   test("librarian: card shows /loans link, click navigates to /loans", async ({
@@ -58,9 +66,20 @@ test.describe("Home page — Collection at a glance card", () => {
     const card = page.locator("#collection-glance");
     await expect(card).toBeVisible();
 
-    // The loan-count line is now a real link to /loans (exactly one).
+    // The loan-count line is the third row and a real link to /loans
+    // (exactly one inside the card; the nav bar also has one but that's
+    // outside the card scope).
+    const rows = card.locator("ul > li");
+    await expect(rows).toHaveCount(3);
+    await expect(rows.nth(2)).toContainText(
+      /\d+\s+(active loans?|prêts? en cours)/i,
+    );
+
     const loansLink = card.locator('a[href="/loans"]');
     await expect(loansLink).toHaveCount(1);
+    await expect(loansLink).toContainText(
+      /active loans?|prêts? en cours/i,
+    );
 
     await loansLink.click();
     await page.waitForURL(/\/loans/);

--- a/tests/e2e/specs/journeys/home.spec.ts
+++ b/tests/e2e/specs/journeys/home.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
 
 test.describe("Home page", () => {
   test("should display mybibli title", async ({ page }) => {
@@ -14,10 +15,54 @@ test.describe("Home page", () => {
   test("should load Tailwind CSS styles", async ({ page }) => {
     await page.goto("/");
     const h1 = page.locator("h1");
-    const color = await h1.evaluate(
-      (el) => getComputedStyle(el).color,
-    );
+    const color = await h1.evaluate((el) => getComputedStyle(el).color);
     // Indigo color should be applied (not default black)
     expect(color).not.toBe("rgb(0, 0, 0)");
+  });
+});
+
+// Story 9-1 — "Collection at a glance" card.
+test.describe("Home page — Collection at a glance card", () => {
+  test("anonymous: card visible, three counts, loan count is NOT a link", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Card section is present and labelled by its heading.
+    const card = page.locator("#collection-glance");
+    await expect(card).toBeVisible();
+    await expect(
+      card.getByRole("heading", { level: 2 }),
+    ).toContainText(/Collection at a glance|Aperçu de la collection/i);
+
+    // The three count rows are rendered (regex tolerates EN/FR plurals).
+    await expect(card).toContainText(/\d+\s+(titles?|titres?)/i);
+    await expect(card).toContainText(/\d+\s+volumes?/i);
+    await expect(card).toContainText(
+      /\d+\s+(active loans?|prêts? en cours)/i,
+    );
+
+    // CRITICAL: anonymous render must NOT leak the /loans link anywhere.
+    await expect(page.locator('a[href="/loans"]')).toHaveCount(0);
+
+    // The aria-describedby target span exists (screen-reader sign-in hint).
+    await expect(card.locator("#glance-loans-hint")).toBeAttached();
+  });
+
+  test("librarian: card shows /loans link, click navigates to /loans", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+    await page.goto("/");
+
+    const card = page.locator("#collection-glance");
+    await expect(card).toBeVisible();
+
+    // The loan-count line is now a real link to /loans (exactly one).
+    const loansLink = card.locator('a[href="/loans"]');
+    await expect(loansLink).toHaveCount(1);
+
+    await loansLink.click();
+    await page.waitForURL(/\/loans/);
   });
 });


### PR DESCRIPTION
## Summary

First story of Epic 9 (Polish UX & Accessibilité). Adds a "Collection at a glance" card to the home page (`/`) displaying three counts — active titles, active volumes, active loans — visible to all roles, with role-aware link generation:
- **Anonymous**: the loan count is rendered as plain text with `aria-describedby` pointing to a hidden "Sign in to view loans" hint (the visible Tooltip component itself ships in Story 9-19).
- **Librarian / Admin**: the loan count is a real `<a href="/loans">`.

This commit is **spec-only** — the implementation-ready story file landed in `_bmad-output/implementation-artifacts/9-1-dashboard-global-stats-card.md` (196 lines, 9 ACs, 8 tasks). Per CLAUDE.md rule 15, this draft PR is opened at the first commit of the story branch so CI runs continuously and `gh pr list` reflects in-flight work. The dev agent will push implementation commits onto this same branch via `/bmad-dev-story`.

## Spec highlights

- **AC2 — single-round-trip query**: SELECT with three correlated subqueries on titles / volumes / loans (`deleted_at IS NULL` everywhere; `returned_at IS NULL` additionally for loans). New service `src/services/dashboard.rs` exposes `collection_glance(pool) -> CollectionGlance`.
- **AC5 — anonymous never receives the loan link**: byte-level assertion in the handler test that anonymous-rendered HTML does NOT contain `href="/loans"`. Regression guard against accidental over-rendering of role-gated routes.
- **AC6 — CSP compliance**: Tailwind utility classes only; existing `templates_audit.rs::no_inline_markup_in_templates` test stays green.
- **AC7 — i18n**: 5 new keys under existing `dashboard.glance.*` sub-section in `locales/en.yml` + `locales/fr.yml`. `touch src/lib.rs && cargo build` after edit.
- **12-file change envelope**: 3 new model `count_active()` methods (will be reused by stories 9-4 / 9-5), 1 new service file, handler + template + 2 locales + test files. No new crates, no version bumps.

## Sprint-status

- `epic-9`: backlog → **in-progress** (first story of the epic starts)
- `9-1-dashboard-global-stats-card`: backlog → **ready-for-dev**
- Per CLAUDE.md rule 16, this PR touches only its own line plus the `last_updated` header.

## Test plan

When implementation lands on this branch:
- [ ] `cargo check && cargo clippy -- -D warnings`
- [ ] `cargo test` — including new `tests/dashboard_glance.rs` (3 `#[sqlx::test]` cases) and handler render tests in `src/routes/home.rs::mod tests`
- [ ] DB integration tests: `tests/dashboard_glance.rs` covers empty DB (0/0/0), mixed soft-deleted/active dataset (3/5/2), and the SQL-text shape of the single-round-trip query
- [ ] E2E (extension to `tests/e2e/specs/journeys/home.spec.ts`):
  - [ ] Anonymous → `/` → glance card visible, three counts, loan count NOT an `<a>`
  - [ ] Librarian (via `loginAs(page, "librarian")`) → `/` → loan count IS an `<a href="/loans">` → click navigates to `/loans`
- [ ] No `waitForTimeout` (CI grep gate)
- [ ] `cargo sqlx prepare` — expected no-op (Task 2 uses dynamic `query_as`, not the macro form)

## Out of scope

- Recent additions section (Story 9-2)
- Stats by genre section (Story 9-3)
- StatusMessage empty-state for an empty catalog (Story 9-15)
- Tooltip visible UI for the "Sign in to view loans" hint (Story 9-19 — only the `aria-describedby` + `sr-only` markup ships now)
- Live refresh / HTMX swap of the counts (counts are cheap; full page render is fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)