### PR TITLE
Story #150: mobile hamburger login/logout parity

### DIFF
--- a/templates/components/nav_bar.html
+++ b/templates/components/nav_bar.html
@@ -80,6 +80,17 @@
         <button type="submit" name="lang" value="en" lang="en" aria-pressed="false" class="text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100 focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2">EN</button>
         {% endif %}
     </form>
+    {# Issue #150 — mobile parity with desktop login/logout (lines 40-47 above).
+       Without this block, an authenticated user on a ≤768px viewport cannot
+       sign out via the navbar (the desktop strip is hidden by `md:hidden`). #}
+    {% if role == "anonymous" %}
+    <a href="/login" class="block py-2 text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100">{{ nav_login }}</a>
+    {% else %}
+    <form method="POST" action="/logout" class="py-2">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
+        <button type="submit" class="block w-full text-left text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100 bg-transparent border-none p-0 cursor-pointer">{{ nav_logout }}</button>
+    </form>
+    {% endif %}
 </div>
 </header>
 

--- a/tests/e2e/specs/journeys/login-smoke.spec.ts
+++ b/tests/e2e/specs/journeys/login-smoke.spec.ts
@@ -12,8 +12,10 @@ test.describe("Login/Logout & Epic 1 Smoke Test (Story 1-9)", () => {
     // Start from home page — no cookies
     await page.goto("/");
 
-    // Click login link in nav bar
-    const loginLink = page.locator('a[href="/login"]');
+    // Click login link in nav bar. Scope to `<nav>` so we don't strict-mode
+    // collide with the mirror link inside `<div id="mobile-nav">` (added by
+    // issue #150 — sibling of <nav>, hidden on desktop but present in the DOM).
+    const loginLink = page.locator('nav a[href="/login"]');
     await expect(loginLink).toBeVisible({ timeout: 5000 });
     await loginLink.click();
 

--- a/tests/e2e/specs/journeys/navbar-hamburger.spec.ts
+++ b/tests/e2e/specs/journeys/navbar-hamburger.spec.ts
@@ -223,4 +223,37 @@ test.describe("Story 9-17 — NavBar hamburger menu", () => {
     );
     expect(errors).toHaveLength(0);
   });
+
+  // Issue #150 — authenticated users on tablet/mobile can log out via
+  // the hamburger panel (parity with the desktop strip hidden by md:hidden).
+  test("logout from mobile panel signs the user out", async ({ page }) => {
+    await loginAs(page, "librarian");
+    await page.setViewportSize(TABLET);
+    await page.goto("/catalog");
+
+    await page.locator("#mobile-menu-toggle").click();
+    await expect(page.locator("#mobile-nav")).not.toHaveClass(
+      /(?:^|\s)hidden(?:\s|$)/,
+    );
+
+    // The mobile panel carries its own POST /logout form. Submit it and
+    // follow the redirect to /.
+    const logoutForm = page.locator(
+      '#mobile-nav form[action="/logout"][method="POST"]',
+    );
+    await expect(logoutForm).toBeVisible();
+    await logoutForm.locator('button[type="submit"]').click();
+
+    // Post-logout, the session cookie is cleared and the user lands on
+    // the public landing page with the anonymous navbar.
+    await page.waitForURL((u) => u.pathname === "/");
+    await page.setViewportSize(TABLET);
+    await page.locator("#mobile-menu-toggle").click();
+    await expect(
+      page.locator('#mobile-nav a[href="/login"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('#mobile-nav form[action="/logout"]'),
+    ).toHaveCount(0);
+  });
 });

--- a/tests/e2e/specs/journeys/navbar-role-visibility.spec.ts
+++ b/tests/e2e/specs/journeys/navbar-role-visibility.spec.ts
@@ -9,9 +9,9 @@
  *
  * Spec ID "NV" — no ISBNs generated.
  *
- * Mobile-panel gap (AC16): the panel does NOT have login/logout — that's
- * a deferred change. Tests assert the gap explicitly so any future work
- * filling it must update both this spec and `tests/navbar_hamburger.rs`.
+ * Mobile-panel login/logout parity (issue #150 — shipped): the panel
+ * now carries the same role-gated login link / logout POST form as the
+ * desktop strip. The 3 scenarios assert this positively.
  */
 import { test, expect } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
@@ -51,12 +51,14 @@ test.describe("Story 9-18 — NavBar role-based visibility", () => {
     await expect(panel.locator("a[href='/locations']")).toBeVisible();
     await expect(panel.locator("a[href='/series']")).toBeVisible();
 
-    // Mobile — hidden (incl. Sign in per the AC16 mobile-gap decision)
+    // Mobile — hidden
     await expect(panel.locator("a[href='/borrowers']")).toHaveCount(0);
     await expect(panel.locator("a[href='/loans']")).toHaveCount(0);
     await expect(panel.locator("a[href='/admin']")).toHaveCount(0);
-    await expect(panel.locator("a[href='/login']")).toHaveCount(0);
     await expect(panel.locator("form[action='/logout']")).toHaveCount(0);
+
+    // Mobile — visible (issue #150 — Sign in now in panel for parity)
+    await expect(panel.locator("a[href='/login']")).toBeVisible();
   });
 
   test("librarian — nav link set on /loans (desktop + mobile panel)", async ({
@@ -86,16 +88,16 @@ test.describe("Story 9-18 — NavBar role-based visibility", () => {
     const panel = page.locator("#mobile-nav");
     await expect(panel).toBeVisible();
 
-    // Mobile — visible
+    // Mobile — visible (issue #150 — logout in panel for parity)
     await expect(panel.locator("a[href='/catalog']")).toBeVisible();
     await expect(panel.locator("a[href='/locations']")).toBeVisible();
     await expect(panel.locator("a[href='/series']")).toBeVisible();
     await expect(panel.locator("a[href='/borrowers']")).toBeVisible();
     await expect(panel.locator("a[href='/loans']")).toBeVisible();
+    await expect(panel.locator("form[action='/logout']")).toBeVisible();
 
-    // Mobile — hidden (incl. logout per AC16 gap)
+    // Mobile — hidden
     await expect(panel.locator("a[href='/admin']")).toHaveCount(0);
-    await expect(panel.locator("form[action='/logout']")).toHaveCount(0);
     await expect(panel.locator("a[href='/login']")).toHaveCount(0);
   });
 
@@ -127,16 +129,16 @@ test.describe("Story 9-18 — NavBar role-based visibility", () => {
     const panel = page.locator("#mobile-nav");
     await expect(panel).toBeVisible();
 
-    // Mobile — visible (admin set including /admin)
+    // Mobile — visible (admin set + logout per issue #150)
     await expect(panel.locator("a[href='/catalog']")).toBeVisible();
     await expect(panel.locator("a[href='/locations']")).toBeVisible();
     await expect(panel.locator("a[href='/series']")).toBeVisible();
     await expect(panel.locator("a[href='/borrowers']")).toBeVisible();
     await expect(panel.locator("a[href='/loans']")).toBeVisible();
     await expect(panel.locator("a[href='/admin']")).toBeVisible();
+    await expect(panel.locator("form[action='/logout']")).toBeVisible();
 
-    // Mobile — hidden (logout gap per AC16)
-    await expect(panel.locator("form[action='/logout']")).toHaveCount(0);
+    // Mobile — hidden
     await expect(panel.locator("a[href='/login']")).toHaveCount(0);
   });
 });

--- a/tests/navbar_role_visibility.rs
+++ b/tests/navbar_role_visibility.rs
@@ -197,12 +197,14 @@ async fn anonymous_nav_link_set_exact(pool: MySqlPool) {
     assert!(panel.contains(r#"href="/series""#), "panel must include /series for anonymous; got panel: {panel}");
     assert!(panel.contains(r#"action="/language""#), "panel must include language toggle for anonymous; got panel: {panel}");
 
-    // Mobile panel — hidden (incl. Sign in per the mobile-gap decision)
+    // Mobile panel — hidden
     assert!(!panel.contains(r#"href="/borrowers""#), "panel must HIDE /borrowers for anonymous; got panel: {panel}");
     assert!(!panel.contains(r#"href="/loans""#), "panel must HIDE /loans for anonymous; got panel: {panel}");
     assert!(!panel.contains(r#"href="/admin""#), "panel must HIDE /admin for anonymous; got panel: {panel}");
-    assert!(!panel.contains(r#"href="/login""#), "panel must HIDE Sign in for anonymous (mobile gap, deferred to AC16); got panel: {panel}");
     assert!(!panel.contains(r#"action="/logout""#), "panel must HIDE logout form for anonymous; got panel: {panel}");
+
+    // Mobile panel — visible (issue #150 — login/logout parity with desktop)
+    assert!(panel.contains(r#"href="/login""#), "panel must include Sign in for anonymous (issue #150); got panel: {panel}");
 }
 
 // AC2 — Librarian nav-link set frozen.
@@ -234,16 +236,16 @@ async fn librarian_nav_link_set_exact(pool: MySqlPool) {
     assert!(!desktop.contains(r#"href="/admin""#), "desktop must HIDE /admin for librarian; got: {desktop}");
     assert!(!desktop.contains(r#"href="/login""#), "desktop must HIDE Sign in for librarian; got: {desktop}");
 
-    // Mobile panel — visible (no logout per AC16 gap)
+    // Mobile panel — visible (issue #150 — logout now in panel for parity)
     assert!(panel.contains(r#"href="/catalog""#), "panel must include /catalog for librarian; got panel: {panel}");
     assert!(panel.contains(r#"href="/locations""#), "panel must include /locations for librarian");
     assert!(panel.contains(r#"href="/series""#), "panel must include /series for librarian");
     assert!(panel.contains(r#"href="/borrowers""#), "panel must include /borrowers for librarian");
     assert!(panel.contains(r#"href="/loans""#), "panel must include /loans for librarian");
+    assert!(panel.contains(r#"action="/logout""#), "panel must include logout form for librarian (issue #150); got panel: {panel}");
 
-    // Mobile panel — hidden (incl. logout per AC16 gap)
+    // Mobile panel — hidden
     assert!(!panel.contains(r#"href="/admin""#), "panel must HIDE /admin for librarian; got panel: {panel}");
-    assert!(!panel.contains(r#"action="/logout""#), "panel must HIDE logout form for librarian (mobile gap, deferred to AC16); got panel: {panel}");
     assert!(!panel.contains(r#"href="/login""#), "panel must HIDE Sign in for librarian; got panel: {panel}");
 }
 
@@ -276,16 +278,16 @@ async fn admin_nav_link_set_exact(pool: MySqlPool) {
     // Desktop — hidden
     assert!(!desktop.contains(r#"href="/login""#), "desktop must HIDE Sign in for admin");
 
-    // Mobile panel — visible
+    // Mobile panel — visible (issue #150 — logout now in panel for parity)
     assert!(panel.contains(r#"href="/catalog""#), "panel must include /catalog for admin");
     assert!(panel.contains(r#"href="/locations""#), "panel must include /locations for admin");
     assert!(panel.contains(r#"href="/series""#), "panel must include /series for admin");
     assert!(panel.contains(r#"href="/borrowers""#), "panel must include /borrowers for admin");
     assert!(panel.contains(r#"href="/loans""#), "panel must include /loans for admin");
     assert!(panel.contains(r#"href="/admin""#), "panel must include /admin for admin");
+    assert!(panel.contains(r#"action="/logout""#), "panel must include logout form for admin (issue #150); got panel: {panel}");
 
-    // Mobile panel — hidden (incl. logout per AC16 gap)
-    assert!(!panel.contains(r#"action="/logout""#), "panel must HIDE logout form for admin (mobile gap, deferred to AC16); got panel: {panel}");
+    // Mobile panel — hidden
     assert!(!panel.contains(r#"href="/login""#), "panel must HIDE Sign in for admin");
 }
 
@@ -463,9 +465,10 @@ async fn role_change_reflects_immediately_in_template_render(pool: MySqlPool) {
     );
 }
 
-// AC6 — Sign out is a POST form on the desktop nav, with a hidden
-// _csrf_token input. NOT an `<a href="/logout">`. Mobile panel does NOT
-// render the form (mobile gap, deferred to AC16).
+// AC6 — Sign out is a POST form, with a hidden _csrf_token input. NOT an
+// `<a href="/logout">`. Issue #150: the mobile panel now renders its own
+// logout form for parity with desktop, so we expect 2 occurrences in
+// total (one desktop, one mobile-panel).
 #[sqlx::test(migrations = "./migrations")]
 async fn logout_is_post_form_with_csrf_token(pool: MySqlPool) {
     let cookie = seed_session(&pool, "admin").await;
@@ -479,15 +482,15 @@ async fn logout_is_post_form_with_csrf_token(pool: MySqlPool) {
     assert_eq!(resp.status(), StatusCode::OK);
     let html = body_text(resp).await;
 
-    // Exactly ONE POST logout form in the entire body — desktop only.
-    // NOTE: when AC16 (mobile login/logout gap) lands and adds a logout
-    // form to the mobile panel, this assertion will need to be updated
-    // to expect 2. The expectation here is a snapshot of the current
-    // (audited) state, not a forever-contract.
+    // Issue #150: two POST logout forms — one in the desktop strip, one
+    // in the mobile panel. Both share the CSRF input + same `/logout`
+    // action. The CSRF assertion below targets the FIRST form (desktop)
+    // via `html.find(...)` so the contract still pins down the desktop
+    // form's internal shape.
     let logout_forms = html.matches(r#"action="/logout""#).count();
     assert_eq!(
-        logout_forms, 1,
-        "expected exactly 1 logout form (desktop only; mobile gap deferred to AC16); got {logout_forms}"
+        logout_forms, 2,
+        "expected exactly 2 logout forms (desktop + mobile-panel per issue #150); got {logout_forms}"
     );
 
     // Slice the logout form's HTML so subsequent assertions verify the


### PR DESCRIPTION
## Summary

Closes #150. Authenticated users on tablet/mobile (≤768px) can now sign out via the navbar hamburger panel; anonymous users see a Sign-in link in the same place. Parity with the desktop strip (which is hidden by \`md:hidden\` at those viewports).

## Changes

- \`templates/components/nav_bar.html\` — replicate the desktop role-gated login/logout block inside the mobile panel, after the language form. The logout uses a POST \`<form>\` with the standard \`_csrf_token\` hidden input.
- \`tests/navbar_role_visibility.rs\` — flip the 3 "deferred to AC16" negative assertions to positive contracts (now-shipped behavior), bump \`logout_is_post_form_with_csrf_token\` expected count 1 → 2.
- \`tests/e2e/specs/journeys/navbar-hamburger.spec.ts\` — new E2E scenario "logout from mobile panel signs the user out" (TABLET viewport, panel open, submit POST /logout, assert redirect + anonymous re-open).

## Test plan

- [x] \`cargo check\` + \`cargo clippy -- -D warnings\` clean
- [x] \`cargo test --lib\` → **779 passed**
- [x] \`cargo test --test navbar_role_visibility\` → **7 passed** (all 3 flipped assertions pass)
- [ ] CI gates green (Rust + DB + E2E + wizard E2E) — incl. the new E2E scenario

After merge: close #150 with cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)