### PR TITLE
chore(9-3): code-review follow-ups — direct helper tests + a11y aria-label

### DIFF
--- a/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md
+++ b/_bmad-output/implementation-artifacts/9-3-dashboard-stats-by-genre.md
@@ -1,6 +1,6 @@
 # Story 9.3: Dashboard — stats by genre
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -427,4 +427,38 @@ The deferred TitleCard partial extraction (filed by 9-2) is **NOT** revisited he
 
 ### Change Log
 
-- **2026-05-01** — Initial implementation. All 7 tasks complete; 643 lib tests + 3 dashboard_stats_by_genre integration tests pass; clippy clean; sqlx cache unchanged. Followed Story 9-1 / 9-2 patterns (handler-side i18n, soft-degrade on DB error, single round-trip query, scoped HTML assertions, sibling integration test file). One spec drift caught in template draft (AC1 ordering — `#stats-by-genre` was placed BEFORE `#recent-additions` in the first pass; re-ordered to satisfy AC1's "directly below recent-additions" placement). E2E run deferred to CI per story 9-1 / 9-2 precedent (`tests/e2e/test-results/` ownership blocker).
+- **2026-05-01** — Initial implementation. All 7 tasks complete; 643 lib tests + 3 dashboard_stats_by_genre integration tests pass; clippy clean; sqlx cache unchanged. Followed Story 9-1 / 9-2 patterns (handler-side i18n, soft-degrade on DB error, single round-trip query, scoped HTML assertions, sibling integration test file). One spec drift caught in template draft (AC1 ordering — `#stats-by-genre` was placed BEFORE `#recent-additions` in the first pass; re-ordered to satisfy AC1's "directly below recent-additions" placement). E2E run deferred to CI per story 9-1 / 9-2 precedent (`tests/e2e/test-results/` ownership blocker). PR #110 squash-merged into `main` as commit 6cf7af5.
+
+- **2026-05-01** — Code review pass (3 parallel reviewers: Blind Hunter, Edge Case Hunter, Acceptance Auditor). 0 decision-needed, 2 patches applied, 2 deferred (filed as GH Issues per CLAUDE.md rule 11), 15+ dismissed. Final test counts: 652 lib tests + 3 integration tests, all green; clippy clean. Patches landed via PR `chore/9-3-code-review-followups`.
+
+### Review Findings
+
+**Code review pass — 2026-05-01** (post-merge of PR #110). 3 parallel reviewers (Blind / Edge Case / Acceptance Auditor) raised ~21 findings; triaged into 2 patch + 2 defer + 15+ dismiss.
+
+**Patch (Medium):**
+
+- [x] [Review][Patch] **`build_stats_by_genre_rows` had no direct unit tests** [`src/routes/home.rs:565-602`] — the helper does the i18n `_one`/`_other` branching + percent computation + total=0 defensive branch, but the existing render tests use `fake_genre_stat_row` which bypasses the helper entirely. A swap of the two `t!()` keys would not have been caught. Fix: 8 new unit tests covering EN/FR singular-vs-plural for counts 0/1/2/many, percent computation for `[3,2,1]→[50.0%, 33.3%, 16.7%]`, FR comma+NBSP through the helper, and empty-input → empty-output.
+- [x] [Review][Patch] **`<progress>` aria-label only carried the percent, not the genre name** [`templates/pages/home.html:162`] — a screen-reader user landing on the bar in isolation would hear "60.0%" with no indication of which genre. Fix: changed to `aria-label="{{ row.name }}: {{ row.percent_label }}"` so the bar carries full context. New regression test `home_progress_bar_aria_label_includes_genre_name` locks in the format.
+
+**Defer (filed as GH Issues per CLAUDE.md rule 11):**
+
+- [x] [Review][Defer] **Stats-by-genre denominator distorted by orphan-FK active titles** [`src/services/dashboard.rs::stats_by_genre` + `src/routes/home.rs::build_stats_by_genre_rows`] — when a genre is soft-deleted but still has active titles pointing at it (FK orphan), those titles vanish from the displayed denominator: per-row percentages still sum to 100% but represent a smaller subset of the catalog than the user assumes. Currently prevented by Story 8-4's `GenreModel::delete_if_unused` deletion guard (refuses to delete genres with active titles), but a future migration / manual SQL / removed guard would silently distort the dashboard. → [GH #111](https://github.com/guycorbaz/mybibli/issues/111).
+- [x] [Review][Defer] **Stale genre-filter link → silent empty results** [cross-cutting: `parse_filter` + `SearchService::search`] — when an admin soft-deletes a genre between link render and click (or the user clicks an old browser tab), the filter URL points at a non-existent genre id; the search returns empty results with no "this genre no longer exists" feedback. Pre-existing class of issue affecting all `/?filter=genre:<id>` producers (the existing filter pills on `/` have the same property), surfaced by 9-3's review but not introduced by 9-3. Cross-cutting fix belongs in `services::search`. → [GH #112](https://github.com/guycorbaz/mybibli/issues/112).
+
+**Dismissed (high-level rationale):**
+
+- **HTML5 `<progress>` inside `<a>`** — `<progress>` is NOT in HTML5's interactive content category (per spec); the nesting is valid. (Both Blind Hunter and Edge Case Hunter raised this as a Medium concern.)
+- **HTML escape on attributes** — Askama 0.15's default `html` escaper covers `<>"'&` for both element-content AND attribute-value contexts. (Blind #1)
+- **Test schema fragility (`INSERT INTO genres` omits version/timestamps)** — schema defaults exist (`version DEFAULT 1`, timestamps `DEFAULT CURRENT_TIMESTAMP`); tests run cleanly. (Blind #2)
+- **f64 banker's rounding edge cases** — consistent with project; no specific failing case named. (Blind #8)
+- **`DELETE FROM titles` FK ordering risk** — `#[sqlx::test]` provides per-test DB isolation; the deletes order respects FK. (Blind #9)
+- **`total == 0` branch unreachable** — defensive code; costs nothing. (Blind #10)
+- **`StatsByGenreRow` `pub` vs `pub(crate)`** — consistent with `HomeTemplate` pattern (Askama-required visibility). (Blind #11)
+- **Document-order test uses count=1 hand-crafted label** — covered by P1's new unit tests for the helper. (Blind #4)
+- **E2E URL regex superset (accepts URL-encoded form)** — defensive, harmless. (Blind #7 + Auditor A1)
+- **rust_i18n migration footgun** — consistent with the 9-1 pattern; the `is_singular` + literal `_one/_other` keys idiom is project-standard. (Edge E3)
+- **`format_percent` accepts negative inputs** — current call site clamps via `total > 0`; adding hypothetical guards contradicts CLAUDE.md "Don't add error handling, fallbacks, or validation for scenarios that can't happen". (Edge E5)
+- **`<progress value > max>` future-refactor hazard** — currently safe; speculative. (Edge E6)
+- **E2E test passes vacuously when section is hidden** — same conditional pattern as story 9-2's E2E (already passed review). (Edge E7)
+- **`format_percent_zero` test name absent (folded into `_one_decimal_kept_en`)** — coverage exists, naming is cosmetic. (Auditor A2)
+- **Spec said "5 vs 6" render tests** — internal spec inconsistency; coverage matches the enumerated bullets. (Auditor A3)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -39,7 +39,7 @@
 # The epics document contains FR/NFR/AR/UX-DR assignments per epic.
 
 generated: 2026-03-29
-last_updated: 2026-05-01 # Story 9-3 dev-story complete (in-progress → review). 7 tasks shipped: services::dashboard::stats_by_genre + GenreStat (1 INNER JOIN GROUP BY round-trip), src/utils.rs::format_percent helper with 7 unit tests (incl. byte-level NBSP guard for FR typography), HomeTemplate extension + build_stats_by_genre_rows helper + soft-degrade on DB error, AC4 hide-entirely template gating, <progress class="genre-bar"> CSS in browse.css using @theme tokens (UX-DR24, no hardcoded hex), EN+FR i18n, 3 sqlx integration tests (empty DB, ordering+soft-delete-both-halves, single-genre full share) + 5 handler render tests (incl. document-order lock + AC7 anonymous-byte-identity + FR-NBSP), 1 E2E test scoped to #stats-by-genre. 643 lib tests, all green; clippy clean; sqlx cache unchanged. Spec creation earlier today: single round-trip GROUP BY, INNER JOIN naturally excludes empty/soft-deleted genres (AC4/AC5), `<progress>` element for CSP-clean variable-width bar (UX-DR24 tokens via @theme vars), locale-aware percentage formatting (FR uses NBSP + comma decimal), row-link targets `/?filter=genre:<id>` (existing route, NOT the spec's `/catalog?genre=` which doesn't exist — same convention as 9-1's volume-link deviation), 5 handler render tests including document-order + anonymous/librarian byte-identity locks, format_percent helper in src/utils.rs with NBSP regression test. Earlier 2026-04-30: Story 9-2 review complete — review → done; Story 9-1 done + 2 GH issues filed (#103/#104), Epic 9 sprint planning (PR #101), Epic 8 close.
+last_updated: 2026-05-01 # Story 9-3 done — code review complete (post-merge of PR #110). 3 parallel reviewers (Blind/Edge/Auditor), ~21 findings: 0 decision-needed, 2 patches applied (build_stats_by_genre_rows direct unit tests + <progress> aria-label includes genre name), 2 deferred as GH Issues #111 (denominator distortion under orphan-FK) and #112 (stale genre-filter link UX, cross-cutting), 15+ dismissed. Final 652 lib tests + 3 integration tests, all green; clippy clean. Earlier today: Story 9-3 dev-story (in-progress → review); spec creation: single round-trip GROUP BY, INNER JOIN naturally excludes empty/soft-deleted genres (AC4/AC5), `<progress>` element for CSP-clean variable-width bar (UX-DR24 tokens via @theme vars), locale-aware percentage formatting (FR uses NBSP + comma decimal), row-link targets `/?filter=genre:<id>` (existing route, NOT the spec's `/catalog?genre=` which doesn't exist — same convention as 9-1's volume-link deviation), 5 handler render tests including document-order + anonymous/librarian byte-identity locks, format_percent helper in src/utils.rs with NBSP regression test. Earlier 2026-04-30: Story 9-2 review complete — review → done; Story 9-1 done + 2 GH issues filed (#103/#104), Epic 9 sprint planning (PR #101), Epic 8 close.
 project: mybibli
 project_key: NOKEY
 tracking_system: file-system
@@ -165,7 +165,7 @@ development_status:
   epic-9: in-progress
   9-1-dashboard-global-stats-card: done
   9-2-dashboard-recent-additions: done
-  9-3-dashboard-stats-by-genre: review
+  9-3-dashboard-stats-by-genre: done
   9-4-filtertag-and-unshelved-indicator: backlog
   9-5-overdue-loans-indicator: backlog
   9-6-series-with-gaps-indicator: backlog

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -1281,4 +1281,124 @@ mod tests {
             "EN-style '60.0%' must not appear when FR labels are passed"
         );
     }
+
+    // ─── Story 9-3 — `build_stats_by_genre_rows` direct unit tests
+    // (added during code-review follow-up — the render tests above use
+    // `fake_genre_stat_row` which bypasses the helper entirely, so the
+    // i18n-branching + percent-rounding + total=0 branches were never
+    // exercised. These tests close that coverage gap.)
+
+    fn make_genre_stat(id: u64, name: &str, count: i64) -> crate::services::dashboard::GenreStat {
+        crate::services::dashboard::GenreStat {
+            id,
+            name: name.to_string(),
+            title_count: count,
+        }
+    }
+
+    /// Helper output for `count == 1` → `_one` key in EN ("1 title", not "1 titles").
+    /// Locks the EN singular branch in `is_singular`.
+    #[test]
+    fn build_stats_by_genre_rows_en_singular_for_count_one() {
+        let rows = vec![make_genre_stat(1, "Roman", 1)];
+        let out = build_stats_by_genre_rows(rows, "en");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].count_label, "1 title");
+    }
+
+    /// EN plural branch — `count == 2` must use `_other` key ("2 titles").
+    /// A swap of the two `t!()` keys would surface as "2 title".
+    #[test]
+    fn build_stats_by_genre_rows_en_plural_for_count_two() {
+        let rows = vec![make_genre_stat(1, "Roman", 2)];
+        let out = build_stats_by_genre_rows(rows, "en");
+        assert_eq!(out[0].count_label, "2 titles");
+    }
+
+    /// FR CLDR rule — count of 0 maps to the singular form ("0 titre",
+    /// not "0 titres"). Encoded by `is_singular` (`fr` arm includes 0).
+    /// Note: this case isn't reachable through the SQL pipeline (INNER
+    /// JOIN excludes zero-count genres) but the helper API is public
+    /// and a future caller could pass it.
+    #[test]
+    fn build_stats_by_genre_rows_fr_singular_for_count_zero() {
+        let rows = vec![make_genre_stat(1, "Roman", 0)];
+        let out = build_stats_by_genre_rows(rows, "fr");
+        assert_eq!(out[0].count_label, "0 titre");
+    }
+
+    /// FR singular for count == 1.
+    #[test]
+    fn build_stats_by_genre_rows_fr_singular_for_count_one() {
+        let rows = vec![make_genre_stat(1, "Roman", 1)];
+        let out = build_stats_by_genre_rows(rows, "fr");
+        assert_eq!(out[0].count_label, "1 titre");
+    }
+
+    /// FR plural for count >= 2.
+    #[test]
+    fn build_stats_by_genre_rows_fr_plural_for_count_many() {
+        let rows = vec![make_genre_stat(1, "Roman", 12)];
+        let out = build_stats_by_genre_rows(rows, "fr");
+        assert_eq!(out[0].count_label, "12 titres");
+    }
+
+    /// Percent computation — three rows with counts 3/2/1 (total 6) must
+    /// round to 50.0% / 33.3% / 16.7% (1 decimal). Bakes in the AC9
+    /// rounding contract end-to-end through the helper.
+    #[test]
+    fn build_stats_by_genre_rows_computes_percent_to_one_decimal() {
+        let rows = vec![
+            make_genre_stat(1, "A", 3),
+            make_genre_stat(2, "B", 2),
+            make_genre_stat(3, "C", 1),
+        ];
+        let out = build_stats_by_genre_rows(rows, "en");
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].percent_label, "50.0%");
+        assert_eq!(out[1].percent_label, "33.3%");
+        assert_eq!(out[2].percent_label, "16.7%");
+        // Each row's `value`/`max` mirrors the count and the global total —
+        // the <progress> bar drives off these.
+        assert_eq!(out[0].value, 3);
+        assert_eq!(out[0].max, 6);
+        assert_eq!(out[2].max, 6);
+    }
+
+    /// FR percent uses comma + NBSP — round-trip through the helper.
+    #[test]
+    fn build_stats_by_genre_rows_fr_percent_uses_comma_and_nbsp() {
+        let rows = vec![
+            make_genre_stat(1, "A", 3),
+            make_genre_stat(2, "B", 2),
+            make_genre_stat(3, "C", 1),
+        ];
+        let out = build_stats_by_genre_rows(rows, "fr");
+        assert_eq!(out[0].percent_label, "50,0\u{00A0}%");
+        assert_eq!(out[1].percent_label, "33,3\u{00A0}%");
+    }
+
+    /// Empty input → empty output. The defensive `total > 0` branch in
+    /// the helper exists for this scenario; we lock it in.
+    #[test]
+    fn build_stats_by_genre_rows_empty_input_yields_empty_output() {
+        let out = build_stats_by_genre_rows(vec![], "en");
+        assert!(out.is_empty());
+    }
+
+    /// `aria-label` carries genre name + percent for screen readers
+    /// reading the `<progress>` in isolation (review patch P2). Without
+    /// this test, a regression to bare `aria-label="{{ percent_label }}"`
+    /// would slip past CI.
+    #[test]
+    fn home_progress_bar_aria_label_includes_genre_name() {
+        let stats = vec![fake_genre_stat_row(7, "Roman", "12 titles", "60.0%", 12, 20)];
+        let template = make_test_home_template_with_stats("anonymous", stats);
+        let html = template.render().expect("render");
+        let slice = stats_by_genre_slice(&html);
+        assert!(
+            slice.contains("aria-label=\"Roman: 60.0%\""),
+            "<progress> aria-label must include genre name + percent; got slice:\n{slice}"
+        );
+    }
 }

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -159,7 +159,7 @@
                         <span class="font-medium text-stone-900 dark:text-stone-100 truncate">{{ row.name }}</span>
                         <span class="text-sm text-stone-600 dark:text-stone-400 whitespace-nowrap"><span class="tabular-nums">{{ row.count_label }}</span> · <span class="tabular-nums">{{ row.percent_label }}</span></span>
                     </div>
-                    <progress class="genre-bar mt-2 w-full" value="{{ row.value }}" max="{{ row.max }}" aria-label="{{ row.percent_label }}">{{ row.percent_label }}</progress>
+                    <progress class="genre-bar mt-2 w-full" value="{{ row.value }}" max="{{ row.max }}" aria-label="{{ row.name }}: {{ row.percent_label }}">{{ row.percent_label }}</progress>
                 </a>
             </li>
             {% endfor %}


### PR DESCRIPTION
## Summary

Post-merge code review on PR #110 raised 2 Medium-severity patch items + 2 deferred-as-Issues items + 15 dismissed. This PR addresses the 2 patches.

## Patches applied

### P1 — `build_stats_by_genre_rows` direct unit tests
The render tests added in #110 use `fake_genre_stat_row` which bypasses the helper. The internal i18n branching + percent rounding + defensive `total=0` branch were never exercised. Adds 8 direct unit tests:
- EN/FR singular vs plural for counts 0/1/2/many (covers `is_singular` + `t!()` key selection)
- Percent computation lock-in: `[3,2,1]` → `[50.0%, 33.3%, 16.7%]`
- FR comma + NBSP round-trip through the helper
- Empty input → empty output (locks `total=0` defensive branch)

### P2 — `<progress>` aria-label includes genre name
A screen-reader user focused on the bar in isolation previously heard only "60.0%". Changed to `aria-label="{{ row.name }}: {{ row.percent_label }}"`. New test `home_progress_bar_aria_label_includes_genre_name` locks the format.

## Deferred (filed as GH Issues)

- **#111** (Medium): denominator distortion when orphan-FK titles exist (currently prevented by Story 8-4's `delete_if_unused` guard).
- **#112** (Low, cross-cutting): stale genre-filter link returns silent empty results (affects all `/?filter=genre:<id>` producers, pre-existing).

## Story status

`review → done` (PR #110 merged + this follow-up = full review pass per Foundation Rule #6).

## Test plan

- [x] `cargo test --lib` — 652 passing (was 643 in PR #110, +9 new = 8 helper tests + 1 aria-label regression test)
- [x] `cargo test --test dashboard_stats_by_genre` — 3/3 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] sprint-status.yaml flipped 9-3 review → done
- [ ] CI green on this branch
- [ ] Squash-merge once CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)