### PR TITLE
chore: bump version 0.1.0 → 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

Cuts the first minor release since 0.1.0 was pushed to Docker Hub ~28 days ago. Aligns \`Cargo.toml\` with the upcoming \`v0.2.0\` tag so the \`release.yml\` workflow's \`verify-version\` step passes.

After merge:
\`\`\`bash
git tag v0.2.0
git push origin v0.2.0
\`\`\`
…triggers the publish workflow → \`gcorbaz/mybibli:0.2.0\` + \`:latest\` on Docker Hub.

## Highlights since 0.1.0

**Epic 9 (UX hardening)** — mobile hamburger nav, tooltip system, keyboard shortcuts cheat-sheet, status messages, modal migrations for all destructive flows, WCAG 2.2 AA full coverage via axe-core.

**Pre-production hardening** — \`MYBIBLI_COOKIE_SECURE\` flag, overdue_threshold_days clamp, trash search whitespace trim, restore TOCTOU tx-snapshot, admin_audit INSERT-OK race recovery.

**Documentation** — Single-tenant deployment model explicit in CLAUDE.md.

## Test plan

- [x] \`cargo check\` clean
- [ ] CI gates green (Rust + clippy + sqlx-prepare + DB integration + E2E + wizard E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)