### PR TITLE
chore(site): add GitHub Pages marketing site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./website
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/about.html
+++ b/website/about.html
@@ -1,0 +1,213 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About — mybibli</title>
+  <meta name="description" content="What mybibli is, who it's for, and why it exists. A self-hosted personal library cataloging app." />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📚%3C/text%3E%3C/svg%3E" />
+  <script>
+    (function () {
+      var s = localStorage.getItem("mybibli-site-theme");
+      var d = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (s === "dark" || (!s && d)) document.documentElement.classList.add("dark");
+    })();
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: "class" };
+  </script>
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body class="min-h-screen bg-stone-50 text-stone-900 dark:bg-stone-950 dark:text-stone-100 antialiased">
+
+  <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-indigo-600 focus:px-3 focus:py-2 focus:text-white">Skip to content</a>
+
+  <header class="sticky top-0 z-40 backdrop-blur-md bg-stone-50/80 dark:bg-stone-950/80 border-b border-stone-200 dark:border-stone-800">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 flex items-center justify-between h-14">
+      <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
+        <span aria-hidden="true" class="text-xl">📚</span>
+        <span>mybibli</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 ring-1 ring-amber-200/60 dark:ring-amber-800/50">pre-v1</span>
+      </a>
+      <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
+        <a href="./index.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Home</a>
+        <a href="./about.html" class="px-3 py-1.5 rounded-md text-indigo-700 dark:text-indigo-300 font-medium" aria-current="page">About</a>
+        <a href="./roadmap.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Issues</a>
+      </nav>
+      <div class="flex items-center gap-1">
+        <button data-theme-toggle type="button" aria-label="Toggle theme" class="p-2 rounded-md text-stone-600 dark:text-stone-300 hover:bg-stone-200/60 dark:hover:bg-stone-800/60">
+          <svg class="hidden dark:block w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v1.5M12 19.5V21M4.22 4.22l1.06 1.06M18.72 18.72l1.06 1.06M3 12h1.5M19.5 12H21M4.22 19.78l1.06-1.06M18.72 5.28l1.06-1.06M12 7.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z" /></svg>
+          <svg class="block dark:hidden w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" /></svg>
+        </button>
+        <a href="https://github.com/guycorbaz/mybibli" class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-stone-900 dark:bg-stone-100 text-white dark:text-stone-900 hover:opacity-90">
+          <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8.013 8.013 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
+        </a>
+        <button data-mobile-nav-toggle type="button" aria-controls="mobile-nav" aria-expanded="false" aria-label="Open menu" class="md:hidden p-2 rounded-md text-stone-600 dark:text-stone-300 hover:bg-stone-200/60 dark:hover:bg-stone-800/60">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <div id="mobile-nav" class="hidden md:hidden border-t border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-950 px-4 py-2">
+      <nav aria-label="Mobile" class="flex flex-col">
+        <a href="./index.html" class="py-2 text-stone-600 dark:text-stone-300">Home</a>
+        <a href="./about.html" class="py-2 text-indigo-700 dark:text-indigo-300 font-medium">About</a>
+        <a href="./roadmap.html" class="py-2 text-stone-600 dark:text-stone-300">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="py-2 text-stone-600 dark:text-stone-300">Issues</a>
+        <a href="https://github.com/guycorbaz/mybibli" class="py-2 text-stone-600 dark:text-stone-300">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+
+    <!-- ===================== HERO ===================== -->
+    <section class="relative isolate overflow-hidden">
+      <div class="absolute inset-0 grid-pattern opacity-50" aria-hidden="true"></div>
+      <div class="absolute inset-0 hero-gradient" aria-hidden="true"></div>
+      <div class="relative max-w-4xl mx-auto px-4 sm:px-6 pt-16 pb-12">
+        <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
+          About
+        </span>
+        <h1 class="mt-5 text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
+          A library for the way you actually read.
+        </h1>
+        <p class="mt-5 text-lg text-stone-600 dark:text-stone-300 leading-relaxed">
+          mybibli started as a one-person itch — keeping track of what's on which shelf, who borrowed which volume, and which BD volumes are still missing in a series I've half-finished. It grew into a small, opinionated tool that tries to be useful without being heavy.
+        </p>
+      </div>
+    </section>
+
+    <!-- ===================== STORY / WHY ===================== -->
+    <section class="py-12 sm:py-16">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6 prose prose-stone dark:prose-invert prose-headings:tracking-tight prose-h2:text-2xl prose-h2:sm:text-3xl prose-h2:font-bold max-w-none">
+
+        <div class="reveal">
+          <h2>Why a self-hosted app?</h2>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            Most existing personal-library apps are either spreadsheets, abandoned mobile apps, or cloud SaaS that wants to know your reading habits. None of those fit. A book collection is a private artifact — it tells you a lot about a household — and shouldn't need an internet connection to be useful.
+          </p>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            mybibli runs on your hardware. A NAS, a small server, a Raspberry Pi 4 — anything that can host Docker. There is no telemetry, no analytics, no phone-home. Metadata enrichment is the one network call out — to public providers like the BnF, Google Books, OpenLibrary, MusicBrainz — and you can disable any of them in the admin panel.
+          </p>
+        </div>
+
+        <div class="reveal mt-12">
+          <h2>Who it's for</h2>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            One household, one library. mybibli is built around <em>shared family use</em>: an admin who set it up, librarians who can catalog and lend, and anonymous browsers (your kids on a tablet) who can search and see what's on a shelf without an account.
+          </p>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            It's not designed to scale to thousands of users or to mediate loans between different libraries. If that's what you need, the open-source ILS world (Koha, Evergreen) is mature and excellent.
+          </p>
+        </div>
+
+        <div class="reveal mt-12">
+          <h2>Design choices that won't change</h2>
+          <ul class="text-stone-600 dark:text-stone-300 leading-relaxed space-y-2 marker:text-indigo-500">
+            <li><strong class="text-stone-900 dark:text-stone-100">Server-rendered HTML.</strong> No SPA, no JSON API as the front-of-house contract. HTMX over the same routes that serve the pages.</li>
+            <li><strong class="text-stone-900 dark:text-stone-100">Compile-time type checking everywhere.</strong> Templates are checked by Askama, queries by SQLx's offline cache, and the routing layer is a typed Axum router.</li>
+            <li><strong class="text-stone-900 dark:text-stone-100">Strict Content Security Policy.</strong> No inline scripts or styles. Every fragment of HTML — server-side or returned to HTMX — is policed by audit tests that fail the build on regression.</li>
+            <li><strong class="text-stone-900 dark:text-stone-100">No background workers framework.</strong> A handful of <code class="font-mono text-sm">tokio::spawn</code> tasks for metadata fetch, provider health pings, anonymous-session purge and soft-delete auto-purge — that's it.</li>
+            <li><strong class="text-stone-900 dark:text-stone-100">Two languages, key-by-key parity.</strong> EN + FR locales, with a unit test that fails if a key exists in one but not the other.</li>
+          </ul>
+        </div>
+
+        <div class="reveal mt-12">
+          <h2>How it's tested</h2>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            Roughly 900 tests across three layers: unit tests for pure logic, <code class="font-mono text-sm">#[sqlx::test]</code> integration tests that get a fresh database per test, and Playwright end-to-end specs that drive a real browser against the full Docker stack. The CI runs Rust tests + clippy + sqlx-prepare check, DB integration tests, and two Playwright lanes — the seeded-stack suite and a dedicated wizard-E2E lane that boots from an empty database.
+          </p>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            Every story merges through a draft PR with green CI. Every epic ends with a retrospective. Every regression gets a test before it gets a fix.
+          </p>
+        </div>
+
+        <div class="reveal mt-12">
+          <h2>License</h2>
+          <p class="text-stone-600 dark:text-stone-300 leading-relaxed">
+            mybibli is licensed under the <strong class="text-stone-900 dark:text-stone-100">GNU Affero General Public License v3.0 or later</strong> (AGPL-3.0-or-later). AGPL was chosen deliberately to keep mybibli and any fork freely modifiable by end users — including forks that are hosted as a service. If you run a modified version, you must offer the corresponding source to your users.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== STACK CARDS ===================== -->
+    <section class="py-12 sm:py-20 bg-stone-100/60 dark:bg-stone-900/40 border-t border-stone-200 dark:border-stone-800">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6">
+        <div class="reveal max-w-2xl mb-10">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">The toolchain</h2>
+          <p class="mt-3 text-stone-600 dark:text-stone-300">Everything is open source. No vendor lock-in.</p>
+        </div>
+        <dl class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Language</dt>
+            <dd class="mt-1 font-semibold">Rust 2024 edition</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">Single statically-linked binary. Memory-safety and a strong type system instead of runtime guards.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Web framework</dt>
+            <dd class="mt-1 font-semibold">Axum 0.8</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">Tokio-based, tower middleware, typed extractors. The middleware order at request time is documented and policed.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Database driver</dt>
+            <dd class="mt-1 font-semibold">SQLx 0.8 (MariaDB)</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">Compile-time query checking via <code class="font-mono text-xs">cargo sqlx prepare</code>. Soft delete + optimistic locking applied uniformly.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Templates</dt>
+            <dd class="mt-1 font-semibold">Askama 0.15</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">Jinja-style with auto HTML-escaping, compiled into Rust types — missing or misnamed fields fail at build time.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Frontend</dt>
+            <dd class="mt-1 font-semibold">HTMX 2.0 + Tailwind 4</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">Server-driven UI coordination via custom events. A handful of small ES modules where it's required.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">i18n</dt>
+            <dd class="mt-1 font-semibold">rust-i18n</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">YAML files compiled into the binary. EN + FR shipping; extra languages are one new file plus the parity test.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Testing</dt>
+            <dd class="mt-1 font-semibold">cargo test + Playwright</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">~525 unit, ~95 DB integration, ~160 Playwright E2E. Two CI lanes — seeded-stack and a wizard-E2E lane that boots from an empty database.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Hosting</dt>
+            <dd class="mt-1 font-semibold">Docker Compose</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">A small <code class="font-mono text-xs">docker-compose.yml</code>: app + MariaDB. Pre-built images on Docker Hub once v1 ships.</dd>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <dt class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">CI/CD</dt>
+            <dd class="mt-1 font-semibold">GitHub Actions</dd>
+            <dd class="mt-2 text-sm text-stone-600 dark:text-stone-400">Four parallel jobs gate every PR. Branch protections require all green before merge.</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 dark:border-stone-800 py-10">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between text-sm">
+      <div class="flex items-center gap-2 text-stone-600 dark:text-stone-400">
+        <span aria-hidden="true">📚</span>
+        <span><strong class="text-stone-900 dark:text-stone-100">mybibli</strong> — AGPL-3.0-or-later</span>
+      </div>
+      <nav aria-label="Footer" class="flex flex-wrap gap-x-5 gap-y-2 text-stone-500 dark:text-stone-400">
+        <a href="./about.html" class="hover:text-stone-900 dark:hover:text-stone-100">About</a>
+        <a href="./roadmap.html" class="hover:text-stone-900 dark:hover:text-stone-100">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli" class="hover:text-stone-900 dark:hover:text-stone-100">GitHub</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="hover:text-stone-900 dark:hover:text-stone-100">Issues</a>
+        <a href="https://github.com/guycorbaz/mybibli/blob/main/LICENSE" class="hover:text-stone-900 dark:hover:text-stone-100">License</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="./js/site.js"></script>
+</body>
+</html>

--- a/website/css/styles.css
+++ b/website/css/styles.css
@@ -1,0 +1,47 @@
+/* mybibli site — small additions on top of Tailwind */
+
+html { scroll-behavior: smooth; }
+
+/* Subtle hero gradient that adapts to dark mode */
+.hero-gradient {
+  background:
+    radial-gradient(ellipse at top right, rgb(99 102 241 / 0.18), transparent 55%),
+    radial-gradient(ellipse at bottom left, rgb(244 114 182 / 0.10), transparent 60%);
+}
+.dark .hero-gradient {
+  background:
+    radial-gradient(ellipse at top right, rgb(99 102 241 / 0.22), transparent 55%),
+    radial-gradient(ellipse at bottom left, rgb(244 114 182 / 0.10), transparent 60%);
+}
+
+/* Decorative grid backdrop */
+.grid-pattern {
+  background-image:
+    linear-gradient(to right, rgb(120 113 108 / 0.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(120 113 108 / 0.08) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+.dark .grid-pattern {
+  background-image:
+    linear-gradient(to right, rgb(231 229 228 / 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(231 229 228 / 0.05) 1px, transparent 1px);
+}
+
+/* Card hover lift */
+.feature-card { transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease; }
+.feature-card:hover { transform: translateY(-2px); }
+
+/* Timeline dot pulse on the active item */
+@keyframes pulse-ring {
+  0%   { box-shadow: 0 0 0 0 rgb(99 102 241 / 0.55); }
+  70%  { box-shadow: 0 0 0 12px rgb(99 102 241 / 0); }
+  100% { box-shadow: 0 0 0 0 rgb(99 102 241 / 0); }
+}
+.timeline-active { animation: pulse-ring 2s infinite; }
+
+/* Reveal-on-scroll: hidden by default, faded in by IntersectionObserver */
+.reveal { opacity: 0; transform: translateY(8px); transition: opacity 500ms ease, transform 500ms ease; }
+.reveal.in { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal { opacity: 1; transform: none; transition: none; }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,371 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>mybibli — your home library, properly cataloged</title>
+  <meta name="description" content="A self-hosted, barcode-first cataloging app for your personal library: books, BD, audio, films. Multi-role, multi-language, no cloud — built in Rust." />
+  <meta property="og:title" content="mybibli — your home library, properly cataloged" />
+  <meta property="og:description" content="Self-hosted cataloging for home collectors: barcode scanning, series gap detection, loan tracking, multi-role access. Built in Rust + HTMX." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://guycorbaz.github.io/mybibli/" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📚%3C/text%3E%3C/svg%3E" />
+
+  <!-- Avoid theme flash: apply persisted theme before body paints -->
+  <script>
+    (function () {
+      var s = localStorage.getItem("mybibli-site-theme");
+      var d = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (s === "dark" || (!s && d)) document.documentElement.classList.add("dark");
+    })();
+  </script>
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ["ui-sans-serif", "system-ui", "-apple-system", "Segoe UI", "Roboto", "Inter", "sans-serif"],
+            mono: ["ui-monospace", "SFMono-Regular", "Menlo", "Consolas", "monospace"],
+          },
+        },
+      },
+    };
+  </script>
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body class="min-h-screen bg-stone-50 text-stone-900 dark:bg-stone-950 dark:text-stone-100 antialiased">
+
+  <!-- Skip link for keyboard users -->
+  <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-indigo-600 focus:px-3 focus:py-2 focus:text-white">Skip to content</a>
+
+  <!-- ===================== NAV ===================== -->
+  <header class="sticky top-0 z-40 backdrop-blur-md bg-stone-50/80 dark:bg-stone-950/80 border-b border-stone-200 dark:border-stone-800">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 flex items-center justify-between h-14">
+      <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
+        <span aria-hidden="true" class="text-xl">📚</span>
+        <span>mybibli</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 ring-1 ring-amber-200/60 dark:ring-amber-800/50">pre-v1</span>
+      </a>
+
+      <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
+        <a href="./index.html" class="px-3 py-1.5 rounded-md text-indigo-700 dark:text-indigo-300 font-medium" aria-current="page">Home</a>
+        <a href="./about.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">About</a>
+        <a href="./roadmap.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Issues</a>
+      </nav>
+
+      <div class="flex items-center gap-1">
+        <button data-theme-toggle type="button" aria-label="Toggle theme" class="p-2 rounded-md text-stone-600 dark:text-stone-300 hover:bg-stone-200/60 dark:hover:bg-stone-800/60">
+          <!-- sun (shown in dark) -->
+          <svg class="hidden dark:block w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v1.5M12 19.5V21M4.22 4.22l1.06 1.06M18.72 18.72l1.06 1.06M3 12h1.5M19.5 12H21M4.22 19.78l1.06-1.06M18.72 5.28l1.06-1.06M12 7.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z" /></svg>
+          <!-- moon (shown in light) -->
+          <svg class="block dark:hidden w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" /></svg>
+        </button>
+        <a href="https://github.com/guycorbaz/mybibli" class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-stone-900 dark:bg-stone-100 text-white dark:text-stone-900 hover:opacity-90">
+          <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8.013 8.013 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
+        </a>
+        <button data-mobile-nav-toggle type="button" aria-controls="mobile-nav" aria-expanded="false" aria-label="Open menu" class="md:hidden p-2 rounded-md text-stone-600 dark:text-stone-300 hover:bg-stone-200/60 dark:hover:bg-stone-800/60">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <div id="mobile-nav" class="hidden md:hidden border-t border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-950 px-4 py-2">
+      <nav aria-label="Mobile" class="flex flex-col">
+        <a href="./index.html" class="py-2 text-indigo-700 dark:text-indigo-300 font-medium">Home</a>
+        <a href="./about.html" class="py-2 text-stone-600 dark:text-stone-300">About</a>
+        <a href="./roadmap.html" class="py-2 text-stone-600 dark:text-stone-300">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="py-2 text-stone-600 dark:text-stone-300">Issues</a>
+        <a href="https://github.com/guycorbaz/mybibli" class="py-2 text-stone-600 dark:text-stone-300">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+
+    <!-- ===================== HERO ===================== -->
+    <section class="relative isolate overflow-hidden">
+      <div class="absolute inset-0 grid-pattern opacity-50" aria-hidden="true"></div>
+      <div class="absolute inset-0 hero-gradient" aria-hidden="true"></div>
+      <div class="relative max-w-6xl mx-auto px-4 sm:px-6 pt-16 sm:pt-24 pb-20 sm:pb-28">
+        <div class="max-w-3xl">
+          <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
+            <span class="w-1.5 h-1.5 rounded-full bg-indigo-500 dark:bg-indigo-400"></span>
+            Active development · v0.1.0
+          </span>
+          <h1 class="mt-5 text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
+            Your home library,<br class="hidden sm:block" />
+            <span class="bg-gradient-to-r from-indigo-600 to-pink-500 bg-clip-text text-transparent">properly cataloged.</span>
+          </h1>
+          <p class="mt-6 text-lg sm:text-xl text-stone-600 dark:text-stone-300 leading-relaxed">
+            <strong class="text-stone-900 dark:text-stone-100">mybibli</strong> is a self-hosted web app to catalog, locate, and loan your personal library. Barcode-first, multi-media, multi-role — and your data never leaves your network.
+          </p>
+          <div class="mt-8 flex flex-wrap gap-3">
+            <a href="https://github.com/guycorbaz/mybibli" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-indigo-600 text-white font-medium shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-stone-50 dark:focus:ring-offset-stone-950">
+              <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8.013 8.013 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+              View on GitHub
+            </a>
+            <a href="./roadmap.html" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 font-medium ring-1 ring-stone-300 dark:ring-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700">
+              See the roadmap
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </a>
+          </div>
+
+          <!-- Status snapshot -->
+          <div class="mt-12 grid grid-cols-2 sm:grid-cols-4 gap-4 max-w-2xl">
+            <div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">8/9</div>
+              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">epics done</div>
+            </div>
+            <div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">~900</div>
+              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">tests green</div>
+            </div>
+            <div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">7</div>
+              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">metadata providers</div>
+            </div>
+            <div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">2</div>
+              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">languages (EN/FR)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== FEATURES ===================== -->
+    <section class="py-20 sm:py-28">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6">
+        <div class="max-w-2xl mb-14 reveal">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-stone-900 dark:text-stone-50">More than a spreadsheet.</h2>
+          <p class="mt-4 text-stone-600 dark:text-stone-300 leading-relaxed">
+            Built for collectors who want their library to actually work. Scan a barcode, find a book on a shelf, lend it to a friend — and see what's missing in a series.
+          </p>
+        </div>
+
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          <!-- Card 1 -->
+          <article class="feature-card reveal rounded-xl p-6 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800 hover:ring-indigo-300 dark:hover:ring-indigo-700 hover:shadow-lg dark:hover:shadow-indigo-900/20">
+            <div class="w-10 h-10 rounded-lg bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 flex items-center justify-center">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 6h2m4 0h2m4 0h2m4 0h2M3 18h2m4 0h2m4 0h2m4 0h2M5 4v16M11 4v16M15 4v16M19 4v16"/></svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Barcode-first cataloging</h3>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+              Scan an ISBN or EAN-13. Title metadata resolves asynchronously through a chain of seven providers — BnF, Google Books, Open Library, MusicBrainz, OMDb, TMDB, BDGest — with cover-image download.
+            </p>
+          </article>
+
+          <!-- Card 2 -->
+          <article class="feature-card reveal rounded-xl p-6 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800 hover:ring-indigo-300 dark:hover:ring-indigo-700 hover:shadow-lg dark:hover:shadow-indigo-900/20">
+            <div class="w-10 h-10 rounded-lg bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 flex items-center justify-center">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6a2 2 0 012-2h2.5l1 2H18a2 2 0 012 2v9a2 2 0 01-2 2H6a2 2 0 01-2-2V6z"/></svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Multi-media support</h3>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+              Books, BD/comics with multi-position omnibus volumes, audio releases, films and series — each typed correctly with the right provider chain selected automatically.
+            </p>
+          </article>
+
+          <!-- Card 3 -->
+          <article class="feature-card reveal rounded-xl p-6 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800 hover:ring-indigo-300 dark:hover:ring-indigo-700 hover:shadow-lg dark:hover:shadow-indigo-900/20">
+            <div class="w-10 h-10 rounded-lg bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 flex items-center justify-center">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 5l7 7-7 7"/></svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Series & gap detection</h3>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+              See which volumes are missing in your series at a glance. The dashboard surfaces "series with gaps" alongside Dewey-based browsing and a similar-titles section.
+            </p>
+          </article>
+
+          <!-- Card 4 -->
+          <article class="feature-card reveal rounded-xl p-6 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800 hover:ring-indigo-300 dark:hover:ring-indigo-700 hover:shadow-lg dark:hover:shadow-indigo-900/20">
+            <div class="w-10 h-10 rounded-lg bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300 flex items-center justify-center">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M5 3v4M3 5h4M6 17v4M4 19h4M13 3l2.286 6.857L22 12l-6.714 2.143L13 21l-2.286-6.857L4 12l6.714-2.143L13 3z"/></svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Storage-location tracking</h3>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+              Configurable hierarchy — room → shelf → row, or whatever fits your home. Each shelf gets a barcode; scan the shelf, scan the volume, done.
+            </p>
+          </article>
+
+          <!-- Card 5 -->
+          <article class="feature-card reveal rounded-xl p-6 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800 hover:ring-indigo-300 dark:hover:ring-indigo-700 hover:shadow-lg dark:hover:shadow-indigo-900/20">
+            <div class="w-10 h-10 rounded-lg bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 flex items-center justify-center">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Loan management</h3>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+              Borrower CRUD, loan registration, automatic location restoration on return, admin-configurable overdue threshold, per-borrower history.
+            </p>
+          </article>
+
+          <!-- Card 6 -->
+          <article class="feature-card reveal rounded-xl p-6 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800 hover:ring-indigo-300 dark:hover:ring-indigo-700 hover:shadow-lg dark:hover:shadow-indigo-900/20">
+            <div class="w-10 h-10 rounded-lg bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 flex items-center justify-center">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"/></svg>
+            </div>
+            <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Multi-role access</h3>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
+              Anonymous (read-only), Librarian (catalog + loans), Admin (everything). Session inactivity timeout with keep-alive toast. EN / FR language toggle, per-user.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== HARDENED CALLOUT ===================== -->
+    <section class="py-16 sm:py-20 bg-stone-100/60 dark:bg-stone-900/40 border-y border-stone-200 dark:border-stone-800">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 grid lg:grid-cols-2 gap-12 items-center">
+        <div class="reveal">
+          <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-600/10 ring-1 ring-emerald-600/20 text-emerald-700 dark:text-emerald-300 text-xs font-medium">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+            Hardened by construction
+          </span>
+          <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Security that sleeps next to your front door.</h2>
+          <p class="mt-4 text-stone-600 dark:text-stone-300 leading-relaxed">
+            Self-hosted means your home network. So mybibli is built defensively from day one — not as an afterthought.
+          </p>
+        </div>
+        <ul class="space-y-4 reveal">
+          <li class="flex gap-4">
+            <div class="shrink-0 w-9 h-9 rounded-lg bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 flex items-center justify-center font-mono text-xs font-bold">CSP</div>
+            <div>
+              <h3 class="font-semibold text-stone-900 dark:text-stone-100">Strict Content Security Policy</h3>
+              <p class="text-sm text-stone-600 dark:text-stone-400">No <code class="font-mono text-xs">unsafe-inline</code>, no <code class="font-mono text-xs">unsafe-eval</code>. Every template — server-rendered or HTMX fragment — is audited for inline script and style attributes.</p>
+            </div>
+          </li>
+          <li class="flex gap-4">
+            <div class="shrink-0 w-9 h-9 rounded-lg bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 flex items-center justify-center font-mono text-xs font-bold">CSRF</div>
+            <div>
+              <h3 class="font-semibold text-stone-900 dark:text-stone-100">Per-session synchronizer token</h3>
+              <p class="text-sm text-stone-600 dark:text-stone-400">Constant-time compare on every state-changing request. Forms inject the token automatically; HTMX inherits via a small JS listener. Exempt-route allowlist is frozen and policed by tests.</p>
+            </div>
+          </li>
+          <li class="flex gap-4">
+            <div class="shrink-0 w-9 h-9 rounded-lg bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 flex items-center justify-center" aria-hidden="true">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </div>
+            <div>
+              <h3 class="font-semibold text-stone-900 dark:text-stone-100">Scanner-guard</h3>
+              <p class="text-sm text-stone-600 dark:text-stone-400">A USB barcode burst that arrives while a modal is open is intercepted at document-capture phase — no leakage into background scan fields, no accidental Cancel/Confirm activation.</p>
+            </div>
+          </li>
+          <li class="flex gap-4">
+            <div class="shrink-0 w-9 h-9 rounded-lg bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300 flex items-center justify-center" aria-hidden="true">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 10v10a1 1 0 001 1h6V10M14 21h6a1 1 0 001-1V10M21 10l-9-7-9 7M9 21V13h6v8"/></svg>
+            </div>
+            <div>
+              <h3 class="font-semibold text-stone-900 dark:text-stone-100">Data stays at home</h3>
+              <p class="text-sm text-stone-600 dark:text-stone-400">No cloud sync, no telemetry, no analytics. Argon2 password hashing, HttpOnly + SameSite cookies, soft-delete with 30-day auto-purge.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ===================== STACK ===================== -->
+    <section class="py-20 sm:py-28">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6">
+        <div class="max-w-2xl mb-14 reveal">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Boring stack, on purpose.</h2>
+          <p class="mt-4 text-stone-600 dark:text-stone-300 leading-relaxed">
+            Server-rendered HTML, type-checked templates, no SPA framework. The whole UI talks to the server with HTMX over the same routes that serve the pages.
+          </p>
+        </div>
+
+        <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Backend</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">Rust 2024 + Axum 0.8</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Compiled binary, async tokio runtime, zero-cost middleware tower stack.</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Database</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">MariaDB + SQLx 0.8</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Compile-time query checking via the offline cache. Versioned migrations checked into the repo.</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Templates</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">Askama 0.15</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Compile-time type-checked Jinja-style templates. Auto HTML-escaping, no surprises.</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Frontend</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">HTMX 2 + Tailwind 4</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">No build step beyond Tailwind. Server-rendered HTML; small ES modules where the UX needs it.</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Auth</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">Sessions + Argon2</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Cookie-based sessions, per-session CSRF synchronizer token, role-based access control.</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">i18n</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">rust-i18n</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">English + French today, key-by-key parity enforced by tests. New languages drop in as a single YAML file.</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">Testing</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">cargo + Playwright</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">~525 unit, ~95 DB integration, ~160 Playwright E2E across two CI lanes (seeded + wizard).</p>
+          </div>
+          <div class="reveal rounded-lg p-5 bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <div class="text-xs uppercase tracking-wide text-stone-500 dark:text-stone-400">CI/CD</div>
+            <div class="mt-1 font-semibold text-stone-900 dark:text-stone-50">GitHub Actions</div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Rust tests + clippy + sqlx-prepare check, DB integration, Playwright E2E and wizard E2E — gated on every PR.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== CTA ===================== -->
+    <section class="pb-20 sm:pb-28">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6">
+        <div class="reveal relative overflow-hidden rounded-2xl p-10 sm:p-14 bg-gradient-to-br from-indigo-600 via-indigo-700 to-pink-600 text-white shadow-xl">
+          <div class="absolute inset-0 grid-pattern opacity-20" aria-hidden="true"></div>
+          <div class="relative">
+            <h2 class="text-2xl sm:text-3xl font-bold">Pre-v1, in active development.</h2>
+            <p class="mt-3 text-indigo-100 max-w-2xl">
+              Eight epics shipped, one to go. v1 ships after Epic 9 — UX polish and accessibility. Watch the repo to be notified, or jump into the issues.
+            </p>
+            <div class="mt-6 flex flex-wrap gap-3">
+              <a href="https://github.com/guycorbaz/mybibli" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-white text-indigo-700 font-medium hover:bg-indigo-50">
+                Star on GitHub
+              </a>
+              <a href="./roadmap.html" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md ring-1 ring-white/40 text-white font-medium hover:bg-white/10">
+                See the roadmap
+              </a>
+              <a href="https://github.com/guycorbaz/mybibli/issues" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md ring-1 ring-white/40 text-white font-medium hover:bg-white/10">
+                Browse issues
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- ===================== FOOTER ===================== -->
+  <footer class="border-t border-stone-200 dark:border-stone-800 py-10">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between text-sm">
+      <div class="flex items-center gap-2 text-stone-600 dark:text-stone-400">
+        <span aria-hidden="true">📚</span>
+        <span><strong class="text-stone-900 dark:text-stone-100">mybibli</strong> — AGPL-3.0-or-later</span>
+      </div>
+      <nav aria-label="Footer" class="flex flex-wrap gap-x-5 gap-y-2 text-stone-500 dark:text-stone-400">
+        <a href="./about.html" class="hover:text-stone-900 dark:hover:text-stone-100">About</a>
+        <a href="./roadmap.html" class="hover:text-stone-900 dark:hover:text-stone-100">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli" class="hover:text-stone-900 dark:hover:text-stone-100">GitHub</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="hover:text-stone-900 dark:hover:text-stone-100">Issues</a>
+        <a href="https://github.com/guycorbaz/mybibli/blob/main/LICENSE" class="hover:text-stone-900 dark:hover:text-stone-100">License</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="./js/site.js"></script>
+</body>
+</html>

--- a/website/js/site.js
+++ b/website/js/site.js
@@ -1,0 +1,66 @@
+// mybibli site — theme toggle + reveal-on-scroll + mobile nav.
+
+(function () {
+  // ---------- Theme toggle ----------
+  const root = document.documentElement;
+  const stored = localStorage.getItem("mybibli-site-theme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const initial = stored || (prefersDark ? "dark" : "light");
+  root.classList.toggle("dark", initial === "dark");
+
+  function setTheme(mode) {
+    root.classList.toggle("dark", mode === "dark");
+    localStorage.setItem("mybibli-site-theme", mode);
+    document.querySelectorAll("[data-theme-toggle]").forEach((btn) => {
+      btn.setAttribute("aria-pressed", mode === "dark" ? "true" : "false");
+    });
+  }
+
+  document.addEventListener("click", (e) => {
+    const btn = e.target.closest("[data-theme-toggle]");
+    if (!btn) return;
+    setTheme(root.classList.contains("dark") ? "light" : "dark");
+  });
+
+  // Initialize aria-pressed on all theme toggles after DOM is ready.
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("[data-theme-toggle]").forEach((btn) => {
+      btn.setAttribute(
+        "aria-pressed",
+        root.classList.contains("dark") ? "true" : "false",
+      );
+    });
+  });
+
+  // ---------- Mobile nav ----------
+  document.addEventListener("click", (e) => {
+    const trigger = e.target.closest("[data-mobile-nav-toggle]");
+    if (!trigger) return;
+    const target = document.getElementById(trigger.getAttribute("aria-controls"));
+    if (!target) return;
+    const open = target.classList.toggle("hidden");
+    trigger.setAttribute("aria-expanded", open ? "false" : "true");
+  });
+
+  // ---------- Reveal on scroll ----------
+  if ("IntersectionObserver" in window) {
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("in");
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 },
+    );
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll(".reveal").forEach((el) => io.observe(el));
+    });
+  } else {
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll(".reveal").forEach((el) => el.classList.add("in"));
+    });
+  }
+})();

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -1,0 +1,419 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Roadmap — mybibli</title>
+  <meta name="description" content="Development roadmap and current sprint status for mybibli — eight epics shipped, one to go before v1." />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📚%3C/text%3E%3C/svg%3E" />
+  <script>
+    (function () {
+      var s = localStorage.getItem("mybibli-site-theme");
+      var d = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (s === "dark" || (!s && d)) document.documentElement.classList.add("dark");
+    })();
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: "class" };
+  </script>
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body class="min-h-screen bg-stone-50 text-stone-900 dark:bg-stone-950 dark:text-stone-100 antialiased">
+
+  <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-indigo-600 focus:px-3 focus:py-2 focus:text-white">Skip to content</a>
+
+  <header class="sticky top-0 z-40 backdrop-blur-md bg-stone-50/80 dark:bg-stone-950/80 border-b border-stone-200 dark:border-stone-800">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 flex items-center justify-between h-14">
+      <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
+        <span aria-hidden="true" class="text-xl">📚</span>
+        <span>mybibli</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 ring-1 ring-amber-200/60 dark:ring-amber-800/50">pre-v1</span>
+      </a>
+      <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
+        <a href="./index.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Home</a>
+        <a href="./about.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">About</a>
+        <a href="./roadmap.html" class="px-3 py-1.5 rounded-md text-indigo-700 dark:text-indigo-300 font-medium" aria-current="page">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Issues</a>
+      </nav>
+      <div class="flex items-center gap-1">
+        <button data-theme-toggle type="button" aria-label="Toggle theme" class="p-2 rounded-md text-stone-600 dark:text-stone-300 hover:bg-stone-200/60 dark:hover:bg-stone-800/60">
+          <svg class="hidden dark:block w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 3v1.5M12 19.5V21M4.22 4.22l1.06 1.06M18.72 18.72l1.06 1.06M3 12h1.5M19.5 12H21M4.22 19.78l1.06-1.06M18.72 5.28l1.06-1.06M12 7.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z" /></svg>
+          <svg class="block dark:hidden w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" /></svg>
+        </button>
+        <a href="https://github.com/guycorbaz/mybibli" class="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-stone-900 dark:bg-stone-100 text-white dark:text-stone-900 hover:opacity-90">
+          <svg class="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8a8.013 8.013 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
+        </a>
+        <button data-mobile-nav-toggle type="button" aria-controls="mobile-nav" aria-expanded="false" aria-label="Open menu" class="md:hidden p-2 rounded-md text-stone-600 dark:text-stone-300 hover:bg-stone-200/60 dark:hover:bg-stone-800/60">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </button>
+      </div>
+    </div>
+    <div id="mobile-nav" class="hidden md:hidden border-t border-stone-200 dark:border-stone-800 bg-stone-50 dark:bg-stone-950 px-4 py-2">
+      <nav aria-label="Mobile" class="flex flex-col">
+        <a href="./index.html" class="py-2 text-stone-600 dark:text-stone-300">Home</a>
+        <a href="./about.html" class="py-2 text-stone-600 dark:text-stone-300">About</a>
+        <a href="./roadmap.html" class="py-2 text-indigo-700 dark:text-indigo-300 font-medium">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="py-2 text-stone-600 dark:text-stone-300">Issues</a>
+        <a href="https://github.com/guycorbaz/mybibli" class="py-2 text-stone-600 dark:text-stone-300">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+
+    <!-- ===================== HERO ===================== -->
+    <section class="relative isolate overflow-hidden">
+      <div class="absolute inset-0 grid-pattern opacity-50" aria-hidden="true"></div>
+      <div class="absolute inset-0 hero-gradient" aria-hidden="true"></div>
+      <div class="relative max-w-4xl mx-auto px-4 sm:px-6 pt-16 pb-12">
+        <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
+          Roadmap
+        </span>
+        <h1 class="mt-5 text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Eight down, one to go.</h1>
+        <p class="mt-5 text-lg text-stone-600 dark:text-stone-300 leading-relaxed">
+          Development is organized into nine epics. Eight have shipped; the ninth — <strong class="text-stone-900 dark:text-stone-100">UX polish &amp; accessibility</strong> — is in flight. v1 ships at its close.
+        </p>
+
+        <!-- Progress bar -->
+        <div class="mt-8" aria-label="Overall progress">
+          <div class="flex items-center justify-between text-sm font-medium">
+            <span class="text-stone-600 dark:text-stone-300">Overall progress</span>
+            <span class="text-stone-900 dark:text-stone-100">~94%</span>
+          </div>
+          <div class="mt-2 h-2.5 rounded-full bg-stone-200 dark:bg-stone-800 overflow-hidden">
+            <div class="h-full rounded-full bg-gradient-to-r from-indigo-500 to-pink-500" style="width: 94%"></div>
+          </div>
+          <p class="mt-2 text-xs text-stone-500 dark:text-stone-400">Source of truth: <code class="font-mono">_bmad-output/implementation-artifacts/sprint-status.yaml</code> in the repo. This page is hand-synced and may lag by a story or two.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== TIMELINE ===================== -->
+    <section class="py-12 sm:py-16">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6">
+        <div class="reveal mb-10">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">The nine epics</h2>
+          <p class="mt-3 text-stone-600 dark:text-stone-300">Each one ships behind a draft PR per story, gated by green CI. Each one ends with a retrospective.</p>
+        </div>
+
+        <ol class="relative border-l-2 border-stone-200 dark:border-stone-800 ml-3 sm:ml-4 space-y-10">
+
+          <!-- Epic 1 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 1</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">Catalog my first book</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Project skeleton, scan field, title CRUD with ISBN scanning, volume management, contributor management, search, async metadata fetch, login. The foundation.</p>
+          </li>
+
+          <!-- Epic 2 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 2</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">I know where my books are</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Configurable storage-location hierarchy, scan-to-shelve workflow, browse a shelf's contents, contextual guidance.</p>
+          </li>
+
+          <!-- Epic 3 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 3</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">All my media types</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Provider chain (BnF / Google Books / Open Library / MusicBrainz / OMDb / TMDB / BDGest), media-type-aware scanning, cover image management, metadata editing and re-download.</p>
+          </li>
+
+          <!-- Epic 4 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 4</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">I manage my loans</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Borrower CRUD &amp; search, loan registration with validation, loan return with automatic location restoration, per-borrower history.</p>
+          </li>
+
+          <!-- Epic 5 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 5</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">My series &amp; my collection</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">E2E test stabilization, contributor deletion guard, series CRUD, title/series assignment with gap detection, BD multi-position omnibus support, browse list/grid toggle, similar titles, Dewey codes.</p>
+          </li>
+
+          <!-- Epic 6 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 6</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">CI/CD pipeline &amp; reliability</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">GitHub Actions pipeline, seeded librarian + login-as for parallel-safe E2E, manually-edited-fields race fix, cleanup of <code class="font-mono text-xs">waitForTimeout</code> with a CI grep gate.</p>
+          </li>
+
+          <!-- Epic 7 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 7</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">Multi-role access &amp; security</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Anonymous browsing with role gating, session inactivity timeout with keep-alive toast, language toggle (FR/EN), strict Content Security Policy headers, scanner-guard modal interception.</p>
+          </li>
+
+          <!-- Epic 8 -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 8</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">Administration &amp; configuration</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Admin shell with health tab, CSRF synchronizer-token middleware, user administration, reference-data management, system settings, trash view + restore, permanent delete + auto-purge, first-launch setup wizard.</p>
+          </li>
+
+          <!-- Epic 9 (active) -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-indigo-500 timeline-active ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-indigo-600 dark:text-indigo-400">Epic 9 — current</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">UX polish &amp; accessibility</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-300">In progress · 10/22</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Dashboard indicators, modal-based confirmations replacing <code class="font-mono text-xs">hx-confirm</code>, status messages and empty states, connection-lost overlay, navbar polish, contextual help tooltips, keyboard shortcuts, responsive layouts, and a final WCAG AA audit.</p>
+          </li>
+
+          <!-- v1 milestone -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[11px] top-1 w-5 h-5 rounded-md bg-pink-500 ring-4 ring-stone-50 dark:ring-stone-950 flex items-center justify-center" aria-hidden="true">
+              <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+            </span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-pink-600 dark:text-pink-400">Milestone</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">v1.0.0 release</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-pink-100 dark:bg-pink-900/40 text-pink-800 dark:text-pink-300">After Epic 9</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">First public release. Pre-built Docker images on Docker Hub, install instructions, release notes.</p>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <!-- ===================== EPIC 9 DETAIL ===================== -->
+    <section class="py-12 sm:py-20 bg-stone-100/60 dark:bg-stone-900/40 border-y border-stone-200 dark:border-stone-800">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="reveal mb-10">
+          <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
+            Active sprint
+          </span>
+          <h2 class="mt-4 text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Epic 9 — story by story</h2>
+          <p class="mt-3 text-stone-600 dark:text-stone-300">Twenty-two stories. Ten shipped, twelve in the backlog. Done stories link to their respective merged PR via the issues view on GitHub.</p>
+        </div>
+
+        <div class="grid sm:grid-cols-2 gap-3">
+          <!-- Done -->
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-1</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Dashboard global stats card</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-2</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Dashboard recent additions</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-3</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Dashboard stats by genre</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-4</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">FilterTag &amp; unshelved indicator</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-5</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Overdue loans indicator</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-6</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Series-with-gaps indicator</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-7</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Recent activity indicators</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-8</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Loan status, role-aware</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-9</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Home page scanner state machine</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-10</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Modal foundation + delete-borrower migration</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
+          </div>
+
+          <!-- Backlog -->
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-11</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate return-loan to modal</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-12</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate delete-contributor to modal</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-13</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate delete-series to modal</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-14</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate deactivate-user to modal</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-15</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Status messages &amp; empty states</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-16</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Connection-lost overlay</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-17</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Navbar hamburger &amp; scanner auto-close</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-18</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Navbar role-visibility polish</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-19</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Contextual help tooltips</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-20</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Keyboard shortcuts &amp; cheat-sheet</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-21</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Responsive per-page layouts</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
+            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+            <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-22</span>
+            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">WCAG AA final audit</span>
+            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== BEYOND v1 ===================== -->
+    <section class="py-16 sm:py-20">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6">
+        <div class="reveal">
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Beyond v1</h2>
+          <p class="mt-3 text-stone-600 dark:text-stone-300 leading-relaxed">
+            Post-v1 plans are tracked openly as GitHub Issues with the <code class="font-mono text-sm">type:change-request</code> label. Likely directions:
+          </p>
+          <ul class="mt-5 space-y-2 text-stone-600 dark:text-stone-300 leading-relaxed marker:text-indigo-500">
+            <li>Pre-built Docker Hub images and a one-line install script.</li>
+            <li>An inline read-status workflow (currently / finished / abandoned) on volumes.</li>
+            <li>A small mobile-friendly "scan a barcode at a friend's place" shortcut.</li>
+            <li>Backup &amp; restore from the admin panel.</li>
+            <li>An optional read-only public catalog for households that want one.</li>
+          </ul>
+          <p class="mt-5 text-stone-600 dark:text-stone-300 leading-relaxed">
+            None of these are committed; they're directions. The shape of v2 will depend on what people actually use v1 for.
+          </p>
+        </div>
+
+        <div class="mt-12 reveal flex flex-wrap gap-3">
+          <a href="https://github.com/guycorbaz/mybibli/issues" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-indigo-600 text-white font-medium shadow-sm hover:bg-indigo-700">
+            Browse open issues
+          </a>
+          <a href="https://github.com/guycorbaz/mybibli/issues/new/choose" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 font-medium ring-1 ring-stone-300 dark:ring-stone-700 hover:bg-stone-100 dark:hover:bg-stone-700">
+            Open a new issue
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-stone-200 dark:border-stone-800 py-10">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between text-sm">
+      <div class="flex items-center gap-2 text-stone-600 dark:text-stone-400">
+        <span aria-hidden="true">📚</span>
+        <span><strong class="text-stone-900 dark:text-stone-100">mybibli</strong> — AGPL-3.0-or-later</span>
+      </div>
+      <nav aria-label="Footer" class="flex flex-wrap gap-x-5 gap-y-2 text-stone-500 dark:text-stone-400">
+        <a href="./about.html" class="hover:text-stone-900 dark:hover:text-stone-100">About</a>
+        <a href="./roadmap.html" class="hover:text-stone-900 dark:hover:text-stone-100">Roadmap</a>
+        <a href="https://github.com/guycorbaz/mybibli" class="hover:text-stone-900 dark:hover:text-stone-100">GitHub</a>
+        <a href="https://github.com/guycorbaz/mybibli/issues" class="hover:text-stone-900 dark:hover:text-stone-100">Issues</a>
+        <a href="https://github.com/guycorbaz/mybibli/blob/main/LICENSE" class="hover:text-stone-900 dark:hover:text-stone-100">License</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="./js/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a static marketing site under `website/` (3 pages — Home / About / Roadmap) and a GitHub Actions workflow that publishes it to GitHub Pages on every merge to `main`.

- **Tech**: plain HTML + Tailwind CSS via CDN (v3, class-based dark mode), tiny vanilla JS module for theme toggle / mobile nav / reveal-on-scroll. Zero build pipeline.
- **Style**: stone + indigo palette to match the app, gradient hero, sticky nav with theme toggle, dark mode default-from-system, mobile menu. WCAG-friendly: skip link, semantic landmarks, `aria-current`, `prefers-reduced-motion` opt-out.
- **Roadmap source-of-truth caveat**: the timeline + Epic 9 detail are hand-synced from `sprint-status.yaml`. The page surfaces this honestly. Auto-sync is parked for post-v1.

## Pages

| Page | What's on it |
|------|--------------|
| `index.html` | Hero with status snapshot, 6 feature cards, "hardened by construction" callout (CSP / CSRF / scanner-guard / data-stays-home), 9-card tech stack grid, gradient CTA, footer. |
| `about.html` | Narrative — why self-hosted, who it's for, design choices that won't change, how it's tested, AGPL-3 rationale. Plus a 9-cell toolchain grid. |
| `roadmap.html` | Vertical timeline of the 9 epics + v1 milestone, hand-edited detail of Epic 9 (10/22 done), "beyond v1" linking to Issues. |

## Deployment

- Workflow: `.github/workflows/pages.yml` — triggered on push to `main` touching `website/**` or the workflow itself, plus `workflow_dispatch`.
- Uses the official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` chain. **No `gh-pages` branch.**

## Required manual step (one-time, after merge)

GitHub Pages must be enabled in **repo Settings → Pages** with source set to **"GitHub Actions"** before the first deploy lands. The first push queues a run that succeeds once the setting is flipped (idempotent — re-trigger via `workflow_dispatch` if needed).

Final URL: **https://guycorbaz.github.io/mybibli/**

## Tested locally

- `python -m http.server` against `website/` — all 4 routes return 200, 6 feature cards rendered on home, theme toggle persists via localStorage.

## Test plan

- [x] Local serve via `python -m http.server`
- [x] All internal links use `./*.html` (relative — works under `/mybibli/` base)
- [ ] After merge: enable Pages in Settings, trigger `workflow_dispatch`, verify URL lands

## Out of scope (future passes)

- Screenshots — placeholders only. Wire after Epic 9 UI polish.
- Auto-sync of roadmap statuses from `sprint-status.yaml` — revisit post-v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)