### PR TITLE
chore: bump version 1.0.1 → 1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

Patch release packaging the 4 PRs merged since v1.0.1:

| PR | Title | Issues shipped |
|---|---|---|
| #169 | Quality batch Phase 2 Tier A | #44, #75, #93, #104, #138 |
| #170 | Story #150 mobile hamburger login/logout parity | #150 |
| #171 | Centralize all config in .env, parametrize docker-compose.yml | — |
| #172 | Doc warning: admin/admin seed runs in production | (#173 opened as follow-up) |

**6 issues closed.** No schema migrations, no breaking changes.

## Release steps (post-merge)

1. Tag: `git tag v1.0.2 && git push origin v1.0.2`
2. `release.yml` workflow runs: verifies tag matches Cargo.toml version, publishes `gcorbaz/mybibli:1.0.2` and `gcorbaz/mybibli:latest` to Docker Hub.
3. Add `status:implemented` label to each shipped issue (#44, #75, #93, #104, #138, #150); remove stale `status:deferred` from #44 and #104; post a "Shipped in v1.0.2" comment on each.

## Test plan
- [x] `cargo check` passes at 1.0.2
- [ ] CI green (Rust + DB + 2× Playwright)
- [ ] Tag pushed + release.yml succeeds + Docker Hub :1.0.2 image available

🤖 Generated with [Claude Code](https://claude.com/claude-code)