### PR TITLE
chore: bump version 1.0.4 → 1.0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

Patch release packaging the single PR merged since v1.0.4:

| PR | Title | Issues shipped |
|---|---|---|
| #179 | Fix #117: align count_*/list_* parent-deletion filters in loan model | #117 |

**1 issue closed.** No schema migrations, no breaking changes. Hardens dashboard count integrity against orphan-loan scenarios reachable via direct DB import / migration / restore-from-trash.

## Release steps (post-merge)

1. Tag: \`git tag v1.0.5 && git push origin v1.0.5\`
2. \`release.yml\` workflow runs: verifies tag matches Cargo.toml version, publishes \`gcorbaz/mybibli:1.0.5\` and \`gcorbaz/mybibli:latest\` to Docker Hub.
3. Post a \"Shipped in v1.0.5\" comment + \`status:implemented\` label on #117.

## Test plan
- [x] \`cargo check\` passes at 1.0.5
- [ ] CI green (Rust + DB + 2× Playwright)
- [ ] Tag pushed + release.yml succeeds + Docker Hub :1.0.5 image available

🤖 Generated with [Claude Code](https://claude.com/claude-code)