### PR TITLE
chore: bump version 1.0.0 → 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

Patch release bundling the post-v1.0.0 work since the first public release. Required by \`release.yml\`'s \`verify-version\` step before tagging \`v1.0.1\`.

## Changes covered

**Pre-production hardening** (PR #164):
- \`MYBIBLI_COOKIE_SECURE\` env var → adds Secure flag on every Set-Cookie behind HTTPS
- \`overdue_threshold_days\` clamp 1..=365 on load_from_db
- Trash \`name_search\` whitespace trim
- Restore TOCTOU 409-vs-404 wrapped in tx snapshot
- admin_audit INSERT-OK / SELECT-fail race → fallback to local clock
- Single-tenant deployment model documented in CLAUDE.md

**Cosmetic batch Phase 1** (PR #167):
- \`html_escape()\` body_html in 5 modal handlers (defense-in-depth for community translations)
- Duplicate \`#session-counter\` ID removed
- setup_step_providers wrapped in \`<fieldset>\` + help-icon on \`<legend>\`
- \`aria-describedby\` moved from help-icon button → 11 form controls
- \`aria-label="Pagination"\` + \`"Remove filter"\` i18n on 5 pages

## Test plan

- [x] \`cargo check\` clean
- [ ] CI gates green (Rust + clippy + sqlx-prepare + DB integration + E2E + wizard E2E)
- [ ] After merge: tag \`v1.0.1\` → release.yml builds + pushes \`gcorbaz/mybibli:1.0.1\` + \`:latest\` on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)