### PR TITLE
chore: v1.0.0 release — bump version + sync README and Pages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Personal library cataloging for home collectors.
 
-**Status:** active development — pre-v1 (current version: `0.1.0`). Epics 1–8 done; Epic 9 (Polish UX & Accessibilité) is next. First public release targeted after Epic 9.
+**Status:** first public release shipped — `v1.0.0`. All nine epics done. Pre-built images on Docker Hub at [`gcorbaz/mybibli`](https://hub.docker.com/r/gcorbaz/mybibli).
 
 ## What it is
 
@@ -34,7 +34,7 @@ Built for collectors who want more than a spreadsheet:
 
 ## Quick start (end users)
 
-Pre-built images are published to Docker Hub once v1 ships. Until then, see **Development** below.
+Pre-built images are published to Docker Hub at [`gcorbaz/mybibli`](https://hub.docker.com/r/gcorbaz/mybibli) — `:latest` tracks the highest semver, individual tags pin to the exact release. For development against the source tree, see **Development** below.
 
 ## Development
 
@@ -228,9 +228,9 @@ Coding conventions and architecture rules for contributors are in [`CLAUDE.md`](
 | 6 | Pipeline CI/CD et fiabilité | ✅ done |
 | 7 | Accès multi-rôle & Sécurité | ✅ done |
 | 8 | Administration & Configuration | ✅ done |
-| 9 | Polish UX & Accessibilité | 🚧 next (decomposition pending) |
+| 9 | Polish UX & Accessibilité | ✅ done |
 
-v1 release will ship after Epic 9. See [`epics.md`](_bmad-output/planning-artifacts/epics.md) for the full breakdown and [`sprint-status.yaml`](_bmad-output/implementation-artifacts/sprint-status.yaml) for the live story-by-story state.
+v1.0.0 shipped after Epic 9 close (2026-05-10). See [`epics.md`](_bmad-output/planning-artifacts/epics.md) for the full breakdown and [`sprint-status.yaml`](_bmad-output/implementation-artifacts/sprint-status.yaml) for the story-by-story state.
 
 ## License
 

--- a/website/about.html
+++ b/website/about.html
@@ -28,7 +28,7 @@
       <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
         <span aria-hidden="true" class="text-xl">📚</span>
         <span>mybibli</span>
-        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 ring-1 ring-amber-200/60 dark:ring-amber-800/50">pre-v1</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.0.0</span>
       </a>
       <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
         <a href="./index.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Home</a>

--- a/website/index.html
+++ b/website/index.html
@@ -47,7 +47,7 @@
       <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
         <span aria-hidden="true" class="text-xl">📚</span>
         <span>mybibli</span>
-        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 ring-1 ring-amber-200/60 dark:ring-amber-800/50">pre-v1</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.0.0</span>
       </a>
 
       <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
@@ -94,7 +94,7 @@
         <div class="max-w-3xl">
           <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
             <span class="w-1.5 h-1.5 rounded-full bg-indigo-500 dark:bg-indigo-400"></span>
-            Active development · v0.1.0
+            v1.0.0 · first public release
           </span>
           <h1 class="mt-5 text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
             Your home library,<br class="hidden sm:block" />
@@ -328,9 +328,9 @@
         <div class="reveal relative overflow-hidden rounded-2xl p-10 sm:p-14 bg-gradient-to-br from-indigo-600 via-indigo-700 to-pink-600 text-white shadow-xl">
           <div class="absolute inset-0 grid-pattern opacity-20" aria-hidden="true"></div>
           <div class="relative">
-            <h2 class="text-2xl sm:text-3xl font-bold">Pre-v1, in active development.</h2>
+            <h2 class="text-2xl sm:text-3xl font-bold">v1.0.0 is here.</h2>
             <p class="mt-3 text-indigo-100 max-w-2xl">
-              Eight epics shipped, one to go. v1 ships after Epic 9 — UX polish and accessibility. Watch the repo to be notified, or jump into the issues.
+              All nine epics shipped. Pre-built Docker images on Docker Hub. Watch the repo to be notified of future releases, or jump into the issues to shape v2.
             </p>
             <div class="mt-6 flex flex-wrap gap-3">
               <a href="https://github.com/guycorbaz/mybibli" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-white text-indigo-700 font-medium hover:bg-indigo-50">

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Roadmap — mybibli</title>
-  <meta name="description" content="Development roadmap and current sprint status for mybibli — eight epics shipped, one to go before v1." />
+  <meta name="description" content="Development roadmap for mybibli — v1.0.0 shipped, all nine epics done, post-v1 directions tracked openly as GitHub issues." />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📚%3C/text%3E%3C/svg%3E" />
   <script>
     (function () {
@@ -28,7 +28,7 @@
       <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
         <span aria-hidden="true" class="text-xl">📚</span>
         <span>mybibli</span>
-        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 ring-1 ring-amber-200/60 dark:ring-amber-800/50">pre-v1</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.0.0</span>
       </a>
       <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
         <a href="./index.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Home</a>
@@ -71,21 +71,21 @@
         <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
           Roadmap
         </span>
-        <h1 class="mt-5 text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Eight down, one to go.</h1>
+        <h1 class="mt-5 text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50">All nine epics shipped.</h1>
         <p class="mt-5 text-lg text-stone-600 dark:text-stone-300 leading-relaxed">
-          Development is organized into nine epics. Eight have shipped; the ninth — <strong class="text-stone-900 dark:text-stone-100">UX polish &amp; accessibility</strong> — is in flight. v1 ships at its close.
+          Development was organized into nine epics. <strong class="text-stone-900 dark:text-stone-100">v1.0.0 shipped at Epic 9's close</strong> — pre-built Docker images now live on Docker Hub. Post-v1 directions are tracked openly as GitHub issues.
         </p>
 
         <!-- Progress bar -->
         <div class="mt-8" aria-label="Overall progress">
           <div class="flex items-center justify-between text-sm font-medium">
-            <span class="text-stone-600 dark:text-stone-300">Overall progress</span>
-            <span class="text-stone-900 dark:text-stone-100">~94%</span>
+            <span class="text-stone-600 dark:text-stone-300">v1 scope</span>
+            <span class="text-stone-900 dark:text-stone-100">100%</span>
           </div>
           <div class="mt-2 h-2.5 rounded-full bg-stone-200 dark:bg-stone-800 overflow-hidden">
-            <div class="h-full rounded-full bg-gradient-to-r from-indigo-500 to-pink-500" style="width: 94%"></div>
+            <div class="h-full rounded-full bg-gradient-to-r from-indigo-500 to-emerald-500" style="width: 100%"></div>
           </div>
-          <p class="mt-2 text-xs text-stone-500 dark:text-stone-400">Source of truth: <code class="font-mono">_bmad-output/implementation-artifacts/sprint-status.yaml</code> in the repo. This page is hand-synced and may lag by a story or two.</p>
+          <p class="mt-2 text-xs text-stone-500 dark:text-stone-400">Source of truth: <code class="font-mono">_bmad-output/implementation-artifacts/sprint-status.yaml</code> in the repo.</p>
         </div>
       </div>
     </section>
@@ -188,28 +188,28 @@
             <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Admin shell with health tab, CSRF synchronizer-token middleware, user administration, reference-data management, system settings, trash view + restore, permanent delete + auto-purge, first-launch setup wizard.</p>
           </li>
 
-          <!-- Epic 9 (active) -->
+          <!-- Epic 9 (done) -->
           <li class="reveal pl-6 sm:pl-8 relative">
-            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-indigo-500 timeline-active ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
             <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <span class="text-xs uppercase tracking-wide font-semibold text-indigo-600 dark:text-indigo-400">Epic 9 — current</span>
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 9</span>
               <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">UX polish &amp; accessibility</h3>
-              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-300">In progress · 10/22</span>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
             </div>
-            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Dashboard indicators, modal-based confirmations replacing <code class="font-mono text-xs">hx-confirm</code>, status messages and empty states, connection-lost overlay, navbar polish, contextual help tooltips, keyboard shortcuts, responsive layouts, and a final WCAG AA audit.</p>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Dashboard indicators, modal-based confirmations replacing <code class="font-mono text-xs">hx-confirm</code>, status messages and empty states, connection-lost overlay, navbar polish, contextual help tooltips, keyboard shortcuts, responsive layouts, and a final WCAG 2.2 AA audit.</p>
           </li>
 
-          <!-- v1 milestone -->
+          <!-- v1 milestone (shipped) -->
           <li class="reveal pl-6 sm:pl-8 relative">
-            <span class="absolute -left-[11px] top-1 w-5 h-5 rounded-md bg-pink-500 ring-4 ring-stone-50 dark:ring-stone-950 flex items-center justify-center" aria-hidden="true">
+            <span class="absolute -left-[11px] top-1 w-5 h-5 rounded-md bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950 flex items-center justify-center" aria-hidden="true">
               <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
             </span>
             <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <span class="text-xs uppercase tracking-wide font-semibold text-pink-600 dark:text-pink-400">Milestone</span>
+              <span class="text-xs uppercase tracking-wide font-semibold text-emerald-600 dark:text-emerald-400">Milestone</span>
               <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">v1.0.0 release</h3>
-              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-pink-100 dark:bg-pink-900/40 text-pink-800 dark:text-pink-300">After Epic 9</span>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Shipped</span>
             </div>
-            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">First public release. Pre-built Docker images on Docker Hub, install instructions, release notes.</p>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">First public release. Pre-built Docker images on Docker Hub at <a href="https://hub.docker.com/r/gcorbaz/mybibli" class="underline decoration-stone-400 hover:decoration-indigo-500">gcorbaz/mybibli</a> (<code class="font-mono text-xs">:1.0.0</code> + <code class="font-mono text-xs">:latest</code>).</p>
           </li>
         </ol>
       </div>
@@ -219,11 +219,11 @@
     <section class="py-12 sm:py-20 bg-stone-100/60 dark:bg-stone-900/40 border-y border-stone-200 dark:border-stone-800">
       <div class="max-w-5xl mx-auto px-4 sm:px-6">
         <div class="reveal mb-10">
-          <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
-            Active sprint
+          <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-600/10 dark:bg-emerald-400/10 ring-1 ring-emerald-600/20 dark:ring-emerald-400/30 text-emerald-700 dark:text-emerald-300 text-xs font-medium">
+            Epic complete
           </span>
           <h2 class="mt-4 text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">Epic 9 — story by story</h2>
-          <p class="mt-3 text-stone-600 dark:text-stone-300">Twenty-two stories. Ten shipped, twelve in the backlog. Done stories link to their respective merged PR via the issues view on GitHub.</p>
+          <p class="mt-3 text-stone-600 dark:text-stone-300">Twenty-two stories. All shipped, retrospective complete (2026-05-10). Each story links to its merged PR via the issues view on GitHub.</p>
         </div>
 
         <div class="grid sm:grid-cols-2 gap-3">
@@ -289,78 +289,77 @@
             <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
 
-          <!-- Backlog -->
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-11</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate return-loan to modal</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Migrate return-loan to modal</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-12</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate delete-contributor to modal</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Migrate delete-contributor to modal</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-13</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate delete-series to modal</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Migrate delete-series to modal</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-14</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Migrate deactivate-user to modal</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Migrate deactivate-user to modal</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-15</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Status messages &amp; empty states</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Status messages &amp; empty states</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-16</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Connection-lost overlay</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Connection-lost overlay</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-17</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Navbar hamburger &amp; scanner auto-close</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Navbar hamburger &amp; scanner auto-close</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-18</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Navbar role-visibility polish</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Navbar role-visibility polish</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-19</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Contextual help tooltips</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Contextual help tooltips</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-20</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Keyboard shortcuts &amp; cheat-sheet</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Keyboard shortcuts &amp; cheat-sheet</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-21</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">Responsive per-page layouts</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">Responsive per-page layouts</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
-          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-stone-50 dark:bg-stone-900/50 ring-1 ring-dashed ring-stone-300 dark:ring-stone-700">
-            <span class="w-2 h-2 rounded-full bg-stone-400 dark:bg-stone-600" aria-hidden="true"></span>
+          <div class="reveal flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-stone-900 ring-1 ring-stone-200 dark:ring-stone-800">
+            <span class="w-2 h-2 rounded-full bg-emerald-500" aria-hidden="true"></span>
             <span class="text-xs font-mono text-stone-500 dark:text-stone-400">9-22</span>
-            <span class="text-sm text-stone-700 dark:text-stone-300 flex-1">WCAG AA final audit</span>
-            <span class="text-xs text-stone-500 dark:text-stone-400 font-medium">backlog</span>
+            <span class="text-sm text-stone-800 dark:text-stone-200 flex-1">WCAG AA final audit</span>
+            <span class="text-xs text-emerald-700 dark:text-emerald-300 font-medium">done</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Cancels and supersedes the v0.2.0 attempt — per the public roadmap, v1.0.0 is the correct version target after Epic 9 close. This PR aligns Cargo.toml, README, and the GitHub Pages site with that target.

## Changes

| File | Before | After |
|---|---|---|
| \`Cargo.toml\` | \`0.2.0\` | \`1.0.0\` |
| \`README.md\` status | active development — pre-v1 | first public release shipped (v1.0.0) |
| \`website/index.html\` hero badge | Active development · v0.1.0 | v1.0.0 · first public release |
| \`website/index.html\` CTA | Pre-v1, in active development | v1.0.0 is here |
| \`website/roadmap.html\` hero | Eight down, one to go | All nine epics shipped |
| \`website/roadmap.html\` progress | 94% | 100% |
| \`website/roadmap.html\` Epic 9 | In progress · 10/22 | ✓ Done |
| \`website/roadmap.html\` v1 milestone | After Epic 9 | ✓ Shipped (linked to Docker Hub) |
| \`website/roadmap.html\` story-by-story | 10 done + 12 backlog | 22 done |
| Header badge (3 pages) | pre-v1 (amber) | v1.0.0 (emerald) |

## Test plan

- [x] \`cargo check\` clean
- [ ] CI gates green (Rust + clippy + sqlx-prepare + DB integration + E2E + wizard E2E)
- [ ] After merge: tag \`v1.0.0\` → \`release.yml\` builds + pushes \`gcorbaz/mybibli:1.0.0\` + \`:latest\` to Docker Hub
- [ ] After Pages workflow runs: verify roadmap/index reflect v1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)