### PR TITLE
chore: pre-production hardening (5 fixes + single-tenant decision)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,16 @@ These apply to ALL sessions without exception.
 
 **Stack:** Rust 2024 + Axum 0.8 + SQLx 0.8 (MariaDB) + Askama 0.15 + HTMX 2.0 + Tailwind CSS v4
 
+### Deployment model: single-tenant
+
+mybibli is designed and operated as a **single-tenant** application — one library instance per deployment (typical: a household NAS or a small association). Several design choices follow from this and are intentionally NOT going to be revisited unless a multi-tenant goal is added explicitly:
+
+- **No per-user authorization scope** on admin routes (issue #54). Every Admin can manipulate every other user. The only ownership-style guard is the self-deactivate / last-active-admin pair in `services/users.rs`.
+- **MariaDB deadlock retry, not topology fix** (issue #16). `LoanService::register_loan` retries on SQLSTATE 40001 / MySQL 1205 up to `LOAN_REGISTER_MAX_ATTEMPTS` times. Sufficient for single-librarian load; would need to be revisited (lock ordering + `READ COMMITTED` + optimistic locking on `volumes.version`) if concurrent librarians become a goal.
+- **One settings table for the whole instance**. `AppSettings` is global, not scoped per user.
+
+If/when multi-tenancy is on the roadmap, both #54 and #16 should be re-opened together; they share the same root cause (no tenant boundary in the schema).
+
 ### Source Layout
 
 - `src/routes/` — HTTP handlers. Thin: extract params, call service, return response. `admin.rs` ships the `/admin` page (tabs: health, users, reference_data, trash, system) — admin-only.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       PORT: "8080"
       RUST_LOG: mybibli=info
       APP_LANGUAGE: ${APP_LANGUAGE:-en}
+      # Issue #94 — set to "true" only when the deployment is fronted by HTTPS.
+      # When set, every Set-Cookie carries `Secure`; browsers refuse the cookie
+      # over plain HTTP, so leaving this unset (or "false") is correct for
+      # localhost-only / direct-port deployments.
+      MYBIBLI_COOKIE_SECURE: ${MYBIBLI_COOKIE_SECURE:-false}
     depends_on:
       db:
         condition: service_healthy

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,47 @@ impl std::fmt::Display for ConfigError {
 
 impl std::error::Error for ConfigError {}
 
+/// Pure parse for the `MYBIBLI_COOKIE_SECURE` accept-set. Mirrors the
+/// `csp_report_only` shape: `true` / `True` / `TRUE` / `1` / `yes`
+/// (case-insensitive, whitespace-tolerant). Anything else (incl. `None`)
+/// resolves to `false` so local dev defaults stay safe.
+fn parse_cookie_secure(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("true" | "1" | "yes")
+    )
+}
+
+/// Issue #94: read `MYBIBLI_COOKIE_SECURE` once at first call and cache
+/// the resolved boolean. All cookie issuers (login session, anonymous
+/// session, language preference, wizard back-target / flash, etc.) call
+/// this so the `Secure` attribute is set uniformly.
+///
+/// Default: `false` so local dev over plain `http://localhost:8080` keeps
+/// working unchanged. Production deployments behind HTTPS MUST set
+/// `MYBIBLI_COOKIE_SECURE=true` (the docker-compose `mybibli` service in
+/// production should inject this).
+pub fn cookie_secure() -> bool {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        let raw = env::var("MYBIBLI_COOKIE_SECURE").ok();
+        let secure = parse_cookie_secure(raw.as_deref());
+        match raw.as_deref() {
+            Some(v) => tracing::info!(
+                cookie_secure = secure,
+                cookie_secure_env = v,
+                "Cookie Secure flag resolved from MYBIBLI_COOKIE_SECURE env var"
+            ),
+            None => tracing::info!(
+                cookie_secure = secure,
+                "Cookie Secure flag resolved (no MYBIBLI_COOKIE_SECURE env var, default off)"
+            ),
+        }
+        secure
+    })
+}
+
 /// Read `CSP_REPORT_ONLY` once at startup and emit a `tracing::info!` line
 /// recording the resolved mode so misconfigurations don't fail silently.
 /// Accepts `true` / `True` / `TRUE` / `1` / `yes` (case-insensitive) as
@@ -134,6 +175,52 @@ mod csp_report_only_tests {
     #[test]
     fn whitespace_is_trimmed() {
         with_env(Some("  true  "), || assert!(csp_report_only()));
+    }
+}
+
+#[cfg(test)]
+mod cookie_secure_tests {
+    use super::parse_cookie_secure;
+
+    // Issue #94: pure-function tests for the accept-set. The runtime
+    // wrapper `cookie_secure()` caches via OnceLock so it can't be
+    // re-tested with mutated env; the parser is what matters.
+
+    #[test]
+    fn unset_means_off() {
+        assert!(!parse_cookie_secure(None));
+    }
+
+    #[test]
+    fn lowercase_true_means_on() {
+        assert!(parse_cookie_secure(Some("true")));
+    }
+
+    #[test]
+    fn uppercase_variants_mean_on() {
+        assert!(parse_cookie_secure(Some("TRUE")));
+        assert!(parse_cookie_secure(Some("True")));
+    }
+
+    #[test]
+    fn one_and_yes_mean_on() {
+        assert!(parse_cookie_secure(Some("1")));
+        assert!(parse_cookie_secure(Some("yes")));
+    }
+
+    #[test]
+    fn anything_else_means_off() {
+        assert!(!parse_cookie_secure(Some("false")));
+        assert!(!parse_cookie_secure(Some("0")));
+        assert!(!parse_cookie_secure(Some("")));
+        assert!(!parse_cookie_secure(Some("on")));
+        assert!(!parse_cookie_secure(Some("nope")));
+    }
+
+    #[test]
+    fn whitespace_is_trimmed() {
+        assert!(parse_cookie_secure(Some("  true  ")));
+        assert!(parse_cookie_secure(Some("\ttrue\n")));
     }
 }
 
@@ -235,7 +322,15 @@ impl AppSettings {
         for (key, value) in &rows {
             match key.as_str() {
                 "overdue_loan_threshold_days" => match value.parse::<i32>() {
-                    Ok(v) => settings.overdue_threshold_days = v,
+                    Ok(v) if (1..=365).contains(&v) => settings.overdue_threshold_days = v,
+                    Ok(v) => {
+                        tracing::warn!(
+                            key = %key,
+                            value = %value,
+                            parsed = v,
+                            "overdue_loan_threshold_days out of range (1..=365), using default"
+                        )
+                    }
                     Err(_) => {
                         tracing::warn!(key = %key, value = %value, "Invalid setting value, using default")
                     }
@@ -623,6 +718,23 @@ mod tests {
     }
 
     /// R3-N10: the auto_purge_interval_seconds clamp range.
+    #[test]
+    fn test_overdue_threshold_clamp_predicate() {
+        // The clamp range mirrors the inline guard in `AppSettings::load_from_db`.
+        // Issue #118: an out-of-range DB value must NOT poison `overdue_threshold_days`.
+        let accept = |v: i32| (1..=365).contains(&v);
+
+        assert!(!accept(0), "0 must be rejected (lower bound is 1)");
+        assert!(!accept(-1), "negative must be rejected");
+        assert!(!accept(i32::MIN), "i32::MIN must be rejected");
+        assert!(!accept(366), "366 must be rejected (upper bound is 365)");
+        assert!(!accept(i32::MAX), "i32::MAX must be rejected");
+
+        assert!(accept(1), "lower bound 1 must be accepted");
+        assert!(accept(30), "default 30 must be accepted");
+        assert!(accept(365), "upper bound 365 must be accepted");
+    }
+
     #[test]
     fn test_auto_purge_interval_clamp_constants() {
         assert_eq!(AUTO_PURGE_INTERVAL_MIN_SECS, 60);

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -179,6 +179,7 @@ pub async fn session_resolve_middleware(
                 .path("/")
                 .same_site(SameSite::Lax)
                 .max_age(time::Duration::days(7))
+                .secure(crate::config::cookie_secure())
                 .build();
             if let Ok(value) = cookie.to_string().parse() {
                 response

--- a/src/models/admin_audit.rs
+++ b/src/models/admin_audit.rs
@@ -57,15 +57,37 @@ impl AdminAuditModel {
 
         let id = result.last_insert_id();
 
-        // Read back the DB-assigned timestamp so the in-memory struct matches
-        // the persisted row exactly.
-        let row = sqlx::query(
-            "SELECT CAST(timestamp AS DATETIME) AS ts FROM admin_audit WHERE id = ?"
+        // Issue #80: read back the DB-assigned timestamp so the in-memory
+        // struct matches the persisted row exactly — but DON'T propagate a
+        // SELECT failure as `Err`. The INSERT has already committed; bubbling
+        // up an error would tell the caller "failure" while the audit row is
+        // permanently stored, leaving the admin with a 500 after a hard delete
+        // already happened. Fall back to the local clock and log a warning
+        // instead. The drift vs DB is at most a few ms.
+        let timestamp: NaiveDateTime = match sqlx::query(
+            "SELECT CAST(timestamp AS DATETIME) AS ts FROM admin_audit WHERE id = ?",
         )
         .bind(id as i64)
-        .fetch_one(&mut *conn)
-        .await?;
-        let timestamp: NaiveDateTime = row.get("ts");
+        .fetch_optional(&mut *conn)
+        .await
+        {
+            Ok(Some(row)) => row.get("ts"),
+            Ok(None) => {
+                tracing::warn!(
+                    audit_id = id,
+                    "audit row inserted but follow-up SELECT returned no row (purged or dropped between INSERT and SELECT?) — using local time"
+                );
+                chrono::Utc::now().naive_utc()
+            }
+            Err(e) => {
+                tracing::warn!(
+                    audit_id = id,
+                    error = %e,
+                    "audit row inserted but timestamp re-fetch failed — using local time"
+                );
+                chrono::Utc::now().naive_utc()
+            }
+        };
 
         Ok(AdminAuditEntry {
             id,

--- a/src/models/trash.rs
+++ b/src/models/trash.rs
@@ -75,18 +75,17 @@ impl TrashModel {
         // `NO_BACKSLASH_ESCAPES` sql_mode (sometimes enabled in
         // production) makes the backslash a literal character, breaking
         // backslash-based escapes silently. The `|` is mode-independent.
-        let (final_query, search_term) = if let Some(search) = name_search {
-            if !search.is_empty() {
-                let escaped = escape_like_pattern(search);
-                let subquery = format!(
-                    "({}) AS trash WHERE item_name LIKE ? ESCAPE '|' ORDER BY deleted_at DESC LIMIT ? OFFSET ?",
-                    query_builder
-                );
-                (subquery, Some(format!("%{}%", escaped)))
-            } else {
-                query_builder.push_str(" ORDER BY deleted_at DESC LIMIT ? OFFSET ?");
-                (query_builder, None)
-            }
+        // Issue #79: trim before is_empty so whitespace-only input doesn't
+        // produce a `%' '%` LIKE pattern that "matches" every row containing
+        // a space — silently widening the result set.
+        let trimmed = name_search.map(|s| s.trim()).filter(|s| !s.is_empty());
+        let (final_query, search_term) = if let Some(search) = trimmed {
+            let escaped = escape_like_pattern(search);
+            let subquery = format!(
+                "({}) AS trash WHERE item_name LIKE ? ESCAPE '|' ORDER BY deleted_at DESC LIMIT ? OFFSET ?",
+                query_builder
+            );
+            (subquery, Some(format!("%{}%", escaped)))
         } else {
             query_builder.push_str(" ORDER BY deleted_at DESC LIMIT ? OFFSET ?");
             (query_builder, None)
@@ -167,15 +166,17 @@ impl TrashModel {
         // Optional name-search filter applied to the same UNION used by
         // `list_trash` so count and page slice always agree.
         // R3-N5: `|` escape char (NO_BACKSLASH_ESCAPES safe).
-        let (final_query, search_term) = match name_search {
-            Some(s) if !s.is_empty() => (
+        // Issue #79: trim before is_empty (see list_trash for rationale).
+        let trimmed = name_search.map(|s| s.trim()).filter(|s| !s.is_empty());
+        let (final_query, search_term) = match trimmed {
+            Some(s) => (
                 format!(
                     "SELECT CAST(COUNT(*) AS SIGNED) as count FROM ({}) AS trash WHERE item_name LIKE ? ESCAPE '|'",
                     union_sql
                 ),
                 Some(format!("%{}%", escape_like_pattern(s))),
             ),
-            _ => (
+            None => (
                 format!("SELECT CAST(COUNT(*) AS SIGNED) as count FROM ({}) AS trash", union_sql),
                 None,
             ),
@@ -264,6 +265,23 @@ fn escape_like_pattern(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_name_search_trim_predicate() {
+        // Issue #79: this mirrors the inline predicate used by `list_trash`
+        // and `trash_count`. A whitespace-only `name_search` must collapse
+        // to "no filter", not to a `%' '%` wildcard.
+        fn normalize(input: Option<&str>) -> Option<&str> {
+            input.map(|s| s.trim()).filter(|s| !s.is_empty())
+        }
+
+        assert_eq!(normalize(None), None);
+        assert_eq!(normalize(Some("")), None);
+        assert_eq!(normalize(Some("   ")), None);
+        assert_eq!(normalize(Some("\t \n")), None);
+        assert_eq!(normalize(Some("  hello  ")), Some("hello"));
+        assert_eq!(normalize(Some("hello")), Some("hello"));
+    }
 
     #[test]
     fn test_escape_like_pattern_passthrough() {

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -224,6 +224,7 @@ pub async fn login(
         .http_only(true)
         .path("/")
         .same_site(SameSite::Lax)
+        .secure(crate::config::cookie_secure())
         .build();
 
     // Honor ?next= if safe and same-origin, else default to /catalog.
@@ -245,6 +246,7 @@ pub async fn login(
                 .same_site(SameSite::Lax)
                 .max_age(time::Duration::days(365))
                 .http_only(false)
+                .secure(crate::config::cookie_secure())
                 .build();
             jar.add(lang_cookie)
         }
@@ -332,6 +334,7 @@ pub async fn change_language(
         .same_site(SameSite::Lax)
         .max_age(time::Duration::days(365))
         .http_only(false)
+        .secure(crate::config::cookie_secure())
         .build();
     let jar = jar.add(cookie);
 

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -1141,8 +1141,11 @@ pub async fn handle_scan_with_type(
     let pool = &state.pool;
 
     // Set cookie to remember media type preference for subsequent UPC scans
-    let updated_jar =
-        jar.add(Cookie::build(("media_type_preference", media_type.to_string())).path("/catalog"));
+    let updated_jar = jar.add(
+        Cookie::build(("media_type_preference", media_type.to_string()))
+            .path("/catalog")
+            .secure(crate::config::cookie_secure()),
+    );
 
     match TitleService::create_from_code(
         pool,

--- a/src/routes/setup.rs
+++ b/src/routes/setup.rs
@@ -840,6 +840,7 @@ pub async fn step_1_submit(
             ))
             .path("/")
             .http_only(true)
+            .secure(crate::config::cookie_secure())
             .build();
             let jar = jar.add(flash);
             refresh_gate(&state.setup_gate, &state.pool).await;
@@ -863,6 +864,7 @@ pub async fn step_1_submit(
         .http_only(true)
         .path("/")
         .same_site(SameSite::Lax)
+        .secure(crate::config::cookie_secure())
         .build();
     let jar = jar.add(cookie);
 
@@ -936,6 +938,7 @@ pub async fn step_2_submit(
         let cookie = Cookie::build((COOKIE_BACK_TARGET.to_string(), "admin".to_string()))
             .path("/")
             .http_only(true)
+            .secure(crate::config::cookie_secure())
             .build();
         let jar = jar.add(cookie);
         return Ok((jar, Redirect::to("/setup").into_response()));

--- a/src/services/trash.rs
+++ b/src/services/trash.rs
@@ -25,7 +25,11 @@ impl TrashService {
             return Err(AppError::BadRequest(format!("Invalid table: {}", table)));
         }
 
-        // UPDATE with optimistic locking
+        // Issue #73: wrap UPDATE + existence-check in a single transaction so
+        // the 409-vs-404 distinction can't be flipped by a concurrent admin
+        // hard-deleting (or restoring) the row between our UPDATE-returning-0
+        // and the follow-up SELECT.
+        let mut tx = pool.begin().await?;
         let result = sqlx::query(
             &format!(
                 "UPDATE {} SET deleted_at = NULL, version = version + 1 WHERE id = ? AND deleted_at IS NOT NULL AND version = ?",
@@ -34,16 +38,17 @@ impl TrashService {
         )
         .bind(id as i64)
         .bind(version)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
 
         // Check if update succeeded
         if result.rows_affected() == 0 {
-            // Check if item exists at all
+            // Check if item exists at all (within the same tx snapshot).
             let exists = sqlx::query(&format!("SELECT id FROM {} WHERE id = ?", table))
                 .bind(id as i64)
-                .fetch_optional(pool)
+                .fetch_optional(&mut *tx)
                 .await?;
+            tx.commit().await?;
 
             if exists.is_some() {
                 return Err(AppError::Conflict("version_mismatch".to_string()));
@@ -51,6 +56,7 @@ impl TrashService {
                 return Err(AppError::NotFound("Item not found in trash".to_string()));
             }
         }
+        tx.commit().await?;
 
         // Fetch restored row
         let item_col = match table {


### PR DESCRIPTION
## Summary

Closes the **2 critical** and **3 high-priority** issues from the pre-production audit, plus documents the single-tenant assumption that two known-failures are accepted under.

### Critical
- **#94** — Cookies missing `Secure` flag → new `config::cookie_secure()` (env var `MYBIBLI_COOKIE_SECURE`), sweep across every `Cookie::build` site, exposed in `docker-compose.yml`
- **#118** — `overdue_threshold_days` unclamped on load → accept `1..=365`, warn-and-fall-back otherwise

### High
- **#79** — Trash `name_search` whitespace bypass (trim before is_empty)
- **#73** — Restore TOCTOU 409 vs 404 (wrap UPDATE + existence-SELECT in a transaction)
- **#80** — `admin_audit::create` INSERT-OK / SELECT-fail race (fall back to local clock + warn)

### Documentation (closes the decision half)
- **#54** + **#16** — CLAUDE.md gains a "Deployment model: single-tenant" subsection making the assumption explicit. The retry loop already in `LoanService::register_loan` is sufficient for this mode; the authorization-scope absence is by design.

## Test plan

- [x] `SQLX_OFFLINE=true cargo check` clean
- [x] `SQLX_OFFLINE=true cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` against `mybibli-rust-test` container — **777 passed, 0 failed**
- [x] New pure-fn unit tests:
  - `config::tests::test_overdue_threshold_clamp_predicate`
  - `config::cookie_secure_tests` (6 cases)
  - `models::trash::tests::test_name_search_trim_predicate`
- [ ] CI green on this branch
- [ ] After merge, close issues #16, #54, #73, #79, #80, #94, #118 with cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)