### PR TITLE
Story 9-3: Dashboard — stats by genre

### DIFF
--- a/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md
+++ b/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md
@@ -1,6 +1,6 @@
 # Story 9.3: Dashboard — stats by genre
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -44,9 +44,9 @@ so that I can understand the composition of the library at a glance.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Add `stats_by_genre()` to `services::dashboard` (AC: 1, 2, 3, 5, 7, 10a–c)**
-  - [ ] In `src/services/dashboard.rs`, add `pub struct GenreStat { pub id: u64, pub name: String, pub title_count: i64 }` deriving `Debug, Clone, sqlx::FromRow`.
-  - [ ] Add `pub async fn stats_by_genre(pool: &DbPool) -> Result<Vec<GenreStat>, AppError>`. SQL shape (single round-trip):
+- [x] **Task 1 — Add `stats_by_genre()` to `services::dashboard` (AC: 1, 2, 3, 5, 7, 10a–c)**
+  - [x] In `src/services/dashboard.rs`, add `pub struct GenreStat { pub id: u64, pub name: String, pub title_count: i64 }` deriving `Debug, Clone, sqlx::FromRow`.
+  - [x] Add `pub async fn stats_by_genre(pool: &DbPool) -> Result<Vec<GenreStat>, AppError>`. SQL shape (single round-trip):
     ```sql
     SELECT g.id, g.name, COUNT(t.id) AS title_count
       FROM titles t
@@ -56,12 +56,12 @@ so that I can understand the composition of the library at a glance.
      ORDER BY title_count DESC, g.name ASC
     ```
     Use `sqlx::query_as::<_, GenreStat>` + `.fetch_all(pool)`. The INNER JOIN form (rather than `FROM genres g LEFT JOIN titles t`) means a genre with zero active titles is automatically excluded — AC4's "no genres assigned → section hidden" is therefore observed naturally by the query: an empty DB returns `Vec::new()`.
-  - [ ] **Do NOT use `sqlx::query!` macro** (forces `.sqlx/` cache regeneration in the PR — project convention is dynamic `query_as`, see `services::dashboard::collection_glance` and `models::title::list_recent_active`).
-  - [ ] Co-locate three `#[sqlx::test]` cases at the bottom of `src/services/dashboard.rs` OR in a new file `tests/dashboard_stats_by_genre.rs` (sibling). **Choose the sibling file** for parity with `tests/dashboard_glance.rs` (9-1) and `tests/dashboard_recent_additions.rs` (9-2) — discoverability by file name beats co-location. The three cases are AC10a/b/c.
-  - [ ] **Test data isolation** — the migration seed adds genres like "Roman", "BD", … so each test must use unique genre names (e.g. prefix with `Z-9-3-`) or rely on pre-seeded ones. The `tests/dashboard_glance.rs::first_genre_id` helper is reusable; clone or import its pattern (helpers can stay file-local — no shared `tests/common.rs` exists yet).
-- [ ] **Task 2 — Wire the handler (AC: 1, 4, 6, 9)**
-  - [ ] In `src/routes/home.rs::home`, after the `recent_additions = …` block (around line ~186), call `crate::services::dashboard::stats_by_genre(pool).await` with the **soft-degrade pattern** established by 9-1/9-2: `match … { Ok(v) => v, Err(e) => { tracing::warn!(error = %e, "stats_by_genre failed; rendering empty section"); Vec::new() } }`. The home page MUST NOT 500 because the dashboard query had a hiccup.
-  - [ ] Compute the total denominator and per-row percentage **in the handler**:
+  - [x] **Do NOT use `sqlx::query!` macro** (forces `.sqlx/` cache regeneration in the PR — project convention is dynamic `query_as`, see `services::dashboard::collection_glance` and `models::title::list_recent_active`).
+  - [x] Co-locate three `#[sqlx::test]` cases at the bottom of `src/services/dashboard.rs` OR in a new file `tests/dashboard_stats_by_genre.rs` (sibling). **Choose the sibling file** for parity with `tests/dashboard_glance.rs` (9-1) and `tests/dashboard_recent_additions.rs` (9-2) — discoverability by file name beats co-location. The three cases are AC10a/b/c.
+  - [x] **Test data isolation** — the migration seed adds genres like "Roman", "BD", … so each test must use unique genre names (e.g. prefix with `Z-9-3-`) or rely on pre-seeded ones. The `tests/dashboard_glance.rs::first_genre_id` helper is reusable; clone or import its pattern (helpers can stay file-local — no shared `tests/common.rs` exists yet).
+- [x] **Task 2 — Wire the handler (AC: 1, 4, 6, 9)**
+  - [x] In `src/routes/home.rs::home`, after the `recent_additions = …` block (around line ~186), call `crate::services::dashboard::stats_by_genre(pool).await` with the **soft-degrade pattern** established by 9-1/9-2: `match … { Ok(v) => v, Err(e) => { tracing::warn!(error = %e, "stats_by_genre failed; rendering empty section"); Vec::new() } }`. The home page MUST NOT 500 because the dashboard query had a hiccup.
+  - [x] Compute the total denominator and per-row percentage **in the handler**:
     ```rust
     let total: i64 = stats_rows.iter().map(|r| r.title_count).sum();
     let stats: Vec<StatsByGenreRow> = stats_rows.into_iter().map(|r| {
@@ -81,8 +81,8 @@ so that I can understand the composition of the library at a glance.
     }).collect();
     ```
     Define `StatsByGenreRow` as a small inner struct in `src/routes/home.rs` (or a sibling module if you prefer — `src/routes/home_dashboard.rs` is overkill for one struct; keep it in `home.rs`).
-  - [ ] Reuse the existing `is_singular(locale, count)` helper at `src/routes/home.rs:333-338` for `_one`/`_other` selection on `count_label`. Do NOT duplicate it.
-  - [ ] Implement `format_percent(value: f64, locale: &str) -> String` — preferred location is `src/utils.rs` (since it's a pure formatting helper with no DB / no AppState dependency, and `utils.rs` already houses `html_escape`, `url_encode`, `current_url` — same shape). Specification:
+  - [x] Reuse the existing `is_singular(locale, count)` helper at `src/routes/home.rs:333-338` for `_one`/`_other` selection on `count_label`. Do NOT duplicate it.
+  - [x] Implement `format_percent(value: f64, locale: &str) -> String` — preferred location is `src/utils.rs` (since it's a pure formatting helper with no DB / no AppState dependency, and `utils.rs` already houses `html_escape`, `url_encode`, `current_url` — same shape). Specification:
     ```rust
     pub fn format_percent(value: f64, locale: &str) -> String {
         let s = format!("{:.1}", value); // e.g., "33.3"
@@ -93,31 +93,31 @@ so that I can understand the composition of the library at a glance.
     }
     ```
     Add three unit tests in the same file covering: EN basic, FR with NBSP, the rounding edge cases listed in AC10h.
-  - [ ] Extend `HomeTemplate` (currently 53 fields post-9-2 at `src/routes/home.rs:31-85`) with **TWO** new fields:
+  - [x] Extend `HomeTemplate` (currently 53 fields post-9-2 at `src/routes/home.rs:31-85`) with **TWO** new fields:
     - `stats_by_genre: Vec<StatsByGenreRow>` — the rows; empty when section should hide
     - `stats_by_genre_heading: String` — pre-translated `dashboard.stats_by_genre.heading`
-  - [ ] Translate the heading via `rust_i18n::t!("dashboard.stats_by_genre.heading", locale = loc).to_string()`. Pre-translate `count_label` per row in the handler (NOT in the template) — same pattern as 9-1/9-2.
-  - [ ] Pass the new fields from the handler. Do NOT add a new route.
-- [ ] **Task 3 — Add i18n keys (AC: 9)**
-  - [ ] In `locales/en.yml`, under `dashboard:` after the `recent_additions:` block, add:
+  - [x] Translate the heading via `rust_i18n::t!("dashboard.stats_by_genre.heading", locale = loc).to_string()`. Pre-translate `count_label` per row in the handler (NOT in the template) — same pattern as 9-1/9-2.
+  - [x] Pass the new fields from the handler. Do NOT add a new route.
+- [x] **Task 3 — Add i18n keys (AC: 9)**
+  - [x] In `locales/en.yml`, under `dashboard:` after the `recent_additions:` block, add:
     ```yaml
       stats_by_genre:
         heading: By genre
         titles_one: "%{count} title"
         titles_other: "%{count} titles"
     ```
-  - [ ] In `locales/fr.yml`, mirror under the same path:
+  - [x] In `locales/fr.yml`, mirror under the same path:
     ```yaml
       stats_by_genre:
         heading: Par genre
         titles_one: "%{count} titre"
         titles_other: "%{count} titres"
     ```
-  - [ ] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper. Keys start at root level. The proc-macro reads filename → locale.
-  - [ ] After editing, run `touch src/lib.rs && cargo build` to force the i18n proc-macro to re-read YAML files. The `i18n::audit::tests::all_t_keys_have_both_locales` test (mentioned in 9-1 Debug Log) will fail if a key exists in only one of EN/FR — keep them perfectly mirrored.
-- [ ] **Task 4 — Render the section in the template (AC: 1, 2, 4, 6, 8)**
-  - [ ] In `templates/pages/home.html`, insert the new section AFTER the closing `</section>` of `#recent-additions` (currently line ~141) and BEFORE the `<!-- Browse toggle + sort -->` block (line ~143).
-  - [ ] Markup outline (Tailwind utility classes only; the bar uses `<progress>` with custom CSS for theming):
+  - [x] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper. Keys start at root level. The proc-macro reads filename → locale.
+  - [x] After editing, run `touch src/lib.rs && cargo build` to force the i18n proc-macro to re-read YAML files. The `i18n::audit::tests::all_t_keys_have_both_locales` test (mentioned in 9-1 Debug Log) will fail if a key exists in only one of EN/FR — keep them perfectly mirrored.
+- [x] **Task 4 — Render the section in the template (AC: 1, 2, 4, 6, 8)**
+  - [x] In `templates/pages/home.html`, insert the new section AFTER the closing `</section>` of `#recent-additions` (currently line ~141) and BEFORE the `<!-- Browse toggle + sort -->` block (line ~143).
+  - [x] Markup outline (Tailwind utility classes only; the bar uses `<progress>` with custom CSS for theming):
     ```jinja
     {# Stats by genre section (story 9-3). Sits between #recent-additions and
        #browse-results so it survives HTMX search swaps. Hidden entirely when
@@ -146,8 +146,8 @@ so that I can understand the composition of the library at a glance.
     - The `<progress>` element is the semantic, CSP-clean choice for a percentage visualization (`value`/`max` are HTML attributes, NOT inline `style`). The textual fallback (`>{{ row.percent_label }}</progress>`) is read by older browsers that don't render `<progress>` natively.
     - The `<a>` wraps the entire list-item so the click target is the full row (UX-DR8 / Fitts's-law). `<a>` + `<progress>` is valid HTML5.
     - `tabular-nums` keeps the count and percentage right-aligned visually as the rows scan.
-  - [ ] CSP discipline: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes + the new `.genre-bar` class only.
-  - [ ] **Add styling for `<progress class="genre-bar">` in `static/css/browse.css`** (extending the file rather than creating a new one — keeps dashboard-related CSS co-located with the title-card rules that 9-2 also targets). Specification:
+  - [x] CSP discipline: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes + the new `.genre-bar` class only.
+  - [x] **Add styling for `<progress class="genre-bar">` in `static/css/browse.css`** (extending the file rather than creating a new one — keeps dashboard-related CSS co-located with the title-card rules that 9-2 also targets). Specification:
     ```css
     /* Story 9-3: Stats-by-genre horizontal bar. <progress> uses cross-browser
        pseudo-elements; values come from the @theme tokens defined in
@@ -182,38 +182,38 @@ so that I can understand the composition of the library at a glance.
     }
     ```
     These use the `@theme` tokens already defined in `static/css/input.css:5-26` — no hardcoded hex values, satisfying AC8's "no hardcoded colors" clause.
-  - [ ] **Tailwind v4 build awareness** — the project uses `@tailwindcss/cli` (see `package.json`); the `output.css` is regenerated when CSS changes. Run `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css` (or whatever the project's npm script is) after editing `browse.css`. Verify `static/css/output.css` actually includes the new `.genre-bar` rules — Tailwind v4 should pass through unrecognized custom CSS verbatim, but confirm.
-- [ ] **Task 5 — Unit tests (AC: 7, 10)**
-  - [ ] Create `tests/dashboard_stats_by_genre.rs` (sibling, not `mod` inside `dashboard_glance.rs` or `dashboard_recent_additions.rs`). Three `#[sqlx::test(migrations = "./migrations")]` cases (AC10a/b/c). Pattern from `tests/dashboard_recent_additions.rs:1-30` for the imports + `MySqlPool` plumbing.
-  - [ ] Helpers needed (file-local — same approach as 9-1/9-2 — no shared `tests/common.rs` yet):
+  - [x] **Tailwind v4 build awareness** — the project uses `@tailwindcss/cli` (see `package.json`); the `output.css` is regenerated when CSS changes. Run `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css` (or whatever the project's npm script is) after editing `browse.css`. Verify `static/css/output.css` actually includes the new `.genre-bar` rules — Tailwind v4 should pass through unrecognized custom CSS verbatim, but confirm.
+- [x] **Task 5 — Unit tests (AC: 7, 10)**
+  - [x] Create `tests/dashboard_stats_by_genre.rs` (sibling, not `mod` inside `dashboard_glance.rs` or `dashboard_recent_additions.rs`). Three `#[sqlx::test(migrations = "./migrations")]` cases (AC10a/b/c). Pattern from `tests/dashboard_recent_additions.rs:1-30` for the imports + `MySqlPool` plumbing.
+  - [x] Helpers needed (file-local — same approach as 9-1/9-2 — no shared `tests/common.rs` yet):
     ```rust
     async fn insert_genre(pool: &MySqlPool, name: &str) -> u64 { … }
     async fn insert_title_in_genre(pool: &MySqlPool, title: &str, genre_id: u64) -> u64 { … }
     async fn soft_delete(pool: &MySqlPool, table: &str, id: u64) { … } // dup from dashboard_glance.rs is fine
     ```
     Genre names must be unique within each test (e.g. `Z-9-3-Foo`, `Z-9-3-Bar`) to avoid colliding with seed migrations or with sibling tests running in parallel via the dedicated test DB.
-  - [ ] Test scenarios:
+  - [x] Test scenarios:
     - `stats_by_genre_on_empty_db_returns_empty_vec` — fresh schema, no fixtures → `Vec::new()`.
     - `stats_by_genre_orders_and_excludes_soft_deleted` — seed: 3 active titles in `Z-9-3-A`, 2 active in `Z-9-3-B`, 1 active + 2 soft-deleted in `Z-9-3-C`, 5 active titles in **soft-deleted** genre `Z-9-3-D` (orphans on FK) → expect rows for A (3), B (2), C (1) only, in that order; D is excluded. The orphan-on-soft-deleted-genre case is the critical AC5 invariant.
     - `stats_by_genre_single_genre_full_share` — seed: 4 active titles all in `Z-9-3-Single` → expect a single row with `title_count = 4`. Handler-side computation in 10d covers the corresponding 100.0% percentage.
-  - [ ] Add **6 handler render tests** in `src/routes/home.rs::mod tests` (AC10d/e/f/g — paired):
+  - [x] Add **6 handler render tests** in `src/routes/home.rs::mod tests` (AC10d/e/f/g — paired):
     - `home_renders_stats_by_genre_with_three_rows` — populated case (3 rows), EN locale; assert section present, 3 `<li>` rows, each contains genre name + percentage. Asserts the EN format `"33.3%"`.
     - `home_renders_stats_by_genre_empty_section_hidden` — empty case (`vec![]`); assert `id="stats-by-genre"` is NOT in the rendered HTML.
     - `home_renders_recent_additions_above_stats_by_genre` — populated case; locks document order between `#recent-additions` and `#stats-by-genre`. Mirror the 9-2 `home_renders_glance_above_recent_additions` test.
     - `home_stats_by_genre_byte_identical_for_anonymous_and_librarian` — render twice with same `stats_by_genre` payload, role differs; slice both to `stats-by-genre`, `assert_eq!(slice_anon, slice_librarian)`. AC7.
     - `home_renders_stats_by_genre_french_uses_nbsp_and_comma` — same data as the EN test but with `lang = "fr"` and `count_label`/`percent_label` pre-formatted via the FR variant; assert the slice contains `"33,3\u{00A0}%"` and does NOT contain `"33.3%"`. AC9 NBSP invariant.
-  - [ ] Add **factories** to `mod tests`:
+  - [x] Add **factories** to `mod tests`:
     - `make_test_home_template_with_stats(role: &str, stats: Vec<StatsByGenreRow>) -> HomeTemplate` — sibling of `make_test_home_template_with_recent`, delegates to `make_test_home_template_with_counts`.
     - `fake_genre_stat_row(id: u64, name: &str, count_label: &str, percent_label: &str, value: i64, max: i64) -> StatsByGenreRow` — deterministic row for assertion-friendly tests.
-  - [ ] Add **slice helper** sibling: `fn stats_by_genre_slice(html: &str) -> &str { slice_section(html, "stats-by-genre") }` next to `recent_additions_slice` at line ~649. Reuse the existing `slice_section` helper unchanged.
-  - [ ] Add **`format_percent` unit tests** in `src/utils.rs` (or wherever the helper lands):
+  - [x] Add **slice helper** sibling: `fn stats_by_genre_slice(html: &str) -> &str { slice_section(html, "stats-by-genre") }` next to `recent_additions_slice` at line ~649. Reuse the existing `slice_section` helper unchanged.
+  - [x] Add **`format_percent` unit tests** in `src/utils.rs` (or wherever the helper lands):
     - `format_percent_en_basic` — `format_percent(33.3, "en") == "33.3%"`
     - `format_percent_fr_basic` — `format_percent(33.3, "fr") == "33,3\u{00A0}%"`
     - `format_percent_fr_uses_nbsp` — assert the byte at `s.len() - 2` is `\u{00A0}` (NBSP), not a regular space `\u{0020}`. NBSP is critical for French typography and would silently degrade if a future refactor changed it.
     - `format_percent_one_decimal_kept` — `format_percent(100.0, "en") == "100.0%"` (we keep `.0` for visual alignment).
     - `format_percent_zero` — defensive (zero-count genres are excluded by SQL but the helper must not panic).
-- [ ] **Task 6 — E2E spec (AC: 11)**
-  - [ ] Extend `tests/e2e/specs/journeys/home.spec.ts`. Place a new `test.describe("Home page — Stats by genre section", ...)` block AFTER the existing `test.describe("Home page — Recent additions section", ...)` block (after line 117 in the current file). One anonymous test:
+- [x] **Task 6 — E2E spec (AC: 11)**
+  - [x] Extend `tests/e2e/specs/journeys/home.spec.ts`. Place a new `test.describe("Home page — Stats by genre section", ...)` block AFTER the existing `test.describe("Home page — Recent additions section", ...)` block (after line 117 in the current file). One anonymous test:
     ```ts
     test.describe("Home page — Stats by genre section", () => {
       test("anonymous: section visible, first row navigates to /?filter=genre:<id> (or section hidden)", async ({
@@ -240,20 +240,20 @@ so that I can understand the composition of the library at a glance.
       });
     });
     ```
-  - [ ] Use i18n-aware regex matchers consistently. Do NOT add `waitForTimeout` (CI grep gate).
-  - [ ] **No login required** — AC7 says role-agnostic. A single anonymous test is sufficient.
-- [ ] **Task 7 — Verify and document (AC: 1–11)**
-  - [ ] `cargo check && cargo clippy --all-targets -- -D warnings` (zero warnings policy, Foundation Rule).
-  - [ ] `cargo test --lib` — full unit + co-located integration suite. Expected count: ~631 (post-9-2) + 5 new render tests in `home.rs` + 5 new `format_percent` tests = ~641 lib tests. Plus the new `tests/dashboard_stats_by_genre.rs` integration tests run separately.
-  - [ ] `SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' cargo test --test dashboard_stats_by_genre` — 3 new integration tests pass.
-  - [ ] `cargo sqlx prepare --check --workspace -- --all-targets` — expected no diff (Task 1 uses dynamic `query_as`).
-  - [ ] **Tailwind build:** verify `static/css/output.css` regenerates and contains the new `.genre-bar` rules. The exact npm command is in `package.json`'s scripts (or run `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css`).
-  - [ ] **Manual smoke** (from a running dev instance — `MYBIBLI_SKIP_SETUP=1 cargo run`):
+  - [x] Use i18n-aware regex matchers consistently. Do NOT add `waitForTimeout` (CI grep gate).
+  - [x] **No login required** — AC7 says role-agnostic. A single anonymous test is sufficient.
+- [x] **Task 7 — Verify and document (AC: 1–11)**
+  - [x] `cargo check && cargo clippy --all-targets -- -D warnings` (zero warnings policy, Foundation Rule).
+  - [x] `cargo test --lib` — full unit + co-located integration suite. Expected count: ~631 (post-9-2) + 5 new render tests in `home.rs` + 5 new `format_percent` tests = ~641 lib tests. Plus the new `tests/dashboard_stats_by_genre.rs` integration tests run separately.
+  - [x] `SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' cargo test --test dashboard_stats_by_genre` — 3 new integration tests pass.
+  - [x] `cargo sqlx prepare --check --workspace -- --all-targets` — expected no diff (Task 1 uses dynamic `query_as`).
+  - [x] **Tailwind build:** verify `static/css/output.css` regenerates and contains the new `.genre-bar` rules. The exact npm command is in `package.json`'s scripts (or run `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css`).
+  - [x] **Manual smoke** (from a running dev instance — `MYBIBLI_SKIP_SETUP=1 cargo run`):
     - `curl http://localhost:8080/` and grep for `id="stats-by-genre"`, `Par genre`, `<progress class="genre-bar"`.
     - Verify in a browser: dark-mode toggle keeps the bar legible; clicking a row navigates to `/?filter=genre:<id>` and the search results show only that genre.
-  - [ ] **E2E** (Foundation Rule #13 — local before push): `./scripts/e2e-reset.sh && cd tests/e2e && npx playwright test specs/journeys/home.spec.ts`. If the local `tests/e2e/test-results/` is owned by root (the recurring 9-1 / 9-2 blocker), document the skip in Dev Agent Record and rely on CI.
-  - [ ] Update Dev Agent Record at the bottom of this file: list of files touched, decisions on `<progress>` styling location, anything surprising.
-  - [ ] Update `_bmad-output/implementation-artifacts/sprint-status.yaml`: flip `9-3-dashboard-stats-by-genre: backlog → ready-for-dev` (already done by the create-story step) → `in-progress` at start of dev-story → `review` at end. Update only this line + `last_updated` (CLAUDE.md rule 16).
+  - [x] **E2E** (Foundation Rule #13 — local before push): `./scripts/e2e-reset.sh && cd tests/e2e && npx playwright test specs/journeys/home.spec.ts`. If the local `tests/e2e/test-results/` is owned by root (the recurring 9-1 / 9-2 blocker), document the skip in Dev Agent Record and rely on CI.
+  - [x] Update Dev Agent Record at the bottom of this file: list of files touched, decisions on `<progress>` styling location, anything surprising.
+  - [x] Update `_bmad-output/implementation-artifacts/sprint-status.yaml`: flip `9-3-dashboard-stats-by-genre: backlog → ready-for-dev` (already done by the create-story step) → `in-progress` at start of dev-story → `review` at end. Update only this line + `last_updated` (CLAUDE.md rule 16).
 
 ## Dev Notes
 
@@ -375,10 +375,56 @@ The deferred TitleCard partial extraction (filed by 9-2) is **NOT** revisited he
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+`claude-opus-4-7` (1M context).
 
 ### Debug Log References
 
+- `SQLX_OFFLINE=true cargo check --all-targets` — clean.
+- `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings` — clean (zero warnings).
+- `SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' cargo test` — full suite green:
+  - **643 lib tests** (was 631 pre-9-3, +12: 7 `format_percent` + 5 `stats_by_genre` handler render tests).
+  - `tests/dashboard_stats_by_genre.rs` — 3/3 integration tests passing (empty DB, ordering + soft-delete exclusion both halves, single-genre full-share).
+  - All other integration suites (dashboard_glance 9-1, dashboard_recent_additions 9-2, etc.) unchanged.
+- `cargo sqlx prepare --check` not run cleanly locally (DB-credential mismatch on pre-existing `query!` macros in `models/session.rs` — same blocker 9-1/9-2 hit). However: `git status .sqlx/` shows zero diff, confirming Task 1's dynamic `query_as` adds no new compile-time-checked queries.
+- Tailwind rebuild via `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css --minify` — no diff in `output.css` (all utility classes I used were already present from other templates: `tabular-nums`, `whitespace-nowrap`, `truncate`, `mt-3`, `space-y-2`, `gap-3`, etc., verified by grep).
+- `templates_audit::no_inline_markup_in_templates` — green. Zero inline `style=`, zero `<style>`, zero inline scripts in the new section.
+- Manual `grep -rE 'waitForTimeout\(' tests/e2e/specs/ tests/e2e/helpers/` — clean (no new violations of the CI grep gate).
+- E2E run not executed locally (same `tests/e2e/test-results/` root-ownership blocker 9-1/9-2 documented). CI on the story branch validates `home.spec.ts`'s new "Stats by genre section" describe block.
+
 ### Completion Notes List
 
+- **Single round-trip query (AC3)** — `services::dashboard::stats_by_genre` returns `Vec<GenreStat>` from one `SELECT … GROUP BY` with INNER JOIN. Total denominator computed Rust-side via `rows.iter().map(|r| r.title_count).sum()`. No second query.
+- **INNER JOIN naturally satisfies AC4 + AC5** — empty / soft-deleted genres can't appear in the result. `wipe_seeded_genres` helper in the integration test gives each `#[sqlx::test]` a hermetic baseline (the seed migration's "Roman" / "BD" rows would otherwise muddy assertions about exact row counts).
+- **Row link target is `/?filter=genre:<id>`** (not the spec literal `/catalog?genre=<id>` — `/catalog` is the scan page in v1, doesn't accept that param). Documented in AC6 + Anti-Patterns; same convention as 9-1's `/catalog?view=volumes` → `/catalog` deviation. The link drives the existing `parse_filter` → `SearchService::search` pipeline unchanged.
+- **`<progress value max>` for the variable-width bar** — semantic, accessible, CSP-clean (HTML attributes, not inline `style`). Custom CSS via `::-webkit-progress-bar`/`::-webkit-progress-value`/`::-moz-progress-bar` pseudo-elements in `static/css/browse.css`, all colors via `var(--color-*)` tokens from `static/css/input.css` `@theme` block (UX-DR24 — no hardcoded hex).
+- **`format_percent` lives in `src/utils.rs`** — pure function, no state, no async. 7 unit tests including a byte-level NBSP regression guard (`format_percent_fr_uses_nbsp`) that asserts the bytes `0xC2 0xA0` immediately before `%` and rejects a regular `0x20` space — load-bearing for FR typography.
+- **`build_stats_by_genre_rows` is a pure helper at module scope** in `home.rs`, not inlined in the handler. Keeps `home::home` readable and gives the test factory a clean injection seam (the render tests pre-construct `StatsByGenreRow` values directly without going through the SQL → `GenreStat` → row pipeline).
+- **`StatsByGenreRow` is module-public** (in `routes/home.rs`) — needed by the test module for the `make_test_home_template_with_stats` factory. Adjacent precedent: `HomeTemplate` itself is `pub struct`. Visibility kept minimal: `pub` on the struct + fields, no derives beyond what Askama needs implicitly.
+- **5 handler render tests + 7 helper tests = 12 new lib tests.** Coverage:
+  - `home_renders_stats_by_genre_with_three_rows` — populated case, 3 rows, in input order, with name/count/percent/link assertions scoped to the section slice.
+  - `home_renders_stats_by_genre_empty_section_hidden` — AC4 lock-in: empty Vec → no `id="stats-by-genre"` in the HTML.
+  - `home_renders_recent_additions_above_stats_by_genre` — AC10f document-order lock; mirrors 9-2's review-fix `home_renders_glance_above_recent_additions`.
+  - `home_stats_by_genre_byte_identical_for_anonymous_and_librarian` — AC7 anonymous parity; `assert_eq!` between the two slice strings.
+  - `home_renders_stats_by_genre_french_uses_nbsp_and_comma` — FR percent labels survive the template render verbatim, EN form does not leak.
+- **Initial template-placement bug caught + fixed in dev** — first edit inserted `#stats-by-genre` BEFORE `#recent-additions` (violates AC1: section must be directly below recent-additions). Re-positioned to between recent-additions and the browse toggle. The new `home_renders_recent_additions_above_stats_by_genre` test would have caught this — exactly the regression class it was designed to lock in.
+- **No new GH Issues filed.** No deferred findings from this story; the previously deferred TitleCard partial extraction (filed by 9-2 review) is unaffected — the genre-row markup is structurally different (no cover, full-width row, `<progress>` bar) and does NOT duplicate TitleCard.
+
 ### File List
+
+| File | Action |
+|---|---|
+| `src/services/dashboard.rs` | edit — added `GenreStat` struct + `stats_by_genre()` async fn (single GROUP BY round-trip) |
+| `src/utils.rs` | edit — added `format_percent(value, locale)` + 7 unit tests including byte-level NBSP guard |
+| `src/routes/home.rs` | edit — extended `HomeTemplate` with `stats_by_genre` + `stats_by_genre_heading` fields, added `StatsByGenreRow` struct, added `build_stats_by_genre_rows` helper, added handler block (single round-trip + soft-degrade + label computation), added `stats_by_genre_slice` helper, added `make_test_home_template_with_stats` + `fake_genre_stat_row` factories, added 5 new render tests |
+| `templates/pages/home.html` | edit — inserted `#stats-by-genre` section between `#recent-additions` and the browse toggle (AC1 placement); rendered as `<ul>` with `<li><a><progress></a></li>` rows; wrapped in `{% if !stats_by_genre.is_empty() %}` for AC4 hide-entirely |
+| `static/css/browse.css` | edit — appended `.genre-bar` rules for `<progress>` (cross-browser pseudo-elements, light + dark, all `@theme` token-based, zero hardcoded hex) |
+| `locales/en.yml` | edit — appended `dashboard.stats_by_genre.{heading, titles_one, titles_other}` |
+| `locales/fr.yml` | edit — same path, FR variants |
+| `tests/dashboard_stats_by_genre.rs` | create — 3 `#[sqlx::test]` cases + file-local helpers (`insert_genre`, `insert_title_in_genre`, `soft_delete`, `wipe_seeded_genres`) |
+| `tests/e2e/specs/journeys/home.spec.ts` | edit — appended `test.describe("Home page — Stats by genre section", …)` block with one anonymous test handling both populated and hidden-section branches; selector scoped to `#stats-by-genre` to sidestep the deferred unscoped-selector flake class flagged by 9-2 |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | edit — `9-3-dashboard-stats-by-genre`: `ready-for-dev → in-progress → review` (per CLAUDE.md rule 16; only this line + `last_updated`) |
+| `_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md` | edit — Status `ready-for-dev → review`, all Tasks checked, Dev Agent Record filled |
+
+### Change Log
+
+- **2026-05-01** — Initial implementation. All 7 tasks complete; 643 lib tests + 3 dashboard_stats_by_genre integration tests pass; clippy clean; sqlx cache unchanged. Followed Story 9-1 / 9-2 patterns (handler-side i18n, soft-degrade on DB error, single round-trip query, scoped HTML assertions, sibling integration test file). One spec drift caught in template draft (AC1 ordering — `#stats-by-genre` was placed BEFORE `#recent-additions` in the first pass; re-ordered to satisfy AC1's "directly below recent-additions" placement). E2E run deferred to CI per story 9-1 / 9-2 precedent (`tests/e2e/test-results/` ownership blocker).

--- a/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md
+++ b/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md
@@ -1,0 +1,384 @@
+# Story 9.3: Dashboard — stats by genre
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As any user (anonymous or authenticated),
+I want to see the catalog distribution by genre on the home page,
+so that I can understand the composition of the library at a glance.
+
+## Acceptance Criteria
+
+1. **AC1 — Section presence and ordering.** Given the home page (`/`), when it renders for any role (Anonymous, Librarian, Admin), then a "By genre" section is visible directly below the "Recent additions" section (story 9-2) and above the browse controls (`<!-- Browse toggle + sort -->`). The section sits OUTSIDE the `#browse-results` HTMX swap target so it survives search/filter swaps — same placement invariant as `#collection-glance` (9-1) and `#recent-additions` (9-2).
+2. **AC2 — Row content.** Given the section is non-empty, when each row renders, then it displays exactly four pieces of information in this order: (a) genre name, (b) title count for that genre, (c) percentage of total active titles in that genre (rounded to 1 decimal), (d) a horizontal bar visually proportional to the percentage. Rows are sorted by `title_count DESC`, then `genres.name ASC` (locale-insensitive tiebreak — keeps order deterministic across runs).
+3. **AC3 — Single round-trip aggregated query.** The query that drives the section is a single `SELECT … GROUP BY genres.id` round-trip joining `titles` to `genres` with `WHERE titles.deleted_at IS NULL AND genres.deleted_at IS NULL`. The total denominator (used for percentage) is computed Rust-side from the rows (`rows.iter().map(|r| r.title_count).sum()`) — NOT via a second SQL round-trip. The query lives at `src/services/dashboard.rs::stats_by_genre(pool) -> Result<Vec<GenreStat>, AppError>` where `GenreStat` is a small struct with the SQL-emitted fields (id, name, title_count). Percentage is computed in the route handler, not in SQL.
+4. **AC4 — Empty state (no genres assigned).** Given the active catalog has zero titles (so zero genre assignments), when the section renders, then it is **hidden entirely** — `<section id="stats-by-genre">` is not emitted. AC1 ordering is preserved when present, but the section may be absent. This deviates from 9-1/9-2 (which always render their card with a 0-state) on purpose: the spec is explicit ("when no genres are assigned anywhere, the section is hidden entirely; the broader empty-catalog UX is handled by StatusMessage in 9.15"). When the StatusMessage component arrives in 9-15, that component will own the empty-catalog story for the page as a whole.
+5. **AC5 — Soft-deleted exclusion (titles AND genres).** Given a genre `g` exists with `deleted_at IS NOT NULL`, when the section renders, then no row for `g` appears even if some titles still point at it (orphan FK left over from soft-deleted reference data). Given a title `t` has `deleted_at IS NOT NULL`, when its genre's count is computed, then `t` is NOT counted. The query JOINs with `genres.deleted_at IS NULL` AND filters `titles.deleted_at IS NULL` — both halves are load-bearing.
+6. **AC6 — Genre row clickability + filter target.** Given a row, when clicked, then it navigates to `/?filter=genre:<id>` (the existing genre-filter URL pattern established in `src/routes/home.rs::parse_filter` at line ~340). **Spec note:** the literal text in `epics.md:1250` says `/catalog?genre=<id>`, but `/catalog` is the scan page (it does NOT support a `genre=` query param — verified in `src/routes/catalog.rs::CatalogTemplate`). The actual genre-filter route in v1 is `/?filter=genre:<id>` (home page with active filter). This is the same convention story 9-1 used when its "volume count → `/catalog?view=volumes`" deviation pointed to plain `/catalog`. Use a real `<a href>` (not HTMX `hx-get`) so the link is bookmarkable AND works without JS; HTMX boost on `<body>` (if/when added) will progressively enhance it.
+7. **AC7 — Anonymous data leak guard.** Given the section is visible to anonymous users, when the query runs, then it SELECTs only public columns (id, name, count) — no role-gated columns are joined. The query is role-agnostic (no `if session.role …` SQL branch) and the rendered HTML for an anonymous request is byte-identical to the librarian/admin HTML for this section. **No** anonymous-leak regression guard is needed in the route test (unlike 9-1's `href="/loans"` check) because there is no role-gated link in this section — but the byte-identical invariant is asserted in the unit test by rendering once with `Anonymous` and once with `Librarian` and comparing the slice.
+8. **AC8 — CSP compliance.** No `style="..."`, no `<style>`, no `<script>`, no `onclick=`, no inline event handlers. The horizontal bar uses semantic `<progress value="X" max="Y">` (HTML attributes, NOT inline CSS — CSP-clean and accessible by default). Custom styling comes from a class-driven rule in `static/css/browse.css` (or a new `static/css/dashboard.css` if browse.css is the wrong home) that uses `var(--color-indigo-500)` / `var(--color-stone-200)` tokens defined in `static/css/input.css` `@theme` block. The `src/templates_audit.rs::no_inline_markup_in_templates` test must continue to pass.
+9. **AC9 — i18n EN + FR with locale-aware percentage formatting.**
+   - Three new keys under the existing `dashboard:` section (after `recent_additions:`):
+     - `dashboard.stats_by_genre.heading` — EN: "By genre", FR: "Par genre"
+     - `dashboard.stats_by_genre.titles_one` — EN: "%{count} title", FR: "%{count} titre"
+     - `dashboard.stats_by_genre.titles_other` — EN: "%{count} titles", FR: "%{count} titres"
+   - The percentage is formatted **locale-aware** — EN: `"12.5%"` (period decimal separator, no space), FR: `"12,5 %"` (comma decimal separator, **non-breaking space** `U+00A0` before the `%` per French typographic convention). Implement as a small helper in `src/routes/home.rs` or `src/utils.rs::format_percent(value: f64, locale: &str) -> String`. **Do NOT** add a new dependency for locale-aware number formatting — a 4-line `if locale == "fr" { … }` branch is sufficient for the v1 EN/FR scope.
+   - Pluralization uses the same `_one`/`_other` pattern as 9-1's glance card (literal `t!` keys, branched on `is_singular(loc, count)` — see Task 2 sub-bullet). After editing locale files, run `touch src/lib.rs && cargo build` to force the proc macro to re-read.
+10. **AC10 — Unit tests.**
+    - (a) `stats_by_genre` returns rows ordered by `title_count DESC, name ASC`, excluding both soft-deleted titles and soft-deleted genres — `tests/dashboard_stats_by_genre.rs::stats_by_genre_orders_and_excludes_soft_deleted` (DB-backed `#[sqlx::test]`).
+    - (b) `stats_by_genre` on an empty DB returns `Ok(vec![])` (not an error) — `tests/dashboard_stats_by_genre.rs::stats_by_genre_on_empty_db_returns_empty_vec`.
+    - (c) `stats_by_genre` with all titles in one genre returns one row whose count equals total active titles — same test file, scenario `stats_by_genre_single_genre_full_share`.
+    - (d) Handler render test — populated case: build a HomeTemplate via `make_test_home_template_with_stats(role, vec_of_3_genre_stats)`, render, scope assertion to `#stats-by-genre` slice (`stats_by_genre_slice` — sibling of `recent_additions_slice` using the existing `slice_section` helper), assert: 3 rows present in input order, each row contains the genre name and the formatted percentage; the EN test asserts `"12.5%"` and the FR test asserts `"12,5\u{00A0}%"` (literal NBSP).
+    - (e) Handler render test — empty case: with `vec![]`, assert: `id="stats-by-genre"` is **NOT** present in the rendered HTML (AC4 hide-entirely).
+    - (f) Document-order regression test: `home_renders_recent_additions_above_stats_by_genre` — locks `#recent-additions` strictly before `#stats-by-genre` in the rendered output. Mirrors the 9-2 review-fix test `home_renders_glance_above_recent_additions`. Without this, a future template edit could swap the order silently.
+    - (g) Anonymous parity test: render the populated case once with `role="anonymous"` and once with `role="librarian"`, slice both to `stats-by-genre`, `assert_eq!(slice_anon, slice_librarian)` — locks AC7.
+    - (h) Percentage rounding edge cases: a unit test on `format_percent` covers `(1.0/3.0) * 100.0 = 33.333…` → EN `"33.3%"`, FR `"33,3\u{00A0}%"`; `100.0` → `"100.0%"` (we keep the trailing `.0` for visual alignment per 1-decimal mandate); `0.0` → `"0.0%"` (defensive — should never appear in rendered output because zero-count genres are excluded from the SQL result by the INNER JOIN, but the helper itself must not panic).
+11. **AC11 — E2E smoke.** Extend `tests/e2e/specs/journeys/home.spec.ts` with one new `test.describe("Home page — Stats by genre section", ...)` block placed AFTER the existing `test.describe("Home page — Recent additions section", ...)` block. The single test (anonymous role, since AC7 is role-agnostic) does:
+    - Navigate to `/`.
+    - If `page.locator("#stats-by-genre").count() > 0`: assert the heading matches `/By genre|Par genre/i`; assert the first row contains both a number AND a percentage matching `/\d+(\.\d+)?\s?%/` (EN) or `/\d+(,\d+)?\s?%/` (FR — combined regex `/\d+([.,]\d+)?\s*%/` accepts both); click the first row and `await page.waitForURL(/\/\?filter=genre:\d+/)` (note: home page URL with filter query, NOT `/catalog?genre=`).
+    - If 0 rows (empty DB): assert `await expect(page.locator("#stats-by-genre")).toHaveCount(0)` (AC4 hide-entirely). Use the same conditional pattern as `home.spec.ts:103-115` (Story 9-2's E2E).
+    - Use i18n-aware regex matchers; no `waitForTimeout` (CI grep gate enforced by the `e2e` job). The new genre-row link selector `'#stats-by-genre a[href^="/?filter=genre:"]'` is **scoped to the section** — explicitly avoiding the deferred unscoped-selector follow-up filed during 9-2 (per `9-2-dashboard-recent-additions.md` Change Log 2026-04-30).
+
+## Tasks / Subtasks
+
+- [ ] **Task 1 — Add `stats_by_genre()` to `services::dashboard` (AC: 1, 2, 3, 5, 7, 10a–c)**
+  - [ ] In `src/services/dashboard.rs`, add `pub struct GenreStat { pub id: u64, pub name: String, pub title_count: i64 }` deriving `Debug, Clone, sqlx::FromRow`.
+  - [ ] Add `pub async fn stats_by_genre(pool: &DbPool) -> Result<Vec<GenreStat>, AppError>`. SQL shape (single round-trip):
+    ```sql
+    SELECT g.id, g.name, COUNT(t.id) AS title_count
+      FROM titles t
+      JOIN genres g ON t.genre_id = g.id AND g.deleted_at IS NULL
+     WHERE t.deleted_at IS NULL
+     GROUP BY g.id, g.name
+     ORDER BY title_count DESC, g.name ASC
+    ```
+    Use `sqlx::query_as::<_, GenreStat>` + `.fetch_all(pool)`. The INNER JOIN form (rather than `FROM genres g LEFT JOIN titles t`) means a genre with zero active titles is automatically excluded — AC4's "no genres assigned → section hidden" is therefore observed naturally by the query: an empty DB returns `Vec::new()`.
+  - [ ] **Do NOT use `sqlx::query!` macro** (forces `.sqlx/` cache regeneration in the PR — project convention is dynamic `query_as`, see `services::dashboard::collection_glance` and `models::title::list_recent_active`).
+  - [ ] Co-locate three `#[sqlx::test]` cases at the bottom of `src/services/dashboard.rs` OR in a new file `tests/dashboard_stats_by_genre.rs` (sibling). **Choose the sibling file** for parity with `tests/dashboard_glance.rs` (9-1) and `tests/dashboard_recent_additions.rs` (9-2) — discoverability by file name beats co-location. The three cases are AC10a/b/c.
+  - [ ] **Test data isolation** — the migration seed adds genres like "Roman", "BD", … so each test must use unique genre names (e.g. prefix with `Z-9-3-`) or rely on pre-seeded ones. The `tests/dashboard_glance.rs::first_genre_id` helper is reusable; clone or import its pattern (helpers can stay file-local — no shared `tests/common.rs` exists yet).
+- [ ] **Task 2 — Wire the handler (AC: 1, 4, 6, 9)**
+  - [ ] In `src/routes/home.rs::home`, after the `recent_additions = …` block (around line ~186), call `crate::services::dashboard::stats_by_genre(pool).await` with the **soft-degrade pattern** established by 9-1/9-2: `match … { Ok(v) => v, Err(e) => { tracing::warn!(error = %e, "stats_by_genre failed; rendering empty section"); Vec::new() } }`. The home page MUST NOT 500 because the dashboard query had a hiccup.
+  - [ ] Compute the total denominator and per-row percentage **in the handler**:
+    ```rust
+    let total: i64 = stats_rows.iter().map(|r| r.title_count).sum();
+    let stats: Vec<StatsByGenreRow> = stats_rows.into_iter().map(|r| {
+        let pct = if total > 0 {
+            ((r.title_count as f64 / total as f64) * 1000.0).round() / 10.0
+        } else { 0.0 };
+        StatsByGenreRow {
+            id: r.id,
+            name: r.name,
+            title_count: r.title_count,
+            count_label: /* t!("dashboard.stats_by_genre.titles_{one|other}", count = …) */,
+            percent_label: format_percent(pct, loc),
+            // For the <progress> element:
+            value: r.title_count,
+            max: total,
+        }
+    }).collect();
+    ```
+    Define `StatsByGenreRow` as a small inner struct in `src/routes/home.rs` (or a sibling module if you prefer — `src/routes/home_dashboard.rs` is overkill for one struct; keep it in `home.rs`).
+  - [ ] Reuse the existing `is_singular(locale, count)` helper at `src/routes/home.rs:333-338` for `_one`/`_other` selection on `count_label`. Do NOT duplicate it.
+  - [ ] Implement `format_percent(value: f64, locale: &str) -> String` — preferred location is `src/utils.rs` (since it's a pure formatting helper with no DB / no AppState dependency, and `utils.rs` already houses `html_escape`, `url_encode`, `current_url` — same shape). Specification:
+    ```rust
+    pub fn format_percent(value: f64, locale: &str) -> String {
+        let s = format!("{:.1}", value); // e.g., "33.3"
+        match locale {
+            "fr" => format!("{}\u{00A0}%", s.replace('.', ",")), // "33,3 %" (NBSP)
+            _    => format!("{}%", s),                           // "33.3%"
+        }
+    }
+    ```
+    Add three unit tests in the same file covering: EN basic, FR with NBSP, the rounding edge cases listed in AC10h.
+  - [ ] Extend `HomeTemplate` (currently 53 fields post-9-2 at `src/routes/home.rs:31-85`) with **TWO** new fields:
+    - `stats_by_genre: Vec<StatsByGenreRow>` — the rows; empty when section should hide
+    - `stats_by_genre_heading: String` — pre-translated `dashboard.stats_by_genre.heading`
+  - [ ] Translate the heading via `rust_i18n::t!("dashboard.stats_by_genre.heading", locale = loc).to_string()`. Pre-translate `count_label` per row in the handler (NOT in the template) — same pattern as 9-1/9-2.
+  - [ ] Pass the new fields from the handler. Do NOT add a new route.
+- [ ] **Task 3 — Add i18n keys (AC: 9)**
+  - [ ] In `locales/en.yml`, under `dashboard:` after the `recent_additions:` block, add:
+    ```yaml
+      stats_by_genre:
+        heading: By genre
+        titles_one: "%{count} title"
+        titles_other: "%{count} titles"
+    ```
+  - [ ] In `locales/fr.yml`, mirror under the same path:
+    ```yaml
+      stats_by_genre:
+        heading: Par genre
+        titles_one: "%{count} titre"
+        titles_other: "%{count} titres"
+    ```
+  - [ ] **CRITICAL:** locale files have NO top-level `en:`/`fr:` wrapper. Keys start at root level. The proc-macro reads filename → locale.
+  - [ ] After editing, run `touch src/lib.rs && cargo build` to force the i18n proc-macro to re-read YAML files. The `i18n::audit::tests::all_t_keys_have_both_locales` test (mentioned in 9-1 Debug Log) will fail if a key exists in only one of EN/FR — keep them perfectly mirrored.
+- [ ] **Task 4 — Render the section in the template (AC: 1, 2, 4, 6, 8)**
+  - [ ] In `templates/pages/home.html`, insert the new section AFTER the closing `</section>` of `#recent-additions` (currently line ~141) and BEFORE the `<!-- Browse toggle + sort -->` block (line ~143).
+  - [ ] Markup outline (Tailwind utility classes only; the bar uses `<progress>` with custom CSS for theming):
+    ```jinja
+    {# Stats by genre section (story 9-3). Sits between #recent-additions and
+       #browse-results so it survives HTMX search swaps. Hidden entirely when
+       the catalog has zero genre assignments (AC4) — empty-state UX moves to
+       StatusMessage in story 9-15 for the page as a whole. #}
+    {% if !stats_by_genre.is_empty() %}
+    <section id="stats-by-genre" aria-labelledby="stats-by-genre-heading" class="w-full max-w-4xl mt-6">
+        <h2 id="stats-by-genre-heading" class="text-sm font-medium text-stone-600 dark:text-stone-400 uppercase tracking-wide">{{ stats_by_genre_heading }}</h2>
+        <ul class="mt-3 space-y-2">
+            {% for row in stats_by_genre %}
+            <li>
+                <a href="/?filter=genre:{{ row.id }}" class="block px-4 py-3 bg-stone-50 dark:bg-stone-800 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-lg border border-stone-200 dark:border-stone-700 transition-colors">
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="font-medium text-stone-900 dark:text-stone-100 truncate">{{ row.name }}</span>
+                        <span class="text-sm text-stone-600 dark:text-stone-400 whitespace-nowrap"><span class="tabular-nums">{{ row.count_label }}</span> · <span class="tabular-nums">{{ row.percent_label }}</span></span>
+                    </div>
+                    <progress class="genre-bar mt-2 w-full" value="{{ row.value }}" max="{{ row.max }}" aria-label="{{ row.percent_label }}">{{ row.percent_label }}</progress>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+    ```
+    Notes:
+    - The `<progress>` element is the semantic, CSP-clean choice for a percentage visualization (`value`/`max` are HTML attributes, NOT inline `style`). The textual fallback (`>{{ row.percent_label }}</progress>`) is read by older browsers that don't render `<progress>` natively.
+    - The `<a>` wraps the entire list-item so the click target is the full row (UX-DR8 / Fitts's-law). `<a>` + `<progress>` is valid HTML5.
+    - `tabular-nums` keeps the count and percentage right-aligned visually as the rows scan.
+  - [ ] CSP discipline: zero `style="..."`, zero `onclick=`, zero inline `<script>`. Tailwind classes + the new `.genre-bar` class only.
+  - [ ] **Add styling for `<progress class="genre-bar">` in `static/css/browse.css`** (extending the file rather than creating a new one — keeps dashboard-related CSS co-located with the title-card rules that 9-2 also targets). Specification:
+    ```css
+    /* Story 9-3: Stats-by-genre horizontal bar. <progress> uses cross-browser
+       pseudo-elements; values come from the @theme tokens defined in
+       static/css/input.css (UX-DR24). */
+    progress.genre-bar {
+        appearance: none;
+        -webkit-appearance: none;
+        height: 6px;
+        border: none;
+        border-radius: 3px;
+        background-color: var(--color-stone-200);
+    }
+    progress.genre-bar::-webkit-progress-bar {
+        background-color: var(--color-stone-200);
+        border-radius: 3px;
+    }
+    progress.genre-bar::-webkit-progress-value {
+        background-color: var(--color-indigo-500);
+        border-radius: 3px;
+    }
+    progress.genre-bar::-moz-progress-bar {
+        background-color: var(--color-indigo-500);
+        border-radius: 3px;
+    }
+    .dark progress.genre-bar,
+    .dark progress.genre-bar::-webkit-progress-bar {
+        background-color: var(--color-stone-700);
+    }
+    .dark progress.genre-bar::-webkit-progress-value,
+    .dark progress.genre-bar::-moz-progress-bar {
+        background-color: var(--color-indigo-400);
+    }
+    ```
+    These use the `@theme` tokens already defined in `static/css/input.css:5-26` — no hardcoded hex values, satisfying AC8's "no hardcoded colors" clause.
+  - [ ] **Tailwind v4 build awareness** — the project uses `@tailwindcss/cli` (see `package.json`); the `output.css` is regenerated when CSS changes. Run `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css` (or whatever the project's npm script is) after editing `browse.css`. Verify `static/css/output.css` actually includes the new `.genre-bar` rules — Tailwind v4 should pass through unrecognized custom CSS verbatim, but confirm.
+- [ ] **Task 5 — Unit tests (AC: 7, 10)**
+  - [ ] Create `tests/dashboard_stats_by_genre.rs` (sibling, not `mod` inside `dashboard_glance.rs` or `dashboard_recent_additions.rs`). Three `#[sqlx::test(migrations = "./migrations")]` cases (AC10a/b/c). Pattern from `tests/dashboard_recent_additions.rs:1-30` for the imports + `MySqlPool` plumbing.
+  - [ ] Helpers needed (file-local — same approach as 9-1/9-2 — no shared `tests/common.rs` yet):
+    ```rust
+    async fn insert_genre(pool: &MySqlPool, name: &str) -> u64 { … }
+    async fn insert_title_in_genre(pool: &MySqlPool, title: &str, genre_id: u64) -> u64 { … }
+    async fn soft_delete(pool: &MySqlPool, table: &str, id: u64) { … } // dup from dashboard_glance.rs is fine
+    ```
+    Genre names must be unique within each test (e.g. `Z-9-3-Foo`, `Z-9-3-Bar`) to avoid colliding with seed migrations or with sibling tests running in parallel via the dedicated test DB.
+  - [ ] Test scenarios:
+    - `stats_by_genre_on_empty_db_returns_empty_vec` — fresh schema, no fixtures → `Vec::new()`.
+    - `stats_by_genre_orders_and_excludes_soft_deleted` — seed: 3 active titles in `Z-9-3-A`, 2 active in `Z-9-3-B`, 1 active + 2 soft-deleted in `Z-9-3-C`, 5 active titles in **soft-deleted** genre `Z-9-3-D` (orphans on FK) → expect rows for A (3), B (2), C (1) only, in that order; D is excluded. The orphan-on-soft-deleted-genre case is the critical AC5 invariant.
+    - `stats_by_genre_single_genre_full_share` — seed: 4 active titles all in `Z-9-3-Single` → expect a single row with `title_count = 4`. Handler-side computation in 10d covers the corresponding 100.0% percentage.
+  - [ ] Add **6 handler render tests** in `src/routes/home.rs::mod tests` (AC10d/e/f/g — paired):
+    - `home_renders_stats_by_genre_with_three_rows` — populated case (3 rows), EN locale; assert section present, 3 `<li>` rows, each contains genre name + percentage. Asserts the EN format `"33.3%"`.
+    - `home_renders_stats_by_genre_empty_section_hidden` — empty case (`vec![]`); assert `id="stats-by-genre"` is NOT in the rendered HTML.
+    - `home_renders_recent_additions_above_stats_by_genre` — populated case; locks document order between `#recent-additions` and `#stats-by-genre`. Mirror the 9-2 `home_renders_glance_above_recent_additions` test.
+    - `home_stats_by_genre_byte_identical_for_anonymous_and_librarian` — render twice with same `stats_by_genre` payload, role differs; slice both to `stats-by-genre`, `assert_eq!(slice_anon, slice_librarian)`. AC7.
+    - `home_renders_stats_by_genre_french_uses_nbsp_and_comma` — same data as the EN test but with `lang = "fr"` and `count_label`/`percent_label` pre-formatted via the FR variant; assert the slice contains `"33,3\u{00A0}%"` and does NOT contain `"33.3%"`. AC9 NBSP invariant.
+  - [ ] Add **factories** to `mod tests`:
+    - `make_test_home_template_with_stats(role: &str, stats: Vec<StatsByGenreRow>) -> HomeTemplate` — sibling of `make_test_home_template_with_recent`, delegates to `make_test_home_template_with_counts`.
+    - `fake_genre_stat_row(id: u64, name: &str, count_label: &str, percent_label: &str, value: i64, max: i64) -> StatsByGenreRow` — deterministic row for assertion-friendly tests.
+  - [ ] Add **slice helper** sibling: `fn stats_by_genre_slice(html: &str) -> &str { slice_section(html, "stats-by-genre") }` next to `recent_additions_slice` at line ~649. Reuse the existing `slice_section` helper unchanged.
+  - [ ] Add **`format_percent` unit tests** in `src/utils.rs` (or wherever the helper lands):
+    - `format_percent_en_basic` — `format_percent(33.3, "en") == "33.3%"`
+    - `format_percent_fr_basic` — `format_percent(33.3, "fr") == "33,3\u{00A0}%"`
+    - `format_percent_fr_uses_nbsp` — assert the byte at `s.len() - 2` is `\u{00A0}` (NBSP), not a regular space `\u{0020}`. NBSP is critical for French typography and would silently degrade if a future refactor changed it.
+    - `format_percent_one_decimal_kept` — `format_percent(100.0, "en") == "100.0%"` (we keep `.0` for visual alignment).
+    - `format_percent_zero` — defensive (zero-count genres are excluded by SQL but the helper must not panic).
+- [ ] **Task 6 — E2E spec (AC: 11)**
+  - [ ] Extend `tests/e2e/specs/journeys/home.spec.ts`. Place a new `test.describe("Home page — Stats by genre section", ...)` block AFTER the existing `test.describe("Home page — Recent additions section", ...)` block (after line 117 in the current file). One anonymous test:
+    ```ts
+    test.describe("Home page — Stats by genre section", () => {
+      test("anonymous: section visible, first row navigates to /?filter=genre:<id> (or section hidden)", async ({
+        page,
+      }) => {
+        await page.goto("/");
+        const section = page.locator("#stats-by-genre");
+        const sectionCount = await section.count();
+        if (sectionCount === 0) {
+          // AC4 — fresh catalog, section is hidden entirely. Done.
+          return;
+        }
+        await expect(section).toBeVisible();
+        await expect(section.getByRole("heading", { level: 2 })).toContainText(
+          /By genre|Par genre/i,
+        );
+        const rows = section.locator("li");
+        await expect(rows.first()).toContainText(/\d+([.,]\d+)?\s*%/);
+        // Scope the link selector to the section to avoid the deferred unscoped-
+        // selector flake (per 9-2 Change Log 2026-04-30).
+        const firstLink = section.locator('a[href^="/?filter=genre:"]').first();
+        await firstLink.click();
+        await page.waitForURL(/\/\?filter=genre:\d+/);
+      });
+    });
+    ```
+  - [ ] Use i18n-aware regex matchers consistently. Do NOT add `waitForTimeout` (CI grep gate).
+  - [ ] **No login required** — AC7 says role-agnostic. A single anonymous test is sufficient.
+- [ ] **Task 7 — Verify and document (AC: 1–11)**
+  - [ ] `cargo check && cargo clippy --all-targets -- -D warnings` (zero warnings policy, Foundation Rule).
+  - [ ] `cargo test --lib` — full unit + co-located integration suite. Expected count: ~631 (post-9-2) + 5 new render tests in `home.rs` + 5 new `format_percent` tests = ~641 lib tests. Plus the new `tests/dashboard_stats_by_genre.rs` integration tests run separately.
+  - [ ] `SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' cargo test --test dashboard_stats_by_genre` — 3 new integration tests pass.
+  - [ ] `cargo sqlx prepare --check --workspace -- --all-targets` — expected no diff (Task 1 uses dynamic `query_as`).
+  - [ ] **Tailwind build:** verify `static/css/output.css` regenerates and contains the new `.genre-bar` rules. The exact npm command is in `package.json`'s scripts (or run `npx @tailwindcss/cli -i static/css/input.css -o static/css/output.css`).
+  - [ ] **Manual smoke** (from a running dev instance — `MYBIBLI_SKIP_SETUP=1 cargo run`):
+    - `curl http://localhost:8080/` and grep for `id="stats-by-genre"`, `Par genre`, `<progress class="genre-bar"`.
+    - Verify in a browser: dark-mode toggle keeps the bar legible; clicking a row navigates to `/?filter=genre:<id>` and the search results show only that genre.
+  - [ ] **E2E** (Foundation Rule #13 — local before push): `./scripts/e2e-reset.sh && cd tests/e2e && npx playwright test specs/journeys/home.spec.ts`. If the local `tests/e2e/test-results/` is owned by root (the recurring 9-1 / 9-2 blocker), document the skip in Dev Agent Record and rely on CI.
+  - [ ] Update Dev Agent Record at the bottom of this file: list of files touched, decisions on `<progress>` styling location, anything surprising.
+  - [ ] Update `_bmad-output/implementation-artifacts/sprint-status.yaml`: flip `9-3-dashboard-stats-by-genre: backlog → ready-for-dev` (already done by the create-story step) → `in-progress` at start of dev-story → `review` at end. Update only this line + `last_updated` (CLAUDE.md rule 16).
+
+## Dev Notes
+
+### Source tree references
+
+The dev agent should not need to reinvent any of these. All paths relative to repo root.
+
+| Concern | File / location | Notes |
+|---|---|---|
+| Home route registration | `src/routes/mod.rs:87` | `.route("/", axum::routing::get(home::home))` — no change needed |
+| Home handler | `src/routes/home.rs:87-326` | extend the existing handler; do NOT create a parallel route |
+| Home template | `templates/pages/home.html` (240 lines post-9-2) | extends `layouts/base.html`; section blocks: search (14-33), filter tags (36-65), metadata error badge (67-74), `#collection-glance` (76-104), `#recent-additions` (106-141), browse toggle (143-169), `#browse-results` (171-237) |
+| Insertion point for the new section | `templates/pages/home.html` between line ~141 (closing `</section>` of `#recent-additions`) and line ~143 (`<!-- Browse toggle + sort -->`) | preserves AC1 ordering invariant: glance → recent → stats → browse |
+| Service module | `src/services/dashboard.rs` (created in 9-1) | extend with `GenreStat` + `stats_by_genre()`; `pub mod` already registered in `src/services/mod.rs` |
+| Existing service pattern | `src/services/dashboard.rs::collection_glance` (lines 37-50) | single round-trip query with `sqlx::query_as` — mirror exactly |
+| Existing genre model | `src/models/genre.rs` | `GenreModel::list_active`, `find_name_by_id`, `count_usage` — useful background but NOT called by Task 1 (the new query JOINs directly) |
+| Title schema reminder | `migrations/*.sql` `CREATE TABLE titles` | `genre_id BIGINT UNSIGNED NOT NULL` + FK to `genres(id)` — every active title has exactly one genre. The spec's "title with no genre — NOT counted" clause is therefore a forward-compat hedge; the current schema makes it impossible. Keep the JOIN form as specified — if a future migration relaxes the FK, the query stays correct. |
+| Soft-delete invariant | `src/services/dashboard.rs:37-49`, `src/models/title.rs:837-855` | every entity SELECT/JOIN must include `deleted_at IS NULL` — both halves of AC5 |
+| `is_singular` helper for plural i18n | `src/routes/home.rs:333-338` | reuse for `count_label`; do NOT duplicate |
+| Pre-translation pattern (handler-side `t!`) | `src/routes/home.rs:303-320` (glance heading + recent_additions heading) | replicate for `stats_by_genre_heading` |
+| Soft-degrade on DB error pattern | `src/routes/home.rs:167-186` (glance + recent_additions) | replicate for stats_by_genre — same `match … Ok(v) / Err(e) → tracing::warn! + Vec::new()` shape |
+| HomeTemplate struct | `src/routes/home.rs:31-85` (53 fields post-9-2) | extend with `stats_by_genre: Vec<StatsByGenreRow>`, `stats_by_genre_heading: String` |
+| Test factory & slice helpers | `src/routes/home.rs:628-651` (`slice_section`, `glance_card_slice`, `recent_additions_slice`); `src/routes/home.rs:653-745` (`make_test_home_template_with_counts`, `make_test_home_template_with_recent`, `fake_search_result`) | reuse + extend (no rewrite) |
+| i18n locales | `locales/en.yml:342-355`, `locales/fr.yml:342-355` (`dashboard:` block) | append `stats_by_genre:` sub-block after `recent_additions:` |
+| i18n audit (forces both locales to mirror) | `src/i18n/audit.rs::all_t_keys_have_both_locales` | `cargo test` enforces — keep EN + FR keys aligned exactly |
+| Templates audit (CSP enforcement) | `src/templates_audit.rs::no_inline_markup_in_templates` | must stay green |
+| Filter parsing (existing genre filter) | `src/routes/home.rs:340-352` (`parse_filter`) | the destination of the row link — `?filter=genre:<id>` |
+| `SearchService::search` (handles the filtered request when user clicks a row) | `src/services/search.rs::search` (lines 75-187) | already handles `genre_id` filter — no change needed; the row link drives the existing pipeline |
+| Test pattern (DB-backed integration) | `tests/dashboard_glance.rs` (story 9-1) and `tests/dashboard_recent_additions.rs` (story 9-2) | `#[sqlx::test(migrations = "./migrations")]` — file-local helpers; no shared `tests/common.rs` |
+| Test pattern (handler render, no DB) | `src/routes/home.rs::mod tests` (lines 612-...; the post-9-2 file has factories `make_test_home_template_with_*`) | reuse the slice + factory pattern verbatim |
+| E2E spec for `/` | `tests/e2e/specs/journeys/home.spec.ts:1-117` | extend with the new describe block AFTER 9-2's block |
+| E2E i18n-aware regex pattern | `tests/e2e/specs/journeys/home.spec.ts:36, 99` | matches both EN and FR — replicate with `/By genre|Par genre/i` |
+| CSS file | `static/css/browse.css` (existing) + `static/css/input.css` (`@theme` tokens) | extend `browse.css` with `.genre-bar` rules; use `var(--color-*)` from the `@theme` block — NO hardcoded hex values |
+| Tailwind build | `package.json`'s scripts + `static/css/output.css` | regenerate after CSS changes |
+
+### Anti-patterns to avoid
+
+- **Two SQL round-trips for count + total.** AC3 explicitly mandates one round-trip. Sum the rows Rust-side; do NOT issue a separate `SELECT COUNT(*) FROM titles …` query. (The spec's "active titles with at least one genre" denominator simplifies to "active titles" given the current `genre_id NOT NULL` FK — keep the Rust-side sum form for forward-compat with a hypothetical NULL-able future.)
+- **Inline `style="width: ...%"` on the bar.** This is the obvious-but-wrong tactic for variable-width visualizations. CSP blocks it (`src/middleware/csp.rs` strict directive — no `unsafe-inline`). Use `<progress value max>` (HTML attributes are NOT inline CSS) or pre-bucketed Tailwind classes. The story specifies `<progress>`.
+- **Linking the row to `/catalog?genre=<id>`.** The spec text says this; the actual route doesn't exist — `/catalog` is the scan page in v1. The home page `/?filter=genre:<id>` is the canonical genre-filter URL. Same convention as 9-1's "volume count → `/catalog`" deviation. Documented in AC6.
+- **Computing percentage in SQL.** The handler is the right layer for the rounding + locale formatting. Keeping SQL strictly aggregational (count, group, order) makes the function reusable for future stories that might want raw counts (e.g., a /admin/health stats panel). Single-responsibility for `stats_by_genre`: return rows, sorted, with counts.
+- **Empty-state hiding via JS / CSS.** AC4 says hide via SERVER-side `{% if %}`. JS-driven hide would briefly flash the empty section and re-trigger HTMX swap recalculation. Server-side `{% if %}` is also CSP-trivial.
+- **Calling `t!()` from inside the Askama template** for the count or heading labels. Project convention is "translate in handler, pass to template" (canonical example: `src/routes/home.rs:303-320`).
+- **Role-branched SQL.** AC7 mandates byte-identical HTML for anonymous and librarian. The query is role-agnostic. If a future story needs role-gated columns (e.g., "private genres for admin only"), branch in the handler, not in SQL — keep the model layer pure.
+- **Hardcoded colors in `browse.css` (or anywhere CSS).** AC8 mandates token-based — `var(--color-indigo-500)` not `#6366f1`. UX-DR24 compliance.
+- **Regular space `\u{0020}` instead of NBSP `\u{00A0}` in the FR percentage format.** French typography requires NBSP between number and `%` (and similarly for `:`, `;`, `?`, `!`). A regular space allows a line break between the number and the unit, which is wrong typographically and visually awful when a row wraps. The unit test `format_percent_fr_uses_nbsp` is the regression guard.
+- **Adding an unscoped `a[href^="/?filter="]` selector in the E2E.** Genre-filter pills already exist in `templates/pages/home.html:36-65` and use the same href pattern. An unscoped selector would match both, and `.first()` would be ambiguous. Always scope to `#stats-by-genre`. (This is the same flake class flagged in 9-2 Change Log 2026-04-30 for `a[href^="/title/"]`.)
+- **Zero-count rows in the rendered output.** The INNER JOIN form excludes them automatically. If you accidentally write `LEFT JOIN`, `genres` with no titles will appear as `0 titles, 0%` rows — wrong per AC2 (sorted by count desc, so they'd cluster at the bottom polluting the visualization).
+
+### Architecture compliance
+
+- **Error handling:** Any DB failure in `stats_by_genre` returns `AppError::Database` via `?`; the handler soft-degrades with `tracing::warn!` + empty `Vec` (per 9-1 / 9-2 patterns). No new `AppError` variant.
+- **Logging:** `tracing::warn!` at handler level on the soft-degrade path; `tracing::debug!` only inside the service function if needed. Counts are not interesting at info-level.
+- **DB query discipline:** `WHERE deleted_at IS NULL` on every SELECT/JOIN of entity tables (titles, genres). MariaDB type gotchas not relevant — `COUNT(t.id)` returns `BIGINT` mapped to Rust `i64` automatically by sqlx.
+- **HTMX coexistence:** The new section sits OUTSIDE `#browse-results` (HTMX swap target) — same invariant as 9-1 and 9-2. Verify by inspecting `home.html` after insert.
+- **CSP middleware:** Already wraps the handler outermost. No work needed in middleware. The `<progress>` element + class-driven CSS is fully CSP-clean.
+- **Pool access:** The handler already has `state.pool: DbPool`. Do not introduce a new connection.
+- **One-branch-one-story (Foundation Rule #14):** Verify `git status` clean + on `main` + `git pull --ff-only` before starting; cut `story/9-3-dashboard-stats-by-genre`. Open a draft PR (Rule #15) at the first commit.
+- **Source-file-size limit (Foundation Rule #12):** `src/routes/home.rs` is ~870 lines post-9-2. This story adds ~30-50 lines (handler block + 2 template fields + 5 render tests). Comfortable headroom to 2000.
+
+### Library / framework requirements
+
+- **Rust 2024 + Axum 0.8 + SQLx 0.8 (MariaDB) + Askama 0.15 + Tailwind CSS v4 + HTMX 2.0** — no version changes, no new dependencies. If you reach for a number-formatting crate (`num-format`, `unicode-segmentation`, etc.) — stop. The 4-line `if locale == "fr" { … }` branch is sufficient for v1 EN/FR scope.
+- **rust_i18n** — already wired. Pre-translate `stats_by_genre_heading` and `count_label` per row in the handler via `rust_i18n::t!(…).to_string()` + the existing `is_singular` helper. Pass as `String` fields. Canonical example: `src/routes/home.rs:303-320`.
+- **`<progress>` element semantics** — supported in all evergreen browsers. Cross-browser styling uses `appearance: none` + `::-webkit-progress-bar` / `::-webkit-progress-value` / `::-moz-progress-bar` pseudo-elements (already specified in Task 4 CSS). No JS, no polyfill.
+
+### File structure requirements
+
+| File | Action | Rough size |
+|---|---|---|
+| `src/services/dashboard.rs` | **edit** | +~25 lines (`GenreStat` struct + `stats_by_genre` fn) |
+| `src/utils.rs` | **edit** | +~15 lines (`format_percent` helper + 5 unit tests) |
+| `src/routes/home.rs` | **edit** | +~40 lines in handler + 2 new `HomeTemplate` fields + 1 inner struct (`StatsByGenreRow`) + 6 new render tests + factories |
+| `templates/pages/home.html` | **edit** | +~25 lines for the section (wrapped in `{% if !empty %}`) |
+| `static/css/browse.css` | **edit** | +~30 lines (`.genre-bar` rules, light + dark, cross-browser) |
+| `static/css/output.css` | **regenerate** | (build artefact — regenerate via Tailwind CLI after browse.css edit) |
+| `locales/en.yml` | **edit** | +~4 lines under `dashboard.stats_by_genre:` |
+| `locales/fr.yml` | **edit** | +~4 lines under `dashboard.stats_by_genre:` |
+| `tests/dashboard_stats_by_genre.rs` | **create** | ~80 lines (3 `#[sqlx::test]` cases + helpers) |
+| `tests/e2e/specs/journeys/home.spec.ts` | **edit** | +~25 lines (1 new test case in a new `describe` block) |
+| `_bmad-output/implementation-artifacts/sprint-status.yaml` | **edit** | only the `9-3-...` line + `last_updated` (CLAUDE.md rule 16) |
+| `_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md` | **edit** | this file — Status, Tasks checked, Dev Agent Record on completion |
+
+### Testing requirements
+
+- **Coverage target:** every AC has at least one test (unit OR E2E). AC8 (CSP) is covered by `templates_audit.rs::no_inline_markup_in_templates` (existing — must stay green).
+- **AC4 hide-entirely** is the load-bearing visual invariant: `home_renders_stats_by_genre_empty_section_hidden` is the regression guard. A future template edit that wraps `#stats-by-genre` in `{% if true %}` would slip past CI without this test.
+- **AC5 soft-deleted exclusion (both halves)** is the load-bearing data invariant: `stats_by_genre_orders_and_excludes_soft_deleted` covers it. Without the orphan-on-soft-deleted-genre fixture, a future migration that drops the `JOIN ... AND g.deleted_at IS NULL` half would silently leak orphans.
+- **AC6 link target** is verified by the E2E (`waitForURL(/\/\?filter=genre:\d+/)`) — the URL pattern lock is what guarantees the route compatibility with `parse_filter`.
+- **AC9 NBSP** is the load-bearing typography invariant: `format_percent_fr_uses_nbsp` (byte-level assertion on `\u{00A0}`) prevents accidental degradation to a regular space.
+- **AC10f document-order** is the load-bearing layout invariant: `home_renders_recent_additions_above_stats_by_genre` prevents the same kind of cross-section ordering regression that 9-2's review caught (`home_renders_glance_above_recent_additions`).
+- **E2E** keeps to 1 anonymous test for parsimony — the section is role-agnostic per AC7; a librarian variant would only re-test what the unit tests already cover.
+
+### Project structure notes
+
+This story aligns cleanly with the existing structure. Three intentional decisions worth flagging:
+
+1. **`<progress>` over a custom div+span bar.** `<progress>` is the semantic, accessible, CSP-clean primitive for "X out of Y" visualizations. Browsers announce it correctly to screen readers (UX-DR23 / accessibility). Custom CSS via pseudo-elements is fully CSP-compatible. The alternative (discretized Tailwind width buckets) is more code for less semantics.
+
+2. **`format_percent` lives in `src/utils.rs`, not in `src/routes/home.rs`.** The utility shape (pure function, no state, no async) matches the existing `html_escape` / `url_encode` / `current_url` neighbors. If a future story (e.g., 9-7 indicator percentages, 9-22 a11y audit metrics) needs locale-aware percentage formatting, it gets the helper for free without an import dance.
+
+3. **`StatsByGenreRow` lives in `src/routes/home.rs`, not in a new module.** It is a presentation-layer struct that pairs SQL output with pre-translated labels — coupled to `HomeTemplate`. Splitting it out would add an indirection without callers. If a future story extracts the dashboard rendering into its own module (`src/routes/dashboard.rs`?), this struct moves with the rest.
+
+The deferred TitleCard partial extraction (filed by 9-2) is **NOT** revisited here. The genre-row markup is structurally different (a full-width row with a bar, no cover) so it does not duplicate the TitleCard. No new follow-up issues planned for this story unless review uncovers something.
+
+## References
+
+- [Story 9.3 spec — `_bmad-output/planning-artifacts/epics.md` lines 1242–1257](../planning-artifacts/epics.md)
+- [Epic 9 scope note + split philosophy — `epics.md` lines 1200–1206](../planning-artifacts/epics.md)
+- [PRD FR57 — `_bmad-output/planning-artifacts/prd.md`](../planning-artifacts/prd.md) (search for `FR57`)
+- [UX-DR24 design tokens — `_bmad-output/planning-artifacts/epics.md:242` + `_bmad-output/planning-artifacts/ux-design-specification.md:403, 2654`](../planning-artifacts/ux-design-specification.md)
+- [Story 9-1 spec (canonical patterns: handler-side i18n, single round-trip, soft-degrade, slice helper for scoped tests, `is_singular` locale-aware plural helper) — `9-1-dashboard-global-stats-card.md`](./9-1-dashboard-global-stats-card.md)
+- [Story 9-2 spec (canonical patterns: empty-state inline rendering, `slice_section` helper, document-order test, `fake_search_result` factory, sibling test file, deferred unscoped-selector flake class) — `9-2-dashboard-recent-additions.md`](./9-2-dashboard-recent-additions.md)
+- [`CLAUDE.md` — Foundation Rules (#1 DRY, #7 E2E smoke per epic, #11 GitHub Issues, #12 ≤ 2000 LOC, #13 local testing, #14 one-branch-one-story, #15 draft PR, #16 sprint-status ownership, #18 CI gating)](../../CLAUDE.md)
+- [Tailwind v4 `@theme` tokens — `static/css/input.css:1-76`](../../static/css/input.css)
+- [Existing genre filter URL pattern — `src/routes/home.rs:340-352` (`parse_filter`)](../../src/routes/home.rs)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-04-30 # Story 9-2 review complete — review → done. Code review: 1 High (unstyled cards — `recent-additions-list` parent class didn't trigger `.browse-list .title-card-*` rules; fixed to `browse-list mt-3`) + 3 Medium patches (empty-state test scoping, AC1 ordering test) applied; 4 deferred (GH Issues to be filed); 4 dismissed. Final 631 lib tests + 3 dashboard_recent_additions integration tests, all green. Earlier 2026-04-30: Story 9-2 implementation + selector-regression fix (PR #105), Story 9-1 done + 2 GH issues filed (#103/#104), Epic 9 sprint planning (PR #101), Epic 8 close.
+last_updated: 2026-05-01 # Story 9-3 created (backlog → ready-for-dev) — comprehensive spec for dashboard stats-by-genre section: single round-trip GROUP BY, INNER JOIN naturally excludes empty/soft-deleted genres (AC4/AC5), `<progress>` element for CSP-clean variable-width bar (UX-DR24 tokens via @theme vars), locale-aware percentage formatting (FR uses NBSP + comma decimal), row-link targets `/?filter=genre:<id>` (existing route, NOT the spec's `/catalog?genre=` which doesn't exist — same convention as 9-1's volume-link deviation), 5 handler render tests including document-order + anonymous/librarian byte-identity locks, format_percent helper in src/utils.rs with NBSP regression test. Earlier 2026-04-30: Story 9-2 review complete — review → done; Story 9-1 done + 2 GH issues filed (#103/#104), Epic 9 sprint planning (PR #101), Epic 8 close.
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -165,7 +165,7 @@ development_status:
   epic-9: in-progress
   9-1-dashboard-global-stats-card: done
   9-2-dashboard-recent-additions: done
-  9-3-dashboard-stats-by-genre: backlog
+  9-3-dashboard-stats-by-genre: ready-for-dev
   9-4-filtertag-and-unshelved-indicator: backlog
   9-5-overdue-loans-indicator: backlog
   9-6-series-with-gaps-indicator: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-05-01 # Story 9-3 created (backlog → ready-for-dev) — comprehensive spec for dashboard stats-by-genre section: single round-trip GROUP BY, INNER JOIN naturally excludes empty/soft-deleted genres (AC4/AC5), `<progress>` element for CSP-clean variable-width bar (UX-DR24 tokens via @theme vars), locale-aware percentage formatting (FR uses NBSP + comma decimal), row-link targets `/?filter=genre:<id>` (existing route, NOT the spec's `/catalog?genre=` which doesn't exist — same convention as 9-1's volume-link deviation), 5 handler render tests including document-order + anonymous/librarian byte-identity locks, format_percent helper in src/utils.rs with NBSP regression test. Earlier 2026-04-30: Story 9-2 review complete — review → done; Story 9-1 done + 2 GH issues filed (#103/#104), Epic 9 sprint planning (PR #101), Epic 8 close.
+last_updated: 2026-05-01 # Story 9-3 dev-story complete (in-progress → review). 7 tasks shipped: services::dashboard::stats_by_genre + GenreStat (1 INNER JOIN GROUP BY round-trip), src/utils.rs::format_percent helper with 7 unit tests (incl. byte-level NBSP guard for FR typography), HomeTemplate extension + build_stats_by_genre_rows helper + soft-degrade on DB error, AC4 hide-entirely template gating, <progress class="genre-bar"> CSS in browse.css using @theme tokens (UX-DR24, no hardcoded hex), EN+FR i18n, 3 sqlx integration tests (empty DB, ordering+soft-delete-both-halves, single-genre full share) + 5 handler render tests (incl. document-order lock + AC7 anonymous-byte-identity + FR-NBSP), 1 E2E test scoped to #stats-by-genre. 643 lib tests, all green; clippy clean; sqlx cache unchanged. Spec creation earlier today: single round-trip GROUP BY, INNER JOIN naturally excludes empty/soft-deleted genres (AC4/AC5), `<progress>` element for CSP-clean variable-width bar (UX-DR24 tokens via @theme vars), locale-aware percentage formatting (FR uses NBSP + comma decimal), row-link targets `/?filter=genre:<id>` (existing route, NOT the spec's `/catalog?genre=` which doesn't exist — same convention as 9-1's volume-link deviation), 5 handler render tests including document-order + anonymous/librarian byte-identity locks, format_percent helper in src/utils.rs with NBSP regression test. Earlier 2026-04-30: Story 9-2 review complete — review → done; Story 9-1 done + 2 GH issues filed (#103/#104), Epic 9 sprint planning (PR #101), Epic 8 close.
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -165,7 +165,7 @@ development_status:
   epic-9: in-progress
   9-1-dashboard-global-stats-card: done
   9-2-dashboard-recent-additions: done
-  9-3-dashboard-stats-by-genre: ready-for-dev
+  9-3-dashboard-stats-by-genre: review
   9-4-filtertag-and-unshelved-indicator: backlog
   9-5-overdue-loans-indicator: backlog
   9-6-series-with-gaps-indicator: backlog

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -353,6 +353,10 @@ dashboard:
   recent_additions:
     heading: Recent additions
     empty_state: "No recent additions yet — start cataloging!"
+  stats_by_genre:
+    heading: By genre
+    titles_one: "%{count} title"
+    titles_other: "%{count} titles"
 borrower:
   list_title: Borrowers
   add: Add borrower

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -353,6 +353,10 @@ dashboard:
   recent_additions:
     heading: Ajouts récents
     empty_state: "Pas encore d'ajouts récents — commencez à cataloguer !"
+  stats_by_genre:
+    heading: Par genre
+    titles_one: "%{count} titre"
+    titles_other: "%{count} titres"
 borrower:
   list_title: Emprunteurs
   add: Ajouter un emprunteur

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -82,6 +82,24 @@ pub struct HomeTemplate {
     pub recent_additions: Vec<crate::models::title::SearchResult>,
     pub recent_additions_heading: String,
     pub recent_additions_empty: String,
+    // "By genre" section (story 9-3) — empty Vec → section hidden entirely (AC4).
+    pub stats_by_genre: Vec<StatsByGenreRow>,
+    pub stats_by_genre_heading: String,
+}
+
+/// One row of the "By genre" dashboard section (story 9-3).
+///
+/// Pairs the SQL-emitted `GenreStat` with the pre-translated, locale-
+/// formatted labels that the Askama template renders verbatim. The
+/// `value`/`max` pair drives the `<progress>` bar's HTML attributes —
+/// CSP-clean variable-width visualization without inline `style=`.
+pub struct StatsByGenreRow {
+    pub id: u64,
+    pub name: String,
+    pub count_label: String,   // pre-translated, e.g. "12 titles" / "12 titres"
+    pub percent_label: String, // locale-formatted, e.g. "33.3%" / "33,3 %"
+    pub value: i64,            // <progress value="...">
+    pub max: i64,              // <progress max="...">
 }
 
 pub async fn home(
@@ -184,6 +202,18 @@ pub async fn home(
             Vec::new()
         }
     };
+
+    // "By genre" section — single GROUP BY round-trip (story 9-3). Same
+    // soft-degrade pattern: a transient DB hiccup yields an empty Vec,
+    // which the template renders as a hidden section per AC4.
+    let stats_rows = match crate::services::dashboard::stats_by_genre(pool).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(error = %e, "stats_by_genre failed; rendering empty section");
+            Vec::new()
+        }
+    };
+    let stats_by_genre = build_stats_by_genre_rows(stats_rows, loc);
 
     // Choose `_one` vs `_other` for each count. Inline if/else so the macro receives
     // a literal key (matching the project's i18n audit at `src/i18n/audit.rs`),
@@ -318,6 +348,9 @@ pub async fn home(
             locale = loc
         )
         .to_string(),
+        stats_by_genre,
+        stats_by_genre_heading: rust_i18n::t!("dashboard.stats_by_genre.heading", locale = loc)
+            .to_string(),
     };
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
@@ -335,6 +368,59 @@ fn is_singular(locale: &str, count: i64) -> bool {
         "fr" => count == 0 || count == 1,
         _ => count == 1,
     }
+}
+
+/// Transform raw `GenreStat` rows into presentation-ready dashboard rows
+/// (story 9-3). The total denominator is the row sum — single SQL
+/// round-trip per AC3, no extra SELECT.
+///
+/// Per-row computation:
+/// - `percent` is `(count / total) * 100` rounded to one decimal place.
+///   When `total == 0` (defensive — shouldn't happen since INNER JOIN
+///   excludes empty genres) we fall back to `0.0` rather than risk a
+///   `NaN` from division.
+/// - `count_label` and `percent_label` are pre-translated locale-aware
+///   strings; the Askama template renders them verbatim. This stays
+///   consistent with the project pattern (see 9-1's `is_singular` +
+///   literal `t!()` keys; canonical example at `src/routes/home.rs`'s
+///   glance-label construction).
+fn build_stats_by_genre_rows(
+    rows: Vec<crate::services::dashboard::GenreStat>,
+    loc: &str,
+) -> Vec<StatsByGenreRow> {
+    let total: i64 = rows.iter().map(|r| r.title_count).sum();
+    rows.into_iter()
+        .map(|r| {
+            let percent = if total > 0 {
+                ((r.title_count as f64 / total as f64) * 1000.0).round() / 10.0
+            } else {
+                0.0
+            };
+            let count_label = if is_singular(loc, r.title_count) {
+                rust_i18n::t!(
+                    "dashboard.stats_by_genre.titles_one",
+                    locale = loc,
+                    count = r.title_count
+                )
+                .to_string()
+            } else {
+                rust_i18n::t!(
+                    "dashboard.stats_by_genre.titles_other",
+                    locale = loc,
+                    count = r.title_count
+                )
+                .to_string()
+            };
+            StatsByGenreRow {
+                id: r.id,
+                name: r.name,
+                count_label,
+                percent_label: crate::utils::format_percent(percent, loc),
+                value: r.title_count,
+                max: total,
+            }
+        })
+        .collect()
 }
 
 fn parse_filter(filter: &Option<String>) -> (Option<u64>, Option<String>) {
@@ -650,6 +736,11 @@ mod tests {
         slice_section(html, "recent-additions")
     }
 
+    /// Story 9-3 helper — scope assertions to the stats-by-genre section.
+    fn stats_by_genre_slice(html: &str) -> &str {
+        slice_section(html, "stats-by-genre")
+    }
+
     fn make_test_home_template_with_counts(
         role: &str,
         loans_link_visible: bool,
@@ -712,6 +803,8 @@ mod tests {
             recent_additions: Vec::new(),
             recent_additions_heading: "Recent additions".to_string(),
             recent_additions_empty: "No recent additions yet — start cataloging!".to_string(),
+            stats_by_genre: Vec::new(),
+            stats_by_genre_heading: "By genre".to_string(),
         }
     }
 
@@ -741,6 +834,41 @@ mod tests {
             volume_count: 1,
             cover_image_url: None,
             publication_date: None,
+        }
+    }
+
+    /// Story 9-3 — build a HomeTemplate with a populated `stats_by_genre`
+    /// list. Reuses the counts factory so glance / recent-additions
+    /// assertions remain possible. The `lang` field can be flipped after
+    /// construction for FR-formatting tests.
+    fn make_test_home_template_with_stats(
+        role: &str,
+        stats: Vec<StatsByGenreRow>,
+    ) -> HomeTemplate {
+        let mut t = make_test_home_template_with_counts(role, false, 5, 8, 2);
+        t.stats_by_genre = stats;
+        t.stats_by_genre_heading = "By genre".to_string();
+        t
+    }
+
+    /// Story 9-3 — deterministic row factory for handler render tests.
+    /// Caller controls every visible field so assertions can pin exact
+    /// strings without running the locale formatter.
+    fn fake_genre_stat_row(
+        id: u64,
+        name: &str,
+        count_label: &str,
+        percent_label: &str,
+        value: i64,
+        max: i64,
+    ) -> StatsByGenreRow {
+        StatsByGenreRow {
+            id,
+            name: name.to_string(),
+            count_label: count_label.to_string(),
+            percent_label: percent_label.to_string(),
+            value,
+            max,
         }
     }
 
@@ -997,5 +1125,160 @@ mod tests {
     fn is_singular_unknown_locale_falls_back_to_english_rule() {
         assert!(!is_singular("de", 0), "unknown locale: 0 → plural (EN fallback)");
         assert!(is_singular("de", 1), "unknown locale: 1 → singular");
+    }
+
+    // ─── Story 9-3 — Stats by genre render tests ──────────────────────
+
+    /// AC10d — populated case. Section appears with three rows in input
+    /// order; each row carries the genre name, count label, and EN
+    /// percentage label. Assertions are scoped to the `#stats-by-genre`
+    /// slice so a same-string match elsewhere on the page (e.g., a genre
+    /// name in the filter pills) cannot mask a regression.
+    #[test]
+    fn home_renders_stats_by_genre_with_three_rows() {
+        let stats = vec![
+            fake_genre_stat_row(1, "Roman", "12 titles", "60.0%", 12, 20),
+            fake_genre_stat_row(2, "BD", "5 titles", "25.0%", 5, 20),
+            fake_genre_stat_row(3, "Essai", "3 titles", "15.0%", 3, 20),
+        ];
+        let template = make_test_home_template_with_stats("anonymous", stats);
+        let html = template.render().expect("render");
+        let slice = stats_by_genre_slice(&html);
+
+        // Section + heading visible.
+        assert!(slice.contains("id=\"stats-by-genre-heading\""));
+        assert!(slice.contains("By genre"));
+
+        // Each row contributes its name, count, and percentage to the slice.
+        for (name, count, pct, link) in [
+            ("Roman", "12 titles", "60.0%", "/?filter=genre:1"),
+            ("BD", "5 titles", "25.0%", "/?filter=genre:2"),
+            ("Essai", "3 titles", "15.0%", "/?filter=genre:3"),
+        ] {
+            assert!(slice.contains(name), "row for {name} must appear in slice");
+            assert!(slice.contains(count), "count {count} for {name} must appear");
+            assert!(slice.contains(pct), "percent {pct} for {name} must appear");
+            assert!(
+                slice.contains(&format!("href=\"{link}\"")),
+                "row link {link} for {name} must point at /?filter=genre:<id>"
+            );
+        }
+
+        // <progress> bar carries semantic value/max attributes (CSP-clean
+        // alternative to inline width=...; AC8).
+        assert!(slice.contains("<progress"));
+        assert!(slice.contains("value=\"12\""));
+        assert!(slice.contains("max=\"20\""));
+
+        // Document order inside the slice — Roman before BD before Essai.
+        let pos_roman = slice.find("Roman").expect("Roman row position");
+        let pos_bd = slice.find("BD").expect("BD row position");
+        let pos_essai = slice.find("Essai").expect("Essai row position");
+        assert!(pos_roman < pos_bd && pos_bd < pos_essai);
+    }
+
+    /// AC4 — empty Vec means the entire `<section id="stats-by-genre">` is
+    /// NOT emitted. A future regression that wraps the section in
+    /// `{% if true %}` would slip past the populated test; only this one
+    /// catches it.
+    #[test]
+    fn home_renders_stats_by_genre_empty_section_hidden() {
+        let template = make_test_home_template_with_stats("anonymous", vec![]);
+        let html = template.render().expect("render");
+
+        assert!(
+            !html.contains("id=\"stats-by-genre\""),
+            "empty stats_by_genre Vec must hide the section entirely (AC4)"
+        );
+        assert!(
+            !html.contains("id=\"stats-by-genre-heading\""),
+            "empty stats_by_genre Vec must not emit the heading either"
+        );
+    }
+
+    /// AC10f — `#recent-additions` (story 9-2) must render BEFORE
+    /// `#stats-by-genre` (story 9-3) in document order. Mirrors the 9-2
+    /// review-fix `home_renders_glance_above_recent_additions` invariant
+    /// and prevents the same kind of silent template re-ordering.
+    #[test]
+    fn home_renders_recent_additions_above_stats_by_genre() {
+        let mut template = make_test_home_template_with_stats(
+            "anonymous",
+            vec![fake_genre_stat_row(1, "Roman", "1 title", "100.0%", 1, 1)],
+        );
+        // Force `recent_additions` to be non-empty so the section renders.
+        template.recent_additions = vec![fake_search_result(42, "Sample Title")];
+        let html = template.render().expect("render");
+
+        let recent_pos = html
+            .find("id=\"recent-additions\"")
+            .expect("recent-additions section must be rendered");
+        let stats_pos = html
+            .find("id=\"stats-by-genre\"")
+            .expect("stats-by-genre section must be rendered");
+        assert!(
+            recent_pos < stats_pos,
+            "AC1: recent-additions ({recent_pos}) must appear before stats-by-genre ({stats_pos})"
+        );
+    }
+
+    /// AC7 — the rendered `#stats-by-genre` slice is byte-identical for
+    /// anonymous and librarian roles. No role-gated columns, no
+    /// conditional markup. If a future story adds e.g. an admin-only
+    /// "delete genre" affordance to a row, this test will fail and force
+    /// the dev to either lift it out of the section or branch in the
+    /// handler (not in SQL — keeping the model role-agnostic per AC7).
+    #[test]
+    fn home_stats_by_genre_byte_identical_for_anonymous_and_librarian() {
+        let stats = || {
+            vec![
+                fake_genre_stat_row(1, "Roman", "12 titles", "60.0%", 12, 20),
+                fake_genre_stat_row(2, "BD", "5 titles", "25.0%", 5, 20),
+            ]
+        };
+        let html_anon = make_test_home_template_with_stats("anonymous", stats())
+            .render()
+            .expect("render anon");
+        let html_lib = make_test_home_template_with_stats("librarian", stats())
+            .render()
+            .expect("render librarian");
+
+        assert_eq!(
+            stats_by_genre_slice(&html_anon),
+            stats_by_genre_slice(&html_lib),
+            "AC7: stats-by-genre slice must be identical across roles"
+        );
+    }
+
+    /// AC9 — French formatting uses comma decimal separator + NBSP before
+    /// `%`. The test feeds pre-formatted FR labels through the template;
+    /// `format_percent` itself is unit-tested in `src/utils.rs`. The
+    /// invariants checked here: (a) the FR percent string makes it into
+    /// the rendered HTML unaltered, (b) the EN-style `33.3%` does NOT
+    /// leak (catches a future "let's strip diacritics for safety"
+    /// refactor that would silently break FR typography).
+    #[test]
+    fn home_renders_stats_by_genre_french_uses_nbsp_and_comma() {
+        let stats = vec![
+            fake_genre_stat_row(1, "Roman", "12 titres", "60,0\u{00A0}%", 12, 20),
+            fake_genre_stat_row(2, "BD", "8 titres", "40,0\u{00A0}%", 8, 20),
+        ];
+        let mut template = make_test_home_template_with_stats("anonymous", stats);
+        template.lang = "fr".to_string();
+        template.stats_by_genre_heading = "Par genre".to_string();
+        let html = template.render().expect("render");
+        let slice = stats_by_genre_slice(&html);
+
+        // FR percentages with comma + NBSP appear verbatim.
+        assert!(
+            slice.contains("60,0\u{00A0}%"),
+            "expected FR percent '60,0 %' (comma + NBSP) in slice; got:\n{slice}"
+        );
+        assert!(slice.contains("40,0\u{00A0}%"));
+        // EN form must not leak.
+        assert!(
+            !slice.contains("60.0%"),
+            "EN-style '60.0%' must not appear when FR labels are passed"
+        );
     }
 }

--- a/src/services/dashboard.rs
+++ b/src/services/dashboard.rs
@@ -49,6 +49,49 @@ pub async fn collection_glance(pool: &DbPool) -> Result<CollectionGlance, AppErr
     Ok(glance)
 }
 
+/// One row of the home-page "By genre" section (story 9-3).
+///
+/// Carries only the SQL-emitted fields (id, name, count). The percentage
+/// and locale-formatted labels are computed in the route handler — keeping
+/// the model layer free of presentation concerns means a future caller
+/// (e.g., an admin stats panel) can reuse the raw counts without ripping
+/// out FR/EN formatting.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct GenreStat {
+    pub id: u64,
+    pub name: String,
+    pub title_count: i64,
+}
+
+/// Aggregate active title counts per genre, sorted for display.
+///
+/// Single SQL round-trip with `INNER JOIN`: a genre with zero active
+/// titles is naturally excluded (no `LEFT JOIN`-induced 0-count rows),
+/// so AC4's "no genres assigned → section hidden" falls out of the query
+/// shape — an empty DB returns `Vec::new()`. Both halves of the soft-
+/// delete invariant (AC5) are load-bearing: `t.deleted_at IS NULL`
+/// excludes trashed titles, `g.deleted_at IS NULL` keeps an orphan FK
+/// (titles still pointing at a soft-deleted genre) from leaking.
+///
+/// Ordering: `title_count DESC` puts the biggest genres on top
+/// (presentation goal); the secondary `g.name ASC` tiebreak keeps the
+/// row order deterministic across runs (and across deployments where
+/// MariaDB's default ordering of equal `COUNT(*)` would otherwise be
+/// implementation-defined).
+pub async fn stats_by_genre(pool: &DbPool) -> Result<Vec<GenreStat>, AppError> {
+    let rows: Vec<GenreStat> = sqlx::query_as(
+        "SELECT g.id, g.name, COUNT(t.id) AS title_count \
+           FROM titles t \
+           JOIN genres g ON t.genre_id = g.id AND g.deleted_at IS NULL \
+          WHERE t.deleted_at IS NULL \
+          GROUP BY g.id, g.name \
+          ORDER BY title_count DESC, g.name ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,6 +38,25 @@ pub fn html_escape(s: &str) -> String {
         .replace('\'', "&#x27;")
 }
 
+/// Locale-aware percentage formatter (story 9-3).
+///
+/// EN: `"33.3%"` — period decimal, no space before `%`.
+/// FR: `"33,3 %"` with a non-breaking space (`U+00A0`) before the `%` —
+/// French typography requires NBSP between a number and any unit, not a
+/// regular space (which would allow a line break between the number and
+/// the unit). The `_uses_nbsp` test guards against that silent regression.
+///
+/// One decimal is always emitted (`100.0%`, never `100%`) for visual row
+/// alignment; the dashboard rows scan more cleanly when the decimals line
+/// up. Other locales fall back to the EN format until v2 broadens i18n.
+pub fn format_percent(value: f64, locale: &str) -> String {
+    let s = format!("{:.1}", value);
+    match locale {
+        "fr" => format!("{}\u{00A0}%", s.replace('.', ",")),
+        _ => format!("{}%", s),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +134,69 @@ mod tests {
     #[test]
     fn test_html_escape_empty() {
         assert_eq!(html_escape(""), "");
+    }
+
+    #[test]
+    fn format_percent_en_basic() {
+        assert_eq!(format_percent(33.3, "en"), "33.3%");
+    }
+
+    #[test]
+    fn format_percent_fr_basic() {
+        assert_eq!(format_percent(33.3, "fr"), "33,3\u{00A0}%");
+    }
+
+    /// AC9 NBSP invariant: French typography requires `U+00A0` between the
+    /// digit run and the `%` sign (not a regular U+0020 space). A future
+    /// "simplification" that swaps `\u{00A0}` for a regular space would
+    /// allow visual line-wrap between the number and the unit — wrong.
+    #[test]
+    fn format_percent_fr_uses_nbsp() {
+        let s = format_percent(50.0, "fr");
+        let bytes = s.as_bytes();
+        // The character before the trailing '%' must be NBSP (U+00A0,
+        // encoded as 2 bytes 0xC2 0xA0 in UTF-8), NOT a regular space.
+        let pct_pos = s.rfind('%').expect("percent sign present");
+        // pct_pos is a byte index pointing at '%'; the two preceding bytes
+        // are the UTF-8 encoding of NBSP.
+        assert!(
+            pct_pos >= 2,
+            "string too short to carry NBSP before '%': {s:?}"
+        );
+        assert_eq!(
+            &bytes[pct_pos - 2..pct_pos],
+            &[0xC2, 0xA0],
+            "expected NBSP (0xC2 0xA0) immediately before '%' in {s:?}"
+        );
+        // Negative assertion: the byte right before '%' must NOT be a
+        // regular ASCII space (0x20) — proves the previous assertion is
+        // not satisfied accidentally by some other 2-byte sequence.
+        assert_ne!(bytes[pct_pos - 1], 0x20);
+    }
+
+    #[test]
+    fn format_percent_one_decimal_kept_en() {
+        assert_eq!(format_percent(100.0, "en"), "100.0%");
+        assert_eq!(format_percent(0.0, "en"), "0.0%");
+    }
+
+    #[test]
+    fn format_percent_one_decimal_kept_fr() {
+        assert_eq!(format_percent(100.0, "fr"), "100,0\u{00A0}%");
+    }
+
+    #[test]
+    fn format_percent_rounds_to_one_decimal() {
+        // 1/3 → 33.333... → 33.3
+        assert_eq!(format_percent((1.0 / 3.0) * 100.0, "en"), "33.3%");
+        // 2/3 → 66.666... → 66.7
+        assert_eq!(format_percent((2.0 / 3.0) * 100.0, "en"), "66.7%");
+        assert_eq!(format_percent((2.0 / 3.0) * 100.0, "fr"), "66,7\u{00A0}%");
+    }
+
+    #[test]
+    fn format_percent_unknown_locale_falls_back_to_en() {
+        assert_eq!(format_percent(42.5, "de"), "42.5%");
+        assert_eq!(format_percent(42.5, ""), "42.5%");
     }
 }

--- a/static/css/browse.css
+++ b/static/css/browse.css
@@ -150,3 +150,36 @@
 .tree-margin-7 { margin-left: 224px; }
 .tree-margin-8,
 .tree-margin-cap { margin-left: 256px; }
+
+/* Story 9-3 — Stats-by-genre horizontal bar.
+   <progress> uses cross-browser pseudo-elements; values come from the
+   @theme tokens in static/css/input.css (UX-DR24 — no hardcoded colors). */
+progress.genre-bar {
+    appearance: none;
+    -webkit-appearance: none;
+    height: 6px;
+    border: none;
+    border-radius: 3px;
+    background-color: var(--color-stone-200);
+    overflow: hidden;
+}
+progress.genre-bar::-webkit-progress-bar {
+    background-color: var(--color-stone-200);
+    border-radius: 3px;
+}
+progress.genre-bar::-webkit-progress-value {
+    background-color: var(--color-indigo-500);
+    border-radius: 3px;
+}
+progress.genre-bar::-moz-progress-bar {
+    background-color: var(--color-indigo-500);
+    border-radius: 3px;
+}
+.dark progress.genre-bar,
+.dark progress.genre-bar::-webkit-progress-bar {
+    background-color: var(--color-stone-700);
+}
+.dark progress.genre-bar::-webkit-progress-value,
+.dark progress.genre-bar::-moz-progress-bar {
+    background-color: var(--color-indigo-400);
+}

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -140,6 +140,33 @@
         {% endif %}
     </section>
 
+    {# Stats by genre section (story 9-3). Sits between #recent-additions and
+       the browse controls so it survives HTMX search swaps. Hidden entirely
+       when the catalog has zero genre assignments (AC4) — broader empty-
+       catalog UX moves to StatusMessage in story 9-15. The row link targets
+       /?filter=genre:<id> (existing genre-filter route via parse_filter),
+       NOT /catalog?genre=<id> (the spec text refers to a v1 route that
+       doesn't exist — same convention as 9-1's /catalog?view=volumes
+       deviation). #}
+    {% if !stats_by_genre.is_empty() %}
+    <section id="stats-by-genre" aria-labelledby="stats-by-genre-heading" class="w-full max-w-4xl mt-6">
+        <h2 id="stats-by-genre-heading" class="text-sm font-medium text-stone-600 dark:text-stone-400 uppercase tracking-wide">{{ stats_by_genre_heading }}</h2>
+        <ul class="mt-3 space-y-2">
+            {% for row in stats_by_genre %}
+            <li>
+                <a href="/?filter=genre:{{ row.id }}" class="block px-4 py-3 bg-stone-50 dark:bg-stone-800 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-lg border border-stone-200 dark:border-stone-700 transition-colors">
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="font-medium text-stone-900 dark:text-stone-100 truncate">{{ row.name }}</span>
+                        <span class="text-sm text-stone-600 dark:text-stone-400 whitespace-nowrap"><span class="tabular-nums">{{ row.count_label }}</span> · <span class="tabular-nums">{{ row.percent_label }}</span></span>
+                    </div>
+                    <progress class="genre-bar mt-2 w-full" value="{{ row.value }}" max="{{ row.max }}" aria-label="{{ row.percent_label }}">{{ row.percent_label }}</progress>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+
     <!-- Browse toggle + sort -->
     <div class="w-full max-w-4xl mt-6 flex items-center justify-between">
         <div class="flex items-center gap-2">

--- a/tests/dashboard_stats_by_genre.rs
+++ b/tests/dashboard_stats_by_genre.rs
@@ -1,0 +1,145 @@
+//! DB-backed tests for `services::dashboard::stats_by_genre` (story 9-3).
+//!
+//! Locks in the soft-delete invariants for the home-page "By genre"
+//! dashboard section. `stats_by_genre_orders_and_excludes_soft_deleted`
+//! is the regression guard for AC5 — both halves: (a) soft-deleted titles
+//! must not contribute to a genre's count; (b) soft-deleted genres must
+//! be excluded entirely, even when active titles still hold an orphan FK.
+//!
+//! The empty-DB case (`stats_by_genre_on_empty_db_returns_empty_vec`) is
+//! the regression guard for AC4: an empty `Vec` here lets the route handler
+//! hide the section via `{% if !stats_by_genre.is_empty() %}` without a
+//! second SQL round-trip.
+//!
+//! To run locally:
+//!
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test dashboard_stats_by_genre
+
+use mybibli::services::dashboard::{stats_by_genre, GenreStat};
+use sqlx::MySqlPool;
+
+async fn insert_genre(pool: &MySqlPool, name: &str) -> u64 {
+    let r = sqlx::query("INSERT INTO genres (name) VALUES (?)")
+        .bind(name)
+        .execute(pool)
+        .await
+        .expect("insert genre");
+    r.last_insert_id()
+}
+
+async fn insert_title_in_genre(pool: &MySqlPool, title: &str, genre_id: u64) -> u64 {
+    let r = sqlx::query(
+        "INSERT INTO titles (title, language, media_type, genre_id) VALUES (?, 'fr', 'book', ?)",
+    )
+    .bind(title)
+    .bind(genre_id)
+    .execute(pool)
+    .await
+    .expect("insert title");
+    r.last_insert_id()
+}
+
+async fn soft_delete(pool: &MySqlPool, table: &str, id: u64) {
+    let sql = format!("UPDATE {table} SET deleted_at = NOW() WHERE id = ?");
+    sqlx::query(&sql)
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("soft delete");
+}
+
+/// Wipe the seeded reference data so test assertions can talk about
+/// genre rows without coordinating with the bootstrap migration. Keeps
+/// each test hermetic: a fresh DB has zero `genres`, the test inserts
+/// exactly what it needs, then asserts on the full result set.
+async fn wipe_seeded_genres(pool: &MySqlPool) {
+    sqlx::query("DELETE FROM titles")
+        .execute(pool)
+        .await
+        .expect("wipe titles");
+    sqlx::query("DELETE FROM genres")
+        .execute(pool)
+        .await
+        .expect("wipe genres");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn stats_by_genre_on_empty_db_returns_empty_vec(pool: MySqlPool) {
+    wipe_seeded_genres(&pool).await;
+
+    let rows: Vec<GenreStat> = stats_by_genre(&pool).await.expect("query ok");
+    assert!(
+        rows.is_empty(),
+        "empty DB must yield empty Vec, got {} rows",
+        rows.len()
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn stats_by_genre_orders_and_excludes_soft_deleted(pool: MySqlPool) {
+    // Hermetic baseline — drop seeded data and rebuild from scratch so the
+    // assertions can name expected counts exactly.
+    wipe_seeded_genres(&pool).await;
+
+    // Genre A: 3 active titles
+    let g_a = insert_genre(&pool, "Z-9-3-A").await;
+    insert_title_in_genre(&pool, "A-1", g_a).await;
+    insert_title_in_genre(&pool, "A-2", g_a).await;
+    insert_title_in_genre(&pool, "A-3", g_a).await;
+
+    // Genre B: 2 active titles
+    let g_b = insert_genre(&pool, "Z-9-3-B").await;
+    insert_title_in_genre(&pool, "B-1", g_b).await;
+    insert_title_in_genre(&pool, "B-2", g_b).await;
+
+    // Genre C: 1 active + 2 soft-deleted titles → expected count 1
+    let g_c = insert_genre(&pool, "Z-9-3-C").await;
+    insert_title_in_genre(&pool, "C-1", g_c).await;
+    let c2 = insert_title_in_genre(&pool, "C-2-soft", g_c).await;
+    let c3 = insert_title_in_genre(&pool, "C-3-soft", g_c).await;
+    soft_delete(&pool, "titles", c2).await;
+    soft_delete(&pool, "titles", c3).await;
+
+    // Genre D: 5 active titles, but the genre itself is soft-deleted
+    // (orphan FK case) → must NOT appear in the result at all.
+    let g_d = insert_genre(&pool, "Z-9-3-D").await;
+    for i in 1..=5 {
+        insert_title_in_genre(&pool, &format!("D-{i}"), g_d).await;
+    }
+    soft_delete(&pool, "genres", g_d).await;
+
+    let rows: Vec<GenreStat> = stats_by_genre(&pool).await.expect("query ok");
+
+    // AC2 + AC5: exactly three rows (D excluded), in count-desc order.
+    assert_eq!(rows.len(), 3, "expected 3 rows, got {rows:#?}");
+    assert_eq!(rows[0].name, "Z-9-3-A");
+    assert_eq!(rows[0].title_count, 3);
+    assert_eq!(rows[1].name, "Z-9-3-B");
+    assert_eq!(rows[1].title_count, 2);
+    assert_eq!(rows[2].name, "Z-9-3-C");
+    assert_eq!(rows[2].title_count, 1);
+
+    // Defensive: no row for the soft-deleted genre, regardless of its
+    // active-title body count.
+    assert!(
+        rows.iter().all(|r| r.name != "Z-9-3-D"),
+        "soft-deleted genre must not surface even with orphan active titles"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn stats_by_genre_single_genre_full_share(pool: MySqlPool) {
+    wipe_seeded_genres(&pool).await;
+
+    let g = insert_genre(&pool, "Z-9-3-Single").await;
+    for i in 1..=4 {
+        insert_title_in_genre(&pool, &format!("S-{i}"), g).await;
+    }
+
+    let rows: Vec<GenreStat> = stats_by_genre(&pool).await.expect("query ok");
+    assert_eq!(rows.len(), 1, "exactly one row for the only genre");
+    assert_eq!(rows[0].name, "Z-9-3-Single");
+    assert_eq!(rows[0].title_count, 4, "all four titles counted");
+}

--- a/tests/e2e/specs/journeys/home.spec.ts
+++ b/tests/e2e/specs/journeys/home.spec.ts
@@ -115,3 +115,39 @@ test.describe("Home page — Recent additions section", () => {
     }
   });
 });
+
+// Story 9-3 — "Stats by genre" section.
+test.describe("Home page — Stats by genre section", () => {
+  test("anonymous: section visible (or hidden), first row navigates to /?filter=genre:<id>", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const section = page.locator("#stats-by-genre");
+    const sectionCount = await section.count();
+    if (sectionCount === 0) {
+      // AC4 — fresh catalog (zero genre assignments) hides the section
+      // entirely. Nothing more to verify; the broader empty-catalog UX
+      // belongs to story 9-15 (StatusMessage).
+      return;
+    }
+
+    await expect(section).toBeVisible();
+    await expect(section.getByRole("heading", { level: 2 })).toContainText(
+      /By genre|Par genre/i,
+    );
+
+    // The first row must show a percentage in either EN (33.3%) or FR
+    // (33,3 %) format. Combined regex accepts both.
+    const rows = section.locator("li");
+    await expect(rows.first()).toContainText(/\d+([.,]\d+)?\s*%/);
+
+    // Scoped selector — explicitly avoids the unscoped-selector flake
+    // class flagged by 9-2's review (a global a[href^="/?filter=genre:"]
+    // would also match the genre-filter pills above #browse-results).
+    const firstLink = section.locator('a[href^="/?filter=genre:"]').first();
+    await expect(firstLink).toBeVisible();
+    await firstLink.click();
+    await page.waitForURL(/\/\?filter=genre%3A\d+|\/\?filter=genre:\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements story 9-3 of Epic 9: a "By genre" section on the home page (`/`) showing the catalog distribution by genre (genre name + title count + percentage + horizontal bar), sorted by count desc, hidden when the catalog has no genre assignments (per spec — empty-state belongs to story 9-15).

Builds on the dashboard plumbing established by 9-1 (`services::dashboard::collection_glance`) and 9-2 (`models::title::list_recent_active` + `recent_additions` slice helper). Same single-round-trip + soft-degrade + handler-side-i18n + scoped-render-test patterns.

## Key implementation decisions

- **Single SQL round-trip with INNER JOIN** in `services::dashboard::stats_by_genre` — empty / soft-deleted genres naturally excluded; total denominator computed Rust-side from the row sum (no second query).
- **Link target** is `/?filter=genre:<id>` (existing genre-filter route via `parse_filter`), NOT the literal spec's `/catalog?genre=<id>` (`/catalog` is the scan page in v1, doesn't accept that param). Same convention as 9-1's `/catalog?view=volumes` → `/catalog` deviation.
- **`<progress value max>`** for the variable-width bar — semantic, accessible, CSP-clean. Custom styling via class-driven CSS in `static/css/browse.css` using `@theme` tokens (`var(--color-indigo-500)` etc.) for UX-DR24 compliance.
- **Locale-aware percentage formatting** — FR uses NBSP + comma decimal (`"33,3 %"`), EN uses period + no space (`"33.3%"`). NBSP invariant locked by a byte-level regression test. New helper in `src/utils.rs::format_percent`.
- **Document-order lock** — new render test `home_renders_recent_additions_above_stats_by_genre` mirrors 9-2's glance-above-recent test, preventing silent template re-orderings.
- **Anonymous parity** — render twice with same data + different role; assert byte-identical slices (AC7).
- **Scoped E2E selector** — `#stats-by-genre a[href^="/?filter=genre:"]` avoids the deferred unscoped-selector flake class flagged by 9-2 review.

## Test plan

- [ ] `cargo check && cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test --lib` (full unit + co-located integration suite, expect ~641)
- [ ] `cargo test --test dashboard_stats_by_genre` (3 new DB-backed integration tests)
- [ ] `cargo sqlx prepare --check --workspace -- --all-targets` (no diff — dynamic queries)
- [ ] Tailwind rebuild — verify `static/css/output.css` includes `.genre-bar` rules
- [ ] Manual smoke — `curl /` finds `id="stats-by-genre"`, percentage formatting matches locale, `<progress>` element renders correctly in browser
- [ ] E2E: `home.spec.ts` "Stats by genre section" describe block — anonymous, conditional populated/empty branches
- [ ] CI green (Foundation Rule #18) before merge

## Story spec

[`_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md`](https://github.com/guycorbaz/mybibli/blob/story/9-3-dashboard-stats-by-genre/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)