### PR TITLE
chore: bump version 1.0.2 → 1.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

Patch release packaging the single PR merged since v1.0.2:

| PR | Title | Issues shipped |
|---|---|---|
| #175 | Fix #60: auto-purge FK ordering — introduce PURGE_DELETION_ORDER, drop ALLOWED_TABLES filter | #60 |

**1 issue closed.** No schema migrations, no breaking changes. Production-impact fix: auto-purge was non-functional, now correct.

## Release steps (post-merge)

1. Tag: \`git tag v1.0.3 && git push origin v1.0.3\`
2. \`release.yml\` workflow runs: verifies tag matches Cargo.toml version, publishes \`gcorbaz/mybibli:1.0.3\` and \`gcorbaz/mybibli:latest\` to Docker Hub.
3. Post a "Shipped in v1.0.3" comment on #60.

## Test plan
- [x] \`cargo check\` passes at 1.0.3
- [ ] CI green (Rust + DB + 2× Playwright)
- [ ] Tag pushed + release.yml succeeds + Docker Hub :1.0.3 image available

🤖 Generated with [Claude Code](https://claude.com/claude-code)