### PR TITLE
chore(site): auto-enable GitHub Pages on first run

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

Follow-up to PR #130. The workflow run on main right after the merge failed at `actions/configure-pages@v5` because Pages wasn't enabled yet:

> Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions.

Adding `enablement: true` makes the action create the Pages site on the first run instead of asking a human to flip the switch in Settings → Pages.

The `pages: write` permission already declared at the workflow level is the scope the action needs to call `POST /repos/{owner}/{repo}/pages` with `build_type=workflow`. No new secret or token required.

## Test plan

- [ ] CI green on this PR (existing gates run on every PR)
- [ ] After merge: workflow run on main succeeds end-to-end
- [ ] https://guycorbaz.github.io/mybibli/ resolves and renders the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)