### PR TITLE
docs: warn that admin/admin seed runs in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,17 @@ cd tests/e2e
 docker compose -f docker-compose.test.yml up --build
 ```
 
-The app listens on `http://localhost:8080`. The seed migrations create a dev admin (username `admin`, password `admin` — dev only) and a librarian (username `librarian`, password `librarian` — dev only).
+The app listens on `http://localhost:8080`. The seed migrations create an admin user (`admin` / `admin`, role `admin`) and a librarian (`librarian` / `librarian`, role `librarian`).
 
-**Fresh-install wizard.** Running `cargo run` against an empty database without `MYBIBLI_SKIP_SETUP=1` triggers the first-launch wizard at `/setup` (see story 8-8). Set `MYBIBLI_SKIP_SETUP=1` (strict accept-set: `1` / `true` / `TRUE`) to bypass it — typically only useful when the seed migrations have already created an admin.
+> ⚠️ **Default credentials run unconditionally — including in production.**
+> The seed migrations apply to every fresh install regardless of `RUST_LOG`
+> or environment. As soon as your deployment is reachable, log in as
+> `admin/admin`, open **`/admin?tab=users`**, rotate the admin password,
+> and deactivate or rename the `librarian` account if you don't need a
+> second seeded user. Never expose a fresh install to an untrusted network
+> before completing this step.
+
+**Fresh-install wizard.** Story 8-8 introduced a first-launch wizard at `/setup` whose gate predicate is `(active_admin_count == 0) AND (settings.setup_completed_at IS NONE)`. Because the seed migrations create an admin before the gate is first evaluated, the wizard never triggers in practice on a default install — the password-rotation step above is the effective onboarding flow. The wizard can still be exercised by running `cargo run` against an empty DB with the seed migrations skipped. `MYBIBLI_SKIP_SETUP=1` (strict accept-set: `1` / `true` / `TRUE`) is the explicit bypass.
 
 ### Build & check (native)
 


### PR DESCRIPTION
## Summary
- README previously claimed the `admin/admin` + `librarian/librarian` seeds were "dev only" — the SQL has no such guard (RUST_LOG cannot be read from migrations), so they apply on every fresh install including production.
- Updates the "Run the app locally" section with a prominent security warning and the rotation path (`/admin?tab=users`).
- Updates the "Fresh-install wizard" paragraph to reflect the actual behavior: the wizard never triggers on a default install because the seed admin satisfies the gate predicate before evaluation.
- v1.0.1 is now in production (2026-05-12). This is the immediate doc mitigation; a follow-up issue will be opened to gate the seed migrations themselves.

## Test plan
- [x] README renders correctly (no broken markdown)
- [ ] CI green (markdown lint / link check if enabled)
- [ ] Follow-up issue opened for production-gating the seed migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)