### PR TITLE
docs: env vars reference + 1.1.0 install warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,32 @@
-# mybibli Environment Configuration
-# Copy this file to .env and adjust values for your environment.
+# mybibli Environment Configuration — copy to .env and adjust for your deployment.
 #
-# All configuration lives here — docker-compose.yml interpolates from this file
-# and the Rust binary reads it when running `cargo run` locally.
-# You should NEVER need to edit docker-compose.yml.
+# All deployment-time environment variables read by the Rust binary or
+# interpolated by docker-compose.yml are documented here. You should NEVER
+# need to edit docker-compose.yml — every value it forwards comes from .env.
+#
+# Boolean accept-set is strict: only `1` / `true` / `TRUE` count as "on";
+# anything else (including empty string and `0`) is treated as "off".
+# This avoids the classic footgun where a stale shell value like `0` reads
+# as "set" and silently enables an opt-out.
+#
+# Variables read at the OS shell level for test/build commands
+# (TEST_ADMIN_PASSWORD, MYBIBLI_SETUP_E2E, SQLX_OFFLINE, …) are NOT listed
+# here — see README.md "Development" section for their use.
 
-# --- Database connection (read directly by the Rust binary) ---
-# In Docker, the app rebuilds this URL from the MYSQL_* parts below —
-# keep this URL in sync if you change them.
+# =====================================================================
+# 1. Database connection
+# =====================================================================
+
+# Connection string read directly by the Rust binary. In Docker, the app
+# rebuilds this URL from the MYSQL_* parts below — keep this URL in sync
+# if you change them, or comment it out and rely on the docker-compose
+# interpolation when running via compose.
 DATABASE_URL=mysql://mybibli:mybibli_password@localhost:3306/mybibli?charset=utf8mb4
 
-# --- Database connection parts (interpolated by docker-compose.yml) ---
-# When using the bundled `db` service, leave MYSQL_HOST=db.
-# For an external database, set MYSQL_HOST to its hostname (and comment out
-# the `db:` service + `depends_on:` + `volumes:` blocks in docker-compose.yml).
+# Connection parts used by docker-compose.yml. When using the bundled
+# `db` service, leave MYSQL_HOST=db. For an external database, set
+# MYSQL_HOST to its hostname (and comment out the `db:` service +
+# `depends_on:` + `volumes:` blocks in docker-compose.yml).
 MYSQL_HOST=db
 MYSQL_PORT=3306
 MYSQL_DATABASE=mybibli
@@ -22,29 +35,115 @@ MYSQL_PASSWORD=mybibli_password
 # Only used by the bundled `db` service — ignored when using an external DB.
 MYSQL_ROOT_PASSWORD=root_password
 
-# --- Server ---
+# =====================================================================
+# 2. HTTP server
+# =====================================================================
+
+# Bind address inside the app/container. `0.0.0.0` accepts external
+# connections; `127.0.0.1` restricts to loopback.
 HOST=0.0.0.0
+
+# Bind port inside the app/container. The Rust binary parses this as u16
+# and refuses to start on invalid values.
 PORT=8080
+
 # Port published by Docker on the host (maps to container PORT above).
+# When running `cargo run` natively, this var is ignored.
 HOST_PORT=8080
 
-# --- Application ---
+# =====================================================================
+# 3. Application
+# =====================================================================
+
+# `tracing` filter directive. Production-safe default: `mybibli=info`.
+# For dev / debugging, try `mybibli=debug,tower_http=debug`.
 RUST_LOG=mybibli=info
+
+# Initial UI language for anonymous visitors. Accepts `en` or `fr`.
+# Authenticated users override this via the language toggle (stored
+# per-user). The active default for the whole instance is also exposed
+# via /admin > System tab and stored in the `settings` table.
 APP_LANGUAGE=en
 
-# --- Cookie security ---
-# Issue #94 — set to "true" only when the deployment is fronted by HTTPS.
-# When set, every Set-Cookie carries `Secure`; browsers refuse the cookie
-# over plain HTTP, so leaving this "false" is correct for localhost-only
-# or direct-port deployments.
+# Path where downloaded cover images are written. Resolved as a regular
+# filesystem path — relative paths resolve against the app's CWD.
+# Default: `./covers`. In Docker, mount a volume here for persistence.
+COVERS_DIR=./covers
+
+# =====================================================================
+# 4. Cookie & CSP hardening
+# =====================================================================
+
+# Issue #94 — set to `true` ONLY when the deployment is fronted by HTTPS.
+# When `true`, every Set-Cookie carries the `Secure` attribute; browsers
+# then refuse the cookie over plain HTTP, so leaving this `false` is
+# correct for localhost-only or direct-port deployments behind no TLS.
+# Accepts: `1` / `true` / `TRUE` / `yes` (case-insensitive). Default: `false`.
 MYBIBLI_COOKIE_SECURE=false
 
-# --- Optional dev/test overrides ---
-# Story 8-7: skip the startup auto-purge for fast dev/test loops.
-# Accepts only "1" / "true" / "TRUE"; anything else (incl. empty / "0") is ignored.
+# Story 7-4 — switch the Content-Security-Policy header to its
+# Report-Only variant. Observe violations without blocking them; useful
+# when introducing new inline-script-like patterns.
+# Accepts: `1` / `true` / `TRUE` / `yes` (case-insensitive). Default: `false` (enforced).
+# CSP_REPORT_ONLY=false
+
+# =====================================================================
+# 5. Metadata provider API keys
+# =====================================================================
+#
+# These env vars are MIGRATED ONCE at boot into the `settings` table (the
+# in-app source of truth). Once migrated, the admin can rotate / clear
+# them via /admin > System > Metadata Providers without a restart. If
+# you leave these env vars set AND clear the row from the UI, the next
+# boot re-migrates the env value — the operator's deployment-time intent
+# wins on boot. To make a Clear durable across reboots, also remove the
+# env var here.
+#
+# Providers without an API key are simply skipped at fetch time (their
+# `available_providers()` check returns false). BnF, Open Library and
+# MusicBrainz do NOT require a key.
+#
+# GOOGLE_BOOKS_API_KEY=
+# OMDB_API_KEY=
+# TMDB_API_KEY=
+
+# =====================================================================
+# 6. Metadata provider base URL overrides
+# =====================================================================
+#
+# Override the upstream API base URL for each metadata provider. Used
+# exclusively by the E2E test stack to point at the in-tree mock server
+# (tests/e2e/mock-metadata-server/server.py). Leave unset in production
+# — the providers default to the official upstream URLs:
+#
+#   BNF_API_BASE_URL=https://catalogue.bnf.fr/api/SRU
+#   COMIC_VINE_API_BASE_URL=https://comicvine.gamespot.com
+#   GOOGLE_BOOKS_API_BASE_URL=https://www.googleapis.com
+#   MUSICBRAINZ_API_BASE_URL=https://musicbrainz.org
+#   OMDB_API_BASE_URL=https://www.omdbapi.com
+#   OPEN_LIBRARY_API_BASE_URL=https://openlibrary.org
+#   TMDB_API_BASE_URL=https://api.themoviedb.org
+#
+# Comic Vine is implemented but NOT registered in the active provider
+# chain — leave its override commented out unless you re-enable the
+# provider in `main.rs`.
+
+# =====================================================================
+# 7. Optional dev/test overrides
+# =====================================================================
+#
+# Each accepts the strict boolean accept-set (`1` / `true` / `TRUE`).
+# Anything else (incl. empty / `0` / `false`) is treated as "off".
+
+# Story 8-7 — skip the startup auto-purge for fast dev/test iteration
+# loops where the cost is not worth paying on every restart. The daily
+# scheduler still runs.
 # MYBIBLI_SKIP_STARTUP_PURGE=1
 
-# Story 8-8: skip the first-launch setup wizard middleware.
-# Accepts only "1" / "true" / "TRUE"; anything else is ignored.
-# Used by E2E tests + dev workflows where the seed migration already provides users.
+# Story 8-8 — skip the first-launch setup wizard middleware. Used by the
+# seeded E2E stack and dev workflows where the seed migration already
+# provides users. NEVER set this on a fresh production install — the
+# wizard is the canonical onboarding flow for fresh deployments (the
+# operator is forced to create a real admin instead of relying on a
+# default seed).
 # MYBIBLI_SKIP_SETUP=1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 
 > Personal library cataloging for home collectors.
 
+> ## 🛑 DO NOT INSTALL VERSIONS BELOW 1.1.0
+>
+> Every published image with a tag below `1.1.0` (including `v1.0.0` …
+> `v1.0.5` and any `:latest` snapshot taken before the 1.1.0 release)
+> ships seed migrations that create default credentials
+> (`admin/admin`, `librarian/librarian`) on EVERY fresh install,
+> including production deployments. The first-launch setup wizard at
+> `/setup` is silently bypassed because the seed creates an admin
+> before the gate predicate is evaluated. See
+> [#173](https://github.com/guycorbaz/mybibli/issues/173) for the full
+> writeup. The pre-1.1.0 Docker Hub tags will be removed to prevent
+> accidental installs.
+>
+> **Install 1.1.0 or later.** A fresh install at 1.1.0+ greets you with
+> the setup wizard and forces you to create your own admin account. If
+> you already deployed an earlier version, wipe the database and
+> reinstall on 1.1.0+ before adding any data.
+
 **Status:** first public release shipped — `v1.0.0`. All nine epics done. Pre-built images on Docker Hub at [`gcorbaz/mybibli`](https://hub.docker.com/r/gcorbaz/mybibli).
 
 ## What it is
@@ -34,7 +52,54 @@ Built for collectors who want more than a spreadsheet:
 
 ## Quick start (end users)
 
-Pre-built images are published to Docker Hub at [`gcorbaz/mybibli`](https://hub.docker.com/r/gcorbaz/mybibli) — `:latest` tracks the highest semver, individual tags pin to the exact release. For development against the source tree, see **Development** below.
+Pre-built images are published to Docker Hub at [`gcorbaz/mybibli`](https://hub.docker.com/r/gcorbaz/mybibli) — `:latest` tracks the highest semver, individual tags pin to the exact release. Honor the **1.1.0 minimum** banner above. For development against the source tree, see **Development** below.
+
+## Configuration
+
+All deployment-time settings are environment variables — there is no
+config file. `.env.example` is the canonical reference: every variable
+the Rust binary reads or that `docker-compose.yml` interpolates is
+listed and commented there. Copy it to `.env` and adjust for your
+deployment:
+
+```bash
+cp .env.example .env
+$EDITOR .env
+docker compose up
+```
+
+The variables are grouped in seven sections:
+
+1. **Database connection** — `DATABASE_URL` plus the `MYSQL_*` parts
+   used by the bundled `db` service.
+2. **HTTP server** — `HOST`, `PORT`, `HOST_PORT` (the host-side port
+   published by Docker).
+3. **Application** — `RUST_LOG` (tracing filter; prod-safe default
+   `mybibli=info`), `APP_LANGUAGE` (`en` or `fr`), `COVERS_DIR`
+   (filesystem path for downloaded cover images).
+4. **Cookie & CSP hardening** — `MYBIBLI_COOKIE_SECURE` (set to `true`
+   only behind HTTPS, see issue
+   [#94](https://github.com/guycorbaz/mybibli/issues/94)),
+   `CSP_REPORT_ONLY`.
+5. **Metadata provider API keys** — `GOOGLE_BOOKS_API_KEY`,
+   `OMDB_API_KEY`, `TMDB_API_KEY`. Migrated ONCE into the `settings`
+   table at boot; afterwards the admin can rotate or clear them via
+   `/admin > System > Metadata Providers`. Re-set them in `.env` only
+   when you want the deployment-time value to win on the next reboot.
+6. **Metadata provider base URL overrides** — used exclusively by the
+   E2E test stack to point each provider at the in-tree mock server.
+   Leave unset in production.
+7. **Optional dev/test overrides** — `MYBIBLI_SKIP_SETUP`,
+   `MYBIBLI_SKIP_STARTUP_PURGE`. Strict accept-set: only `1` / `true`
+   / `TRUE` count as "on"; anything else is ignored.
+
+Boolean variables across the codebase use the same strict accept-set,
+which avoids the classic footgun where a stale shell value like `0`
+reads as "set" and silently flips an opt-out.
+
+Shell-level env vars used for build / test commands (`SQLX_OFFLINE`,
+`TEST_ADMIN_PASSWORD`, `MYBIBLI_SETUP_E2E`, …) are documented inline
+in the **Development** section below — they do not belong in `.env`.
 
 ## Development
 
@@ -63,7 +128,10 @@ The app listens on `http://localhost:8080`. The seed migrations create an admin 
 > `admin/admin`, open **`/admin?tab=users`**, rotate the admin password,
 > and deactivate or rename the `librarian` account if you don't need a
 > second seeded user. Never expose a fresh install to an untrusted network
-> before completing this step.
+> before completing this step. **This is being fixed in 1.1.0** — see
+> [#173](https://github.com/guycorbaz/mybibli/issues/173); a new env var
+> (`MYBIBLI_SEED_DEV_USERS`, default `0`) gates the seed so production
+> installs land on the `/setup` wizard instead.
 
 **Fresh-install wizard.** Story 8-8 introduced a first-launch wizard at `/setup` whose gate predicate is `(active_admin_count == 0) AND (settings.setup_completed_at IS NONE)`. Because the seed migrations create an admin before the gate is first evaluated, the wizard never triggers in practice on a default install — the password-rotation step above is the effective onboarding flow. The wizard can still be exercised by running `cargo run` against an empty DB with the seed migrations skipped. `MYBIBLI_SKIP_SETUP=1` (strict accept-set: `1` / `true` / `TRUE`) is the explicit bypass.
 


### PR DESCRIPTION
## Summary

- Exhaustive `.env.example` rewrite — 49 → 137 lines, grouped into 7 commented sections covering every env var read by the Rust binary or interpolated by docker-compose.
- Prominent 🛑 banner in `README.md` warning operators NOT to install any version below **1.1.0** (issue #173). Forward-pointer added to the existing "Default credentials" notice.
- New `## Configuration` section in README describing the seven `.env` sections.
- `.env` synced locally (gitignored — not part of this diff).

## Why now

Pre-work for the 1.1.0 release that fixes #173 (seed migrations create `admin/admin` on every install, bypassing the setup wizard). The seed-gate impl + audit-trio fixes (#68 / #69 / #70) land on a sibling branch; this PR is docs-only and non-breaking.

## Test plan

- [x] `.env.example` reads cleanly — every section pointer matches README "## Configuration" numbering
- [x] README renders the banner above the status line (visible without scrolling)
- [x] No code changes — `cargo check` / `cargo clippy` unaffected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)