### PR TITLE
chore: centralize all config in .env, parametrize docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,45 @@
 # mybibli Environment Configuration
 # Copy this file to .env and adjust values for your environment.
-# NOTE: In production, environment variables are injected by Docker — no .env file needed.
+#
+# All configuration lives here — docker-compose.yml interpolates from this file
+# and the Rust binary reads it when running `cargo run` locally.
+# You should NEVER need to edit docker-compose.yml.
 
-# Database
+# --- Database connection (read directly by the Rust binary) ---
+# In Docker, the app rebuilds this URL from the MYSQL_* parts below —
+# keep this URL in sync if you change them.
 DATABASE_URL=mysql://mybibli:mybibli_password@localhost:3306/mybibli?charset=utf8mb4
 
-# Server
+# --- Database connection parts (interpolated by docker-compose.yml) ---
+# When using the bundled `db` service, leave MYSQL_HOST=db.
+# For an external database, set MYSQL_HOST to its hostname (and comment out
+# the `db:` service + `depends_on:` + `volumes:` blocks in docker-compose.yml).
+MYSQL_HOST=db
+MYSQL_PORT=3306
+MYSQL_DATABASE=mybibli
+MYSQL_USER=mybibli
+MYSQL_PASSWORD=mybibli_password
+# Only used by the bundled `db` service — ignored when using an external DB.
+MYSQL_ROOT_PASSWORD=root_password
+
+# --- Server ---
 HOST=0.0.0.0
 PORT=8080
+# Port published by Docker on the host (maps to container PORT above).
+HOST_PORT=8080
 
-# Application
-RUST_LOG=mybibli=debug,tower_http=debug
+# --- Application ---
+RUST_LOG=mybibli=info
 APP_LANGUAGE=en
 
+# --- Cookie security ---
+# Issue #94 — set to "true" only when the deployment is fronted by HTTPS.
+# When set, every Set-Cookie carries `Secure`; browsers refuse the cookie
+# over plain HTTP, so leaving this "false" is correct for localhost-only
+# or direct-port deployments.
+MYBIBLI_COOKIE_SECURE=false
+
+# --- Optional dev/test overrides ---
 # Story 8-7: skip the startup auto-purge for fast dev/test loops.
 # Accepts only "1" / "true" / "TRUE"; anything else (incl. empty / "0") is ignored.
 # MYBIBLI_SKIP_STARTUP_PURGE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,24 @@
 # Full local stack: app + persistent MariaDB.
 #
-# To use an external database instead:
-#   1. Comment out (or delete) the `db` service and the `volumes:` block.
-#   2. Remove the `depends_on:` block from the `mybibli` service.
-#   3. Set MYSQL_HOST / MYSQL_PORT / MYSQL_PASSWORD in your .env or shell
-#      to point at the external DB (defaults below target the bundled `db`).
+# All configuration values live in .env — nothing in this file needs editing.
+#
+# To use an EXTERNAL database instead:
+#   1. Comment out (or delete) the `db:` service and the `volumes:` block.
+#   2. Comment out the `depends_on:` block on the `mybibli` service.
+#   3. Set MYSQL_HOST / MYSQL_PORT / MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE
+#      in your .env to point at the external DB.
 
 services:
   mybibli:
     build: .
     ports:
-      - "8080:8080"
+      - "${HOST_PORT:-8080}:${PORT:-8080}"
     environment:
-      DATABASE_URL: mysql://mybibli:${MYSQL_PASSWORD:-mybibli_password}@${MYSQL_HOST:-db}:${MYSQL_PORT:-3306}/mybibli?charset=utf8mb4
-      HOST: "0.0.0.0"
-      PORT: "8080"
-      RUST_LOG: mybibli=info
+      DATABASE_URL: mysql://${MYSQL_USER:-mybibli}:${MYSQL_PASSWORD:-mybibli_password}@${MYSQL_HOST:-db}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-mybibli}?charset=utf8mb4
+      HOST: ${HOST:-0.0.0.0}
+      PORT: ${PORT:-8080}
+      RUST_LOG: ${RUST_LOG:-mybibli=info}
       APP_LANGUAGE: ${APP_LANGUAGE:-en}
-      # Issue #94 — set to "true" only when the deployment is fronted by HTTPS.
-      # When set, every Set-Cookie carries `Secure`; browsers refuse the cookie
-      # over plain HTTP, so leaving this unset (or "false") is correct for
-      # localhost-only / direct-port deployments.
       MYBIBLI_COOKIE_SECURE: ${MYBIBLI_COOKIE_SECURE:-false}
     depends_on:
       db:
@@ -31,14 +29,14 @@ services:
     image: mariadb:10.11
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root_password}
-      MYSQL_DATABASE: mybibli
-      MYSQL_USER: mybibli
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-mybibli}
+      MYSQL_USER: ${MYSQL_USER:-mybibli}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-mybibli_password}
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT:-3306}:3306"
     volumes:
       - mybibli_db_data:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
## Summary
- All DB parameters (host, port, database, user, password, root password) and app parameters (`HOST_PORT`, `RUST_LOG`, `APP_LANGUAGE`, `MYBIBLI_COOKIE_SECURE`) now live in `.env` exclusively.
- `docker-compose.yml` interpolates every value via `${VAR:-default}` — no parameter needs editing in the YAML anymore.
- Header comment documents how to disable the bundled `db:` service when pointing at an external database (3-step comment-out procedure).
- `docker-compose.dev.yml` and `tests/e2e/docker-compose.test.yml` left as-is — to be harmonized later if needed.

## Test plan
- [x] `docker compose config` resolves all interpolations correctly
- [x] Override propagates end-to-end: `MYSQL_PASSWORD=secret123 MYSQL_DATABASE=mylib MYSQL_USER=alice docker compose config` reflects in both the `db` service env and the assembled `DATABASE_URL` of the app service
- [x] `SQLX_OFFLINE=true cargo check` passes
- [ ] CI green (Rust + DB integration + Playwright E2E + wizard E2E)
- [ ] Manual: `docker compose up` boots app + DB with the new defaults
- [ ] Manual: setting a non-default `MYSQL_PASSWORD` in `.env` works without YAML edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)