### PR TITLE
chore: bump version 1.0.3 → 1.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

Patch release packaging the single PR merged since v1.0.3:

| PR | Title | Issues shipped |
|---|---|---|
| #177 | Fix #66: series-restore SQL — use real title_series + 2-step DELETE | #66 |

**1 issue closed.** No schema migrations, no breaking changes. Production-impact fix: series restore-with-conflicts path was crashing on any real conflict; now correct. Entangled stale-read in the same function also fixed.

After this release, no production code references the ghost \`series_title_assignments\` name any longer — closes the family of bugs opened by #60 + #66.

## Release steps (post-merge)

1. Tag: \`git tag v1.0.4 && git push origin v1.0.4\`
2. \`release.yml\` workflow runs: verifies tag matches Cargo.toml version, publishes \`gcorbaz/mybibli:1.0.4\` and \`gcorbaz/mybibli:latest\` to Docker Hub.
3. Post a \"Shipped in v1.0.4\" comment on #66.

## Test plan
- [x] \`cargo check\` passes at 1.0.4
- [ ] CI green (Rust + DB + 2× Playwright)
- [ ] Tag pushed + release.yml succeeds + Docker Hub :1.0.4 image available

🤖 Generated with [Claude Code](https://claude.com/claude-code)