### PR TITLE
docs: LaTeX user manual (EN + FR) with PDF build

### DIFF
--- a/docs/manual/.gitignore
+++ b/docs/manual/.gitignore
@@ -1,0 +1,34 @@
+# LaTeX build artifacts — kept out of git.
+# The generated PDFs are committed only when attached to a release.
+*.aux
+*.log
+*.toc
+*.lof
+*.lot
+*.out
+*.idx
+*.ind
+*.ilg
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+*.bbl
+*.blg
+*.nav
+*.snm
+*.vrb
+*-blx.bib
+*.run.xml
+*.xdv
+*.bcf
+*.acn
+*.acr
+*.alg
+*.glg
+*.glo
+*.gls
+*.ist
+
+# Generated PDFs — uncomment to commit alongside source.
+# mybibli-manual-en.pdf
+# mybibli-manual-fr.pdf

--- a/docs/manual/.gitignore
+++ b/docs/manual/.gitignore
@@ -29,6 +29,11 @@
 *.gls
 *.ist
 
-# Generated PDFs — uncomment to commit alongside source.
+# Intermediate per-language PDFs produced by latexmk before build.sh
+# copies them to the top-level mybibli-manual-{en,fr}.pdf.
+en/main.pdf
+fr/main.pdf
+
+# Top-level distribution PDFs — uncomment to commit alongside source.
 # mybibli-manual-en.pdf
 # mybibli-manual-fr.pdf

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -1,0 +1,89 @@
+# mybibli — User Manual Sources
+
+LaTeX sources for the mybibli end-user manual, produced as one
+self-contained PDF per language.
+
+## Layout
+
+```
+docs/manual/
+├── en/                 # English source — main.tex + chapter files
+├── fr/                 # French source — main.tex + chapter files
+├── build.sh            # invoke latexmk on each language
+└── README.md           # this file
+```
+
+Each language directory is **self-contained**: it carries its own
+`main.tex`, preamble, chapter files, and `images/` folder. The two
+languages share no common LaTeX preamble — drift between EN and FR
+preambles is therefore visible at review time, by design.
+
+## Prerequisites
+
+The build uses **XeLaTeX** (for Unicode and system fonts via
+`fontspec`) plus **latexmk** to manage multi-pass compilation
+(table of contents, index, cross-references):
+
+| Distribution | One-line install |
+|--------------|------------------|
+| Debian / Ubuntu | `sudo apt-get install texlive-xetex texlive-latex-extra texlive-fonts-recommended texlive-lang-french latexmk` |
+| Fedora | `sudo dnf install texlive-scheme-medium texlive-collection-langfrench latexmk` |
+| Arch | `sudo pacman -S texlive-most texlive-langfrench` |
+| macOS | `brew install --cask mactex-no-gui` (full) or `basictex` (then `tlmgr install latexmk fontspec polyglossia hyphen-french`) |
+
+## Building
+
+```bash
+./build.sh            # both languages
+./build.sh en         # English only
+./build.sh fr         # French only
+./build.sh clean      # remove .aux/.log/etc, keep PDFs
+./build.sh distclean  # remove .aux/.log/etc AND PDFs
+```
+
+Output files land at the top of `docs/manual/`:
+
+```
+docs/manual/
+├── mybibli-manual-en.pdf
+└── mybibli-manual-fr.pdf
+```
+
+The script fails fast with a clear message when `xelatex`, `latexmk`
+or `makeindex` is missing.
+
+## Editing
+
+* **Chapter files** are named with a numeric prefix (`01-`, `02-`, …)
+  that controls the reading order. They are pulled into `main.tex`
+  via `\input{NN-name}`.
+* **Index entries** are added inline with `\index{term}` next to the
+  first meaningful mention of a term. The index is built automatically
+  during the latexmk run and printed at the end of the document.
+* **Cross-references** between chapters use `\label{ch:name}` /
+  `\ref{ch:name}` (or `\pageref{}`).
+* **Code listings** use the `listings` package; configuration in the
+  preamble. Inline shell commands use `\texttt{...}`.
+* **Callouts** (Note / Tip / Warning) use the `tcolorbox` environments
+  defined in the preamble.
+
+## Updating after a release
+
+When a new version of mybibli is published:
+
+1. Bump the `\date{Version X.Y.Z --- \today}` in both `main.tex` files.
+2. Update the relevant chapters (new features, changed env vars, etc.).
+3. Run `./build.sh` and review the generated PDFs.
+4. Attach the two PDFs to the GitHub Release as build artifacts.
+
+There is no CI build for the manual today — the PDFs are produced
+locally by the maintainer at release time. Wiring up a release-tag
+GitHub Actions job is tracked as a future enhancement.
+
+## Translation policy
+
+The French version is a **localized adaptation**, not a literal
+translation. Idiomatic phrasing, examples and label names follow the
+expectations of a Switzerland / France household audience. Keep the
+chapter structure aligned across both languages so cross-references
+stay valid.

--- a/docs/manual/build.sh
+++ b/docs/manual/build.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Build the mybibli user manual PDFs (English + French).
+#
+# Requires: xelatex + latexmk + the standard TeX Live LaTeX packages.
+# On Debian/Ubuntu:
+#     sudo apt-get install texlive-xetex texlive-latex-extra \
+#                          texlive-fonts-recommended texlive-lang-french \
+#                          latexmk
+# On macOS (with MacTeX or BasicTeX):
+#     brew install --cask mactex-no-gui     # full
+#     # or:
+#     brew install --cask basictex          # minimal — then `tlmgr install ...`
+#
+# Usage:
+#     ./build.sh            # build both languages
+#     ./build.sh en         # English only
+#     ./build.sh fr         # French only
+#     ./build.sh clean      # remove build artifacts (keeps PDFs)
+#     ./build.sh distclean  # remove build artifacts AND PDFs
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+REQUIRED_BINS=(xelatex latexmk makeindex)
+for bin in "${REQUIRED_BINS[@]}"; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "error: \`$bin\` not found in PATH." >&2
+        echo "       Install a TeX Live distribution that includes xelatex," >&2
+        echo "       latexmk and makeindex (see the comment at the top of" >&2
+        echo "       this script for distribution-specific commands)." >&2
+        exit 1
+    fi
+done
+
+build_lang() {
+    local lang="$1"
+    local out_pdf="mybibli-manual-${lang}.pdf"
+
+    if [[ ! -d "$lang" ]]; then
+        echo "error: directory \`$lang/\` does not exist." >&2
+        exit 1
+    fi
+
+    echo ">>> Building ${lang} manual..."
+    (
+        cd "$lang"
+        # -xelatex      → use XeLaTeX (needed for fontspec, polyglossia, Unicode)
+        # -interaction  → don't stop at minor warnings
+        # -halt-on-error → fail fast on real errors
+        # -shell-escape → not needed; we use `listings`, not `minted`
+        latexmk -xelatex \
+                -interaction=nonstopmode \
+                -halt-on-error \
+                -file-line-error \
+                main.tex
+    )
+
+    cp "${lang}/main.pdf" "$out_pdf"
+    echo ">>> Wrote ${out_pdf}"
+}
+
+clean_lang() {
+    local lang="$1"
+    [[ -d "$lang" ]] || return 0
+    echo ">>> Cleaning ${lang} build artifacts..."
+    (cd "$lang" && latexmk -C >/dev/null 2>&1 || true)
+    # latexmk -C removes main.pdf too; that's fine for clean inside the lang
+    # dir. We keep the top-level mybibli-manual-${lang}.pdf untouched.
+}
+
+case "${1:-all}" in
+    en)    build_lang en ;;
+    fr)    build_lang fr ;;
+    all)
+        build_lang en
+        build_lang fr
+        echo ""
+        echo "Both PDFs built:"
+        ls -lh mybibli-manual-*.pdf
+        ;;
+    clean)
+        clean_lang en
+        clean_lang fr
+        echo "Build artifacts removed (PDFs kept)."
+        ;;
+    distclean)
+        clean_lang en
+        clean_lang fr
+        rm -f mybibli-manual-en.pdf mybibli-manual-fr.pdf
+        echo "Build artifacts and PDFs removed."
+        ;;
+    *)
+        echo "Usage: $0 [en|fr|all|clean|distclean]" >&2
+        exit 1
+        ;;
+esac

--- a/docs/manual/en/00-preface.tex
+++ b/docs/manual/en/00-preface.tex
@@ -1,0 +1,81 @@
+\chapter*{Preface}
+\addcontentsline{toc}{chapter}{Preface}
+\markboth{Preface}{Preface}
+
+\section*{Who this manual is for}
+
+This manual is written for the person who installs, configures and
+runs a mybibli instance for their household, a small association,
+or a community library. It assumes you can:
+
+\begin{itemize}
+  \item open a terminal and run \texttt{docker compose} commands;
+  \item edit a plain-text configuration file with the editor of
+        your choice;
+  \item read a URL printed in a log line and open it in a browser.
+\end{itemize}
+
+No Rust, MariaDB or HTMX knowledge is required. The manual is
+deliberately scoped to the \emph{operator} role — building mybibli
+from source or modifying its code is covered by
+\texttt{CLAUDE.md} and the planning artifacts in the repository.
+
+\section*{Conventions}
+
+\textbf{Commands.} Shell snippets are shown in a fixed-width box:
+
+\begin{lstlisting}
+docker compose up -d
+\end{lstlisting}
+
+\textbf{Configuration files.} File excerpts use the same style with
+the file name called out in the surrounding text. Comments inside
+the snippet use the file's native comment marker.
+
+\textbf{Callouts.} Three sidebars highlight important text:
+
+\begin{note}
+A \emph{note} provides background or context that helps you understand
+why something works the way it does. Skipping it is safe.
+\end{note}
+
+\begin{tip}
+A \emph{tip} suggests a practice that makes day-to-day use smoother.
+Try it once you are comfortable with the basics.
+\end{tip}
+
+\begin{warning}
+A \emph{warning} flags a step where a mistake can lose data, lock
+you out of the admin panel, or expose the instance to unauthorized
+access. Read these in full.
+\end{warning}
+
+\textbf{Cross-references.} Chapters and sections are linked in the
+PDF — click any blue title or page number to jump there. The
+\hyperref[index]{index} at the end maps every important term to its
+page of first use.
+
+\section*{Getting help}
+
+The canonical source of truth for mybibli is the GitHub repository:
+
+\begin{center}
+\url{https://github.com/guycorbaz/mybibli}
+\end{center}
+
+Open an issue against the \texttt{guycorbaz/mybibli} repository when
+you hit a bug, a documentation gap, or a missing feature. The issue
+templates ask for the version (visible at the bottom of any page in
+the admin panel), your install method, and the steps to reproduce.
+
+\section*{Manual coverage}
+
+This manual covers mybibli \textbf{1.1.0 and later}. Older versions
+shipped a security-relevant bug where the first-launch setup wizard
+was silently bypassed — see chapter~\ref{ch:upgrade} for the
+upgrade path from 1.0.x.
+
+\vspace{1cm}
+\hrule
+\vspace{0.5cm}
+\textit{Happy cataloging.}

--- a/docs/manual/en/01-installation.tex
+++ b/docs/manual/en/01-installation.tex
@@ -218,11 +218,11 @@ strings \texttt{1}, \texttt{true} and \texttt{TRUE} count as
 footgun where a stale shell value like \texttt{0} reads as ``set''
 and silently flips an opt-out.
 
-\begin{longtable}{@{} l l p{6.5cm} @{}}
+\begin{center}\small
+\begin{tabular}{l l >{\raggedright\arraybackslash}p{6.2cm}}
 \toprule
 \textbf{Variable} & \textbf{Default} & \textbf{Purpose} \\
 \midrule
-\endhead
 \multicolumn{3}{l}{\emph{Database}} \\
 \texttt{DATABASE\_URL}        & --- (required) & MariaDB connection string (DSN). \\
 \texttt{MYSQL\_HOST}          & \texttt{db}    & Hostname for the bundled DB service. \\
@@ -256,7 +256,8 @@ and silently flips an opt-out.
 \texttt{MYBIBLI\_SKIP\_STARTUP\_PURGE} & \texttt{false} & Skip the boot-time auto-purge. \\
 \texttt{MYBIBLI\_SEED\_DEV\_USERS} & \texttt{false} & Seed dev \texttt{admin/admin} + \texttt{librarian/librarian}. \emph{Never on prod.} \\
 \bottomrule
-\end{longtable}
+\end{tabular}
+\end{center}
 
 Provider base-URL overrides (\texttt{BNF\_API\_BASE\_URL},
 \texttt{GOOGLE\_BOOKS\_API\_BASE\_URL}, \dots) exist solely to point

--- a/docs/manual/en/01-installation.tex
+++ b/docs/manual/en/01-installation.tex
@@ -1,0 +1,312 @@
+\chapter{Installation}
+\label{ch:installation}
+
+This chapter walks you through installing mybibli\index{installation}
+on your own hardware. The reference deployment target is a home
+server, NAS, or any always-on Linux box that can run Docker.
+
+\section{System requirements}
+
+\begin{itemize}
+  \item \textbf{Operating system:} any Linux distribution, macOS, or
+        Windows host capable of running Docker. The host kernel must
+        support cgroups v2 (any distribution from 2021 onward).
+  \item \textbf{Docker:} version 24 or later, with the \texttt{compose}
+        plugin. Test with \texttt{docker compose version}.
+  \item \textbf{Disk:} at least 1\,GB free for the application image
+        plus the database. Cover images add roughly 50\,KB per title.
+  \item \textbf{Memory:} 512\,MB is enough for a household-sized
+        library (a few thousand titles); 1\,GB gives generous
+        headroom for the metadata-fetch pipeline.
+  \item \textbf{Network:} outbound HTTPS to the metadata
+        providers\index{metadata providers} you choose to use
+        (see chapter~\ref{ch:providers}). LAN-only deployments work
+        without any inbound port forwarding.
+\end{itemize}
+
+\begin{warning}
+\textbf{Do not install mybibli versions below 1.1.0.}\index{security!1.1.0 floor}
+Every published image with a tag below \texttt{1.1.0} contains a seed
+migration that creates the credentials \texttt{admin/admin} and
+\texttt{librarian/librarian} on \emph{every} fresh install, including
+production. The first-launch setup wizard is silently bypassed. Use
+1.1.0 or later; the pre-1.1.0 images will be removed from Docker Hub
+to prevent accidental use.
+\end{warning}
+
+\section{Pre-installation checklist}
+
+Before you start:
+
+\begin{enumerate}
+  \item Pick a host directory for the mybibli files
+        (e.g.\ \texttt{/srv/mybibli} on Linux,
+        \texttt{/volume1/docker/mybibli} on Synology DSM).
+  \item Pick a host directory for the cover-image
+        store\index{covers!directory}
+        (e.g.\ \texttt{/srv/mybibli/covers}). This will be mounted
+        into the container.
+  \item Choose a strong password for the bundled MariaDB
+        \texttt{root} and application users — or, for an external
+        database, create a dedicated database and user up front (see
+        section~\ref{sec:install-external-db}).
+\end{enumerate}
+
+\section{Method 1 — Bundled database}\label{sec:install-bundled}
+
+This is the simplest path. The shipped \texttt{docker-compose.yml}
+file declares two services: the mybibli application and a MariaDB
+instance pinned to a known version. Both are managed as one unit.
+
+\subsection*{1. Get the compose file and \texttt{.env}}
+
+Download the \texttt{docker-compose.yml} and \texttt{.env.example}
+from the release you intend to install (or check out the repository
+at the matching tag):
+
+\begin{lstlisting}
+mkdir -p /srv/mybibli && cd /srv/mybibli
+curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/docker-compose.yml
+curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/.env.example
+cp .env.example .env
+\end{lstlisting}
+
+\subsection*{2. Edit \texttt{.env}}
+
+Open \texttt{.env} in your editor. Every variable carries an
+explanatory comment; the values that matter for a bundled-database
+install are:
+
+\begin{lstlisting}
+DATABASE_URL=mysql://mybibli:mybibli_password@db:3306/mybibli?charset=utf8mb4
+MYSQL_HOST=db
+MYSQL_DATABASE=mybibli
+MYSQL_USER=mybibli
+MYSQL_PASSWORD=<choose-a-strong-password>
+MYSQL_ROOT_PASSWORD=<choose-a-strong-password>
+
+HOST_PORT=8080         # change if 8080 is already taken on the host
+APP_LANGUAGE=en        # or 'fr' for the French UI by default
+
+MYBIBLI_COOKIE_SECURE=false   # set to true only behind HTTPS
+\end{lstlisting}
+
+The \texttt{DATABASE\_URL} \emph{must} reference the same user,
+password and database name as the \texttt{MYSQL\_*} values — the
+compose file rebuilds the URL from those parts but the Rust binary
+reads \texttt{DATABASE\_URL} directly, so the two must agree.
+
+\begin{warning}
+The default passwords in \texttt{.env.example}
+(\texttt{mybibli\_password}, \texttt{root\_password}) are
+placeholders, not credentials to keep. Change them before the first
+\texttt{docker compose up}. After the database has been created,
+rotating these passwords requires also rewriting the MariaDB user
+entries — easier to get it right the first time.
+\end{warning}
+
+\subsection*{3. Start the stack}
+
+\begin{lstlisting}
+docker compose up -d
+docker compose logs -f mybibli
+\end{lstlisting}
+
+The first launch:
+
+\begin{enumerate}
+  \item pulls the \texttt{gcorbaz/mybibli:1.1.0} (or later) image
+        and the MariaDB image;
+  \item starts the database and waits for it to be healthy;
+  \item runs the mybibli database migrations
+        (one-time schema setup);
+  \item starts the HTTP listener on the port you configured.
+\end{enumerate}
+
+You can stop tailing the logs with \texttt{Ctrl-C}; the containers
+keep running detached.
+
+\subsection*{4. Open the setup wizard}
+
+Visit \url{http://<host>:8080/setup} in a browser. The first-launch
+setup wizard\index{setup wizard} appears (covered in
+section~\ref{sec:first-boot}).
+
+\section{Method 2 — External database (Synology NAS example)}\label{sec:install-external-db}
+
+If you already run MariaDB on your NAS — for example via the Synology
+\textbf{MariaDB 10} package — you can point mybibli at it instead of
+running a second database in Docker. The mybibli image is unchanged;
+only the compose file and \texttt{.env} differ.
+
+\subsection*{1. Create the database and user}
+
+Connect to the external MariaDB as \texttt{root} and run:
+
+\begin{lstlisting}
+CREATE DATABASE mybibli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER 'mybibli'@'%' IDENTIFIED BY 'choose-a-strong-password';
+GRANT ALL PRIVILEGES ON mybibli.* TO 'mybibli'@'%';
+FLUSH PRIVILEGES;
+\end{lstlisting}
+
+\begin{note}
+On Synology DSM, MariaDB 10 listens on port \texttt{3307} by default
+(not 3306 — that port is reserved for the older MySQL package). Open
+\textbf{MariaDB 10 → Settings} and tick \emph{Enable TCP/IP
+connection} so containers on the same Docker bridge can reach the
+server.
+\end{note}
+
+\subsection*{2. Trim the compose file}
+
+Edit \texttt{docker-compose.yml} and remove the bundled database:
+
+\begin{itemize}
+  \item delete (or comment out) the entire \texttt{db:} service;
+  \item delete (or comment out) the \texttt{depends\_on:} block on
+        the \texttt{mybibli} service;
+  \item delete (or comment out) the \texttt{volumes:} block at the
+        bottom of the file.
+\end{itemize}
+
+\subsection*{3. Point \texttt{.env} at the external database}
+
+\begin{lstlisting}
+DATABASE_URL=mysql://mybibli:strong-password@host.docker.internal:3307/mybibli?charset=utf8mb4
+\end{lstlisting}
+
+Substitute the host name and port that match your network. From a
+mybibli container running on the same Docker bridge as the NAS host,
+\texttt{host.docker.internal} resolves to the host on macOS and
+recent Linux Docker installs; on older Docker engines, use the LAN
+IP of the NAS instead (e.g.\ \texttt{192.168.1.10}).
+
+The \texttt{MYSQL\_*} variables are now unused — leave them blank or
+delete them.
+
+\subsection*{4. Start the application}
+
+\begin{lstlisting}
+docker compose up -d
+docker compose logs -f mybibli
+\end{lstlisting}
+
+The first launch runs the schema migrations against the external
+database. The Synology MariaDB package will hold this schema for as
+long as the package exists; backing it up is covered by the NAS-level
+backup tools (see chapter~\ref{ch:backup}).
+
+\begin{tip}
+The external-database setup is the recommended path when you already
+maintain a database server, because it gives you one backup pipeline
+to monitor instead of two. The bundled-database setup is faster to
+get going if you have no other workloads on the host.
+\end{tip}
+
+\section{Environment variable reference}\label{sec:env-vars}
+
+The full reference lives in the file
+\texttt{.env.example}\index{env vars!.env.example} at the repository
+root — every variable carries an inline comment. The table below
+summarises which variable applies where.
+
+All boolean variables follow a \textbf{strict accept-set}: only the
+strings \texttt{1}, \texttt{true} and \texttt{TRUE} count as
+``on''. Anything else (including the empty string, \texttt{0}, and
+\texttt{false}) is treated as ``off''. This avoids the classic
+footgun where a stale shell value like \texttt{0} reads as ``set''
+and silently flips an opt-out.
+
+\begin{longtable}{@{} l l p{6.5cm} @{}}
+\toprule
+\textbf{Variable} & \textbf{Default} & \textbf{Purpose} \\
+\midrule
+\endhead
+\multicolumn{3}{l}{\emph{Database}} \\
+\texttt{DATABASE\_URL}        & --- (required) & MariaDB connection string (DSN). \\
+\texttt{MYSQL\_HOST}          & \texttt{db}    & Hostname for the bundled DB service. \\
+\texttt{MYSQL\_PORT}          & \texttt{3306}  & Port for the bundled DB service. \\
+\texttt{MYSQL\_DATABASE}      & \texttt{mybibli} & DB name for the bundled service. \\
+\texttt{MYSQL\_USER}          & \texttt{mybibli} & DB user for the bundled service. \\
+\texttt{MYSQL\_PASSWORD}      & --- & DB user password for the bundled service. \\
+\texttt{MYSQL\_ROOT\_PASSWORD}& --- & Root password for the bundled service. \\
+\midrule
+\multicolumn{3}{l}{\emph{HTTP server}} \\
+\texttt{HOST}                 & \texttt{0.0.0.0} & Bind address inside the container. \\
+\texttt{PORT}                 & \texttt{8080}    & Bind port inside the container. \\
+\texttt{HOST\_PORT}           & \texttt{8080}    & Port published by Docker on the host. \\
+\midrule
+\multicolumn{3}{l}{\emph{Application}} \\
+\texttt{RUST\_LOG}            & \texttt{mybibli=info} & Tracing filter. Use \texttt{mybibli=debug} for verbose logs. \\
+\texttt{APP\_LANGUAGE}        & \texttt{en}     & Default UI language for anonymous visitors. \\
+\texttt{COVERS\_DIR}          & \texttt{./covers} & Filesystem path for cover-image storage. \\
+\midrule
+\multicolumn{3}{l}{\emph{Hardening}} \\
+\texttt{MYBIBLI\_COOKIE\_SECURE} & \texttt{false} & Set to \texttt{true} only behind HTTPS. \\
+\texttt{CSP\_REPORT\_ONLY}     & \texttt{false} & Switch CSP header to report-only mode. \\
+\midrule
+\multicolumn{3}{l}{\emph{Metadata providers (migrated to DB on first boot)}} \\
+\texttt{GOOGLE\_BOOKS\_API\_KEY} & --- & Optional key for Google Books. \\
+\texttt{OMDB\_API\_KEY}         & --- & Optional key for OMDb (films/series). \\
+\texttt{TMDB\_API\_KEY}         & --- & Optional key for TMDb (films/series). \\
+\midrule
+\multicolumn{3}{l}{\emph{Optional dev / test overrides}} \\
+\texttt{MYBIBLI\_SKIP\_SETUP}      & \texttt{false} & Bypass the first-launch wizard. \emph{Never on prod.} \\
+\texttt{MYBIBLI\_SKIP\_STARTUP\_PURGE} & \texttt{false} & Skip the boot-time auto-purge. \\
+\texttt{MYBIBLI\_SEED\_DEV\_USERS} & \texttt{false} & Seed dev \texttt{admin/admin} + \texttt{librarian/librarian}. \emph{Never on prod.} \\
+\bottomrule
+\end{longtable}
+
+Provider base-URL overrides (\texttt{BNF\_API\_BASE\_URL},
+\texttt{GOOGLE\_BOOKS\_API\_BASE\_URL}, \dots) exist solely to point
+the metadata pipeline at the in-tree mock server during automated
+tests. Leave them unset in production.
+
+\section{First boot — the setup wizard}\label{sec:first-boot}
+
+On a clean install, every request is redirected to \texttt{/setup}
+until the wizard\index{setup wizard} completes. The wizard has four
+steps:
+
+\begin{enumerate}
+  \item \textbf{Admin account.} Choose a username and a strong
+        password for the first administrator. This step is the whole
+        reason the wizard exists — once the account is created, the
+        wizard's gate predicate flips and subsequent visitors land on
+        the public catalog instead.
+  \item \textbf{Metadata providers.} Paste in any API keys you have
+        on hand (Google Books, OMDb, TMDb). All keyed providers are
+        optional — you can skip this step entirely and add keys later
+        from \texttt{/admin > System > Metadata Providers}.
+  \item \textbf{Preferences.} Pick the default UI language for
+        anonymous visitors and the loan overdue threshold (in days).
+  \item \textbf{Done.} A summary screen. After confirming, the wizard
+        writes \texttt{settings.setup\_completed\_at} and disables
+        itself for the lifetime of the installation.
+\end{enumerate}
+
+The wizard is idempotent: if you close the browser between steps,
+reopen \texttt{/setup} and the wizard resumes server-side at the
+right step (it queries the database on every load — there is no
+client state to lose).
+
+\section{Verifying the install}
+
+After the wizard finishes:
+
+\begin{itemize}
+  \item Log in at \url{http://<host>:8080/login} with the admin
+        credentials you just created.
+  \item Visit \texttt{/admin > Health}. The page should show
+        non-zero entity counts (zero on a clean install — that is
+        expected) and a green check next to each metadata provider
+        that has been reachable in the last 5\,minutes.
+  \item Scan an ISBN (the search field at the top of the home page)
+        to confirm the metadata pipeline resolves a real title. The
+        first scan takes a couple of seconds; the result appears in
+        the timeline of recent additions on the home page once the
+        background fetch completes.
+\end{itemize}
+
+If anything goes wrong, jump to chapter~\ref{ch:troubleshooting}.

--- a/docs/manual/en/02-configuration.tex
+++ b/docs/manual/en/02-configuration.tex
@@ -1,0 +1,224 @@
+\chapter{Configuration}
+\label{ch:configuration}
+
+Once the setup wizard is behind you, the day-one configuration work
+consists of three blocks: defining your \emph{storage
+locations}\index{storage locations}, populating the \emph{reference
+data} (genres, contributor roles, volume states, location types),
+and adjusting the system-wide \emph{settings} (overdue threshold,
+auto-purge cadence, provider keys).
+
+Everything in this chapter is configured from the
+\texttt{/admin}\index{admin panel} panel — there is no separate
+configuration file. The panel has five tabs:
+
+\begin{itemize}
+  \item \textbf{Health} — read-only status dashboard.
+  \item \textbf{Users} — create / deactivate users, change roles.
+  \item \textbf{Reference data} — the four taxonomy tables.
+  \item \textbf{Trash} — view and restore soft-deleted items.
+  \item \textbf{System} — global settings.
+\end{itemize}
+
+Only the \texttt{Admin} role sees the panel; \texttt{Librarian} and
+\texttt{Anonymous} users get a 403 from every \texttt{/admin/*}
+route.
+
+\section{Storage locations and hierarchy}\label{sec:locations}
+
+Storage locations are the physical spots where your volumes
+live\index{volume}: a room, a shelf, a row, a numbered box, a
+specific cell in a cabinet. mybibli organises them as a
+\textbf{tree}\index{location tree} — every location has at most one
+parent. The hierarchy is arbitrary: you decide both the levels and
+the labels.
+
+A workable household hierarchy might be three levels deep:
+
+\begin{lstlisting}
+Living room          (room)
+ └── Bookshelf A      (shelf)
+      └── Row 1       (row)
+      └── Row 2       (row)
+ └── Bookshelf B      (shelf)
+      └── Row 1       (row)
+Bedroom              (room)
+ └── Nightstand      (shelf)
+\end{lstlisting}
+
+Three levels is enough to find any volume in seconds without forcing
+the hierarchy to mirror every nook of your living space. A flat list
+(one big ``shelf'' per physical shelf) works equally well for
+collections under a few hundred volumes.
+
+\subsection*{Editing the tree}
+
+Open \texttt{/locations}. The tree is rendered as a nested list with
+inline create / rename / move / delete affordances. Drag-and-drop is
+\emph{not} supported (mybibli ships with a CSP-strict no-JS policy);
+moves are done by editing a node and picking a new parent from a
+dropdown.
+
+\subsection*{Location node types}
+
+Each location node carries a \textbf{node type}\index{node type} —
+``room'', ``shelf'', ``row'', ``box'', anything you like. Node types
+are managed under \texttt{/admin > Reference data > Location node
+types}. They are pure labels; mybibli does not enforce that a
+``shelf'' must sit under a ``room''.
+
+\begin{tip}
+Renaming a node type cascades to every location that uses it (the
+type is stored by name in the locations table). Deleting a node type
+is refused as long as one location still references it.
+\end{tip}
+
+\section{Labels: V-codes and L-codes}\label{sec:labels}
+
+mybibli prints two kinds of barcode labels:
+
+\begin{itemize}
+  \item \textbf{V-codes}\index{V-code} — one per
+        \emph{volume}\index{volume} (the physical book on a shelf).
+        Format: \texttt{V} followed by a zero-padded sequence
+        (e.g.\ \texttt{V0042}).
+  \item \textbf{L-codes}\index{L-code} — one per
+        \emph{storage location}. Format: \texttt{L} followed by a
+        zero-padded sequence (e.g.\ \texttt{L0007}).
+\end{itemize}
+
+V-codes and L-codes are scanned with the same barcode scanner you
+use for ISBNs at cataloging time. The scanner's prefix
+(\texttt{V} or \texttt{L}) tells mybibli which lookup to perform.
+
+\subsection*{Printing labels}
+
+Open \texttt{/locations} or the relevant volume page and click
+\textbf{Print label}. mybibli renders a printable HTML page with the
+Code-128 barcode and human-readable text. Print on plain paper or
+sticker stock — the encoding is forgiving enough that a low-cost
+inkjet works for V-codes and L-codes alike.
+
+\begin{tip}
+Print V-code stickers \emph{before} you start cataloging in bulk. A
+roll of pre-printed V0001 through V0500 means you can grab a sticker,
+stick it on the back cover, and scan in one motion — no
+context-switch between the cataloging UI and the printer.
+\end{tip}
+
+\section{Reference data}\label{sec:reference-data}
+
+Four taxonomy tables drive the dropdowns you see while
+cataloging. They live under \texttt{/admin > Reference data}:
+
+\begin{description}
+  \item[Genres]\index{genres} The genres assigned to titles. mybibli
+        ships with a baseline FR/EN seed (Fiction, Non-fiction,
+        Biography, \dots) — edit or extend to match your collection.
+  \item[Contributor roles]\index{contributor roles} Author,
+        Illustrator, Translator, Editor, Narrator, \dots Used by
+        title detail pages to attribute the right people to the
+        right slots.
+  \item[Volume states]\index{volume state} The physical condition
+        of an exemplaire — New, Good, Worn, Damaged, \dots Useful
+        for loan returns (mark a volume Worn when the borrower
+        damaged it).
+  \item[Location node types]\index{node type} See
+        section~\ref{sec:locations} above.
+\end{description}
+
+\subsection*{CRUD semantics}
+
+All four tables share the same CRUD pattern:
+
+\begin{itemize}
+  \item \textbf{Create} adds a row. If the name collides with a
+        soft-deleted row of the same table, the existing row is
+        reactivated and the result reads \emph{Reactivated} instead
+        of \emph{Created}.
+  \item \textbf{Rename} updates the name. For location node types,
+        the new name cascades to every location that uses the
+        type.
+  \item \textbf{Delete} performs a soft-delete \emph{only when the
+        row is unused}. If any title still references the
+        genre / role / state / type, the deletion is refused with
+        a count of dependents.
+\end{itemize}
+
+\subsection*{Reference data is not translated}
+
+Reference data values are stored verbatim — the FR seed creates a
+genre called ``Roman'' and that is the literal text English-speaking
+users will see if they switch the UI to English. Only the UI
+chrome\index{i18n} (button labels, navigation, error messages) is
+translated.
+
+\section{System settings}\label{sec:system}
+
+The \texttt{/admin > System} tab groups every global setting. The
+panel is divided into three forms, each with its own save button:
+
+\subsection*{Loans}
+
+\begin{itemize}
+  \item \textbf{Overdue threshold (days).} Defines how many days a
+        loan can run before it surfaces as overdue on the dashboard.
+        Default 30.
+  \item \textbf{Session inactivity timeout (seconds).} Idle time
+        after which an authenticated session is wiped. Default
+        1800\,s (30\,minutes).
+  \item \textbf{Auto-purge interval (seconds).} How often the
+        background scheduler hard-deletes items older than 30\,days
+        in the trash. Default 86400\,s (24\,hours).
+\end{itemize}
+
+\subsection*{Metadata providers}
+
+One row per keyed provider (Google Books, OMDb, TMDb). Each row has
+a key input and a \emph{Clear} button. Saving a key takes effect on
+the next metadata fetch — no restart, no re-deploy.
+
+\begin{note}
+If the same provider key is set in \texttt{.env} \emph{and} cleared
+from the UI, the next reboot re-migrates the value from
+\texttt{.env}. The operator's deployment-time intent wins on boot.
+To make a Clear durable across reboots, also remove the variable
+from \texttt{.env} (or \texttt{docker-compose.yml}).
+\end{note}
+
+\subsection*{Language}
+
+Sets the default UI language for \emph{anonymous} visitors.
+Authenticated users override this with the language toggle in the
+navigation bar — the choice is stored on their user row.
+
+\section{Users}\label{sec:users}
+
+Open \texttt{/admin > Users} to manage user accounts. Each row shows
+the username, role, active flag, and last-seen timestamp. The
+available actions are:
+
+\begin{itemize}
+  \item \textbf{Create user} (top of the page) — username, password,
+        role.
+  \item \textbf{Edit} — change role or rename. Cannot change another
+        user's password from this view; password resets go through
+        the user's own \texttt{Account} page.
+  \item \textbf{Deactivate} — soft-delete the user. Their sessions
+        are wiped immediately; they cannot log back in.
+  \item \textbf{Reactivate} — undo a deactivation (from the
+        \texttt{Trash} tab).
+\end{itemize}
+
+Two safety guards apply:
+
+\begin{itemize}
+  \item \textbf{Self-deactivate is blocked.} You cannot deactivate
+        the account you are logged in as.
+  \item \textbf{Last-active-admin guard.} The system always keeps at
+        least one active admin. Deactivating the last one is
+        refused with a 409 conflict and a clear error.
+\end{itemize}
+
+The three roles\index{roles} (Anonymous, Librarian, Admin) are
+detailed in chapter~\ref{ch:roles}.

--- a/docs/manual/en/03-usage.tex
+++ b/docs/manual/en/03-usage.tex
@@ -1,0 +1,173 @@
+\chapter{Everyday use}
+\label{ch:usage}
+
+This chapter walks through the workflows you will run dozens of
+times once the library is live: cataloging a new volume, searching
+your collection, moving a volume, lending it out, taking it back,
+and auditing what is on the shelves.
+
+\section{The home page}\label{sec:home}
+
+The home page is the dashboard. From top to bottom:
+
+\begin{itemize}
+  \item \textbf{Scan field.}\index{scan field} A focused input that
+        accepts an ISBN, a V-code or an L-code. The scanner-guard
+        layer routes the input to the right page depending on its
+        prefix.
+  \item \textbf{Indicators row.} Recent additions, overdue loans,
+        series with gaps, unshelved volumes — each click jumps to
+        the filtered list.
+  \item \textbf{Recent activity.} The last seven days of cataloging
+        and returns.
+\end{itemize}
+
+\section{Cataloging a new title via barcode}\label{sec:catalog-scan}
+
+\begin{enumerate}
+  \item Focus the home-page scan field (it is selected by default
+        on page load). Scan the ISBN / EAN-13 of the back cover.
+  \item mybibli redirects to the catalog page, which displays a
+        skeleton title with the barcode you scanned. A background
+        task fires off requests against the metadata provider
+        chain.
+  \item Within a few seconds, the skeleton fills in: title,
+        contributors, publisher, year, cover image. A small
+        indicator confirms which provider resolved the title.
+  \item Pick a \textbf{location}\index{location} from the dropdown
+        (or scan the L-code of the destination shelf) and pick a
+        \textbf{volume state}\index{volume state} (typically
+        \emph{New}). Click \textbf{Add volume}.
+  \item Print and stick a V-code label on the volume.
+\end{enumerate}
+
+If the metadata pipeline fails to resolve the ISBN, the title
+appears with an \emph{Unresolved} badge. You can edit the title
+fields manually and the volume is still created.
+
+\begin{tip}
+Cataloging in batches works best when the V-code sticker roll, the
+scanner and the printer are all within arm's reach. Most of the time
+is spent scanning, not waiting for mybibli — the metadata fetch is
+asynchronous, so you do not have to wait for it to finish before
+moving on to the next volume.
+\end{tip}
+
+\section{Searching the collection}\label{sec:search}
+
+The \texttt{/search} page accepts:
+
+\begin{itemize}
+  \item full or partial \textbf{title};
+  \item \textbf{contributor name} (matches on author by default;
+        other contributor roles are scored lower);
+  \item \textbf{ISBN / EAN-13} — exact match;
+  \item \textbf{V-code} or \textbf{L-code} — exact match;
+  \item \textbf{Dewey code} (for libraries that use Dewey).
+\end{itemize}
+
+Results are sorted by relevance. Click a result to open the
+title page; click a contributor to filter the catalog by their
+work; click a location label to see every volume currently in
+that location.
+
+\begin{tip}
+You can ``search'' a single volume by scanning its V-code from any
+page that has the home-page scan field — that includes the home
+page, \texttt{/search} and \texttt{/loans}. Faster than typing.
+\end{tip}
+
+\section{Moving a volume to another location}\label{sec:move-volume}
+
+\begin{enumerate}
+  \item Open the volume page (search by V-code or click through from
+        a title page).
+  \item Click \textbf{Move}.
+  \item Scan the L-code of the destination location, or pick it
+        from the dropdown.
+  \item Confirm.
+\end{enumerate}
+
+mybibli records the move in the volume's location history so you can
+trace where a book has lived over time.
+
+\section{Loans}\label{sec:loans}
+
+\subsection*{Lending a volume}
+
+\begin{enumerate}
+  \item Open \texttt{/loans} and click \textbf{New loan}.
+  \item Scan or pick the \textbf{borrower}\index{borrower}. If the
+        borrower does not exist yet, click \emph{Create borrower}
+        inline.
+  \item Scan or pick the \textbf{volume} (V-code).
+  \item Optionally set a custom \textbf{due date}; otherwise mybibli
+        derives it from the overdue threshold (chapter
+        \ref{ch:configuration}).
+  \item Confirm.
+\end{enumerate}
+
+The volume's current location is recorded on the loan row so a
+later return can restore it to the right shelf.
+
+\subsection*{Returning a volume}
+
+\begin{enumerate}
+  \item Open \texttt{/loans} and find the active loan (filter on
+        \emph{Active} or scan the V-code).
+  \item Click \textbf{Return}.
+  \item Pick the post-return state (\emph{Good}, \emph{Worn},
+        \dots).
+  \item Confirm. The volume snaps back to its pre-loan
+        location automatically.
+\end{enumerate}
+
+\subsection*{Overdue loans}
+
+Loans that exceed the overdue threshold turn red on the
+\texttt{/loans} page and on the home-page \emph{Overdue} indicator.
+You can run \texttt{/loans?filter=overdue} for a focused list.
+
+\section{Library audit}\label{sec:audit}
+
+An \emph{audit}\index{audit} is the routine ``walk the shelves and
+confirm everything is where the database says it is''. mybibli does
+not ship a dedicated audit mode — the equivalent workflow is:
+
+\begin{enumerate}
+  \item Filter \texttt{/search} by the location you intend to
+        audit, sorted by V-code.
+  \item Walk the shelf, scanning each V-code.
+  \item For any volume scanned that is \emph{not} in the filtered
+        list, mybibli surfaces a \emph{Volume not in this location}
+        message. Move it (section~\ref{sec:move-volume}) and move
+        on.
+  \item Any volume \emph{in} the filtered list that you did
+        \emph{not} scan after walking the shelf is suspect — either
+        misplaced or missing. Mark it for follow-up.
+\end{enumerate}
+
+\begin{tip}
+A quarterly audit catches misplaced volumes early — the longer a
+book has been on the wrong shelf, the harder it is to remember
+where it should be.
+\end{tip}
+
+\section{Shelving workflow}\label{sec:shelving}
+
+After a returns batch, the volumes pile up near the scanner
+station. mybibli's \emph{shelving}\index{shelving} flow speeds up
+putting them back:
+
+\begin{enumerate}
+  \item Pick up a volume and scan its V-code.
+  \item mybibli shows the volume page with the original location
+        prominently displayed.
+  \item Walk the volume to that shelf. Scan the L-code on the shelf
+        to confirm.
+  \item Repeat.
+\end{enumerate}
+
+Confirming with the L-code is optional but recommended — it leaves
+a fresh entry in the volume's location history that the next audit
+can rely on.

--- a/docs/manual/en/04-multimedia.tex
+++ b/docs/manual/en/04-multimedia.tex
@@ -1,0 +1,83 @@
+\chapter{Multiple media types}
+\label{ch:multimedia}
+
+mybibli is not just for books. Four media
+types\index{media types} are first-class citizens:
+
+\begin{itemize}
+  \item \textbf{Book} — the default. Single-volume novels, essays,
+        reference works, children's picture books.
+  \item \textbf{Comic / BD}\index{comic / BD} — single-issue comics
+        or multi-position omnibus albums (e.g.\ a ``Tintin
+        anthology'' that physically gathers volumes 1--5).
+  \item \textbf{Audio} — CDs, vinyl records, audiobooks on
+        physical media.
+  \item \textbf{Film / series}\index{film} — DVDs, Blu-ray boxsets,
+        TV-series collections.
+\end{itemize}
+
+The media type drives three things:
+
+\begin{enumerate}
+  \item \textbf{Which metadata provider is consulted first.} ISBNs
+        route to BnF + Google Books + Open Library; films route to
+        TMDb + OMDb; audio routes to MusicBrainz.
+  \item \textbf{Which fields are exposed on the title page.}
+        Audio titles surface a track list; films surface director,
+        runtime, age rating.
+  \item \textbf{The icon shown next to the title} in search results
+        and the catalog list.
+\end{enumerate}
+
+\section{Books}
+
+The default media type. Catalog as described in
+section~\ref{sec:catalog-scan}. Multi-volume series (encyclopaedias,
+trilogies, \dots) are modeled with a \emph{Series}\index{series}
+entity in chapter~\ref{ch:configuration}.
+
+\section{Comics and BD}
+
+A single \textbf{omnibus}\index{omnibus} volume can contain several
+positions in a series. mybibli supports this with the
+\emph{multi-position}\index{multi-position} feature: at volume
+creation time, you can set the volume's \emph{position range} (for
+example, ``contains volumes 5--7''). Series-gap detection
+(chapter~\ref{ch:usage}) understands these ranges and will not flag
+positions 5, 6 or 7 as missing once the omnibus is on the shelf.
+
+\section{Audio releases}
+
+Audio titles use MusicBrainz\index{MusicBrainz} as the primary
+metadata source. The barcode on the back of a CD (EAN-13) resolves
+the same way as an ISBN.
+
+\begin{itemize}
+  \item \textbf{Tracks.} MusicBrainz returns the track list; mybibli
+        renders it on the title page.
+  \item \textbf{Format.} CD vs vinyl vs cassette is captured on the
+        volume row (not on the title) — two identical pressings on
+        different media are two volumes of the same title.
+\end{itemize}
+
+\section{Films and series}
+
+Films and TV series use OMDb\index{OMDb} and TMDb\index{TMDb} as the
+primary metadata sources. A series boxset is modeled as a
+\emph{title} with a multi-position volume covering the disc range.
+
+\begin{tip}
+OMDb is free for low volumes (under 1000 requests per day); TMDb is
+free with attribution. Either covers a household-sized
+DVD / Blu-ray shelf. See chapter~\ref{ch:providers} for setup.
+\end{tip}
+
+\section{Picking the media type at scan time}
+
+After you scan an unfamiliar barcode, mybibli guesses the media
+type from the EAN prefix (the GS1 country prefix and the resolved
+provider's response). The guess is shown on the catalog page; you
+can override it before clicking \textbf{Add volume} if it is
+wrong. Re-typing a title later is a few clicks
+(\texttt{/title/<id>}) and the provider chain re-runs against the
+new type if you trigger \emph{Re-fetch metadata}.

--- a/docs/manual/en/05-metadata-providers.tex
+++ b/docs/manual/en/05-metadata-providers.tex
@@ -1,0 +1,130 @@
+\chapter{Metadata providers}
+\label{ch:providers}
+
+When you scan an ISBN or an EAN-13, mybibli does not look the title
+up in a local catalog — it queries one or more external
+\emph{metadata providers}\index{metadata providers} until one
+returns a clean answer. This chapter explains the chain, where to
+get API keys, and how to rotate them safely.
+
+\section{The provider chain}
+
+mybibli walks the providers in the order best-suited to the guessed
+media type:
+
+\begin{longtable}{@{} l l p{4.5cm} c @{}}
+\toprule
+\textbf{Provider} & \textbf{Media types} & \textbf{Notes} & \textbf{Key?} \\
+\midrule
+\endhead
+BnF\index{BnF}                  & Books         & French
+Bibliothèque nationale catalogue; best for French-language titles. & no \\
+Open Library\index{Open Library} & Books         & Volunteer
+catalogue; broad English / multilingual coverage. & no \\
+Google Books\index{Google Books} & Books         & Commercial; good
+for trade non-fiction. & optional \\
+MusicBrainz\index{MusicBrainz}  & Audio         & Volunteer music
+metadata; very deep on CDs / LPs. & no \\
+OMDb\index{OMDb}                & Films, series & Free tier; rate-limited. & required \\
+TMDb\index{TMDb}                & Films, series & Free with attribution. & required \\
+BDGest\index{BDGest}            & Comics, BD    & FR-language comic
+catalogue (web-scraped). & no \\
+\bottomrule
+\end{longtable}
+
+The first provider to return a \emph{clean} record wins. ``Clean''
+means: title present, at least one contributor, and a year. Partial
+matches are recorded but mybibli keeps walking the chain until it
+finds a clean one or runs out of providers.
+
+\section{API keys}
+
+Three providers require an API key:
+
+\subsection*{Google Books}
+
+Optional but raises the daily request budget significantly.
+
+\begin{enumerate}
+  \item Sign in to \url{https://console.cloud.google.com/}.
+  \item Create a new project (or reuse one).
+  \item Enable the \textbf{Books API}.
+  \item Create an \textbf{API key} under \emph{APIs \& Services →
+        Credentials}.
+  \item Paste it into \texttt{/admin > System > Metadata Providers}
+        in mybibli.
+\end{enumerate}
+
+\subsection*{OMDb}
+
+\begin{enumerate}
+  \item Visit \url{https://www.omdbapi.com/apikey.aspx}.
+  \item Pick the free tier (1000 requests/day).
+  \item Confirm via the activation email you receive.
+  \item Paste the key into mybibli.
+\end{enumerate}
+
+\subsection*{TMDb}
+
+\begin{enumerate}
+  \item Sign up at \url{https://www.themoviedb.org/}.
+  \item Open \emph{Settings → API} and request a key for
+        \emph{Personal / non-commercial use}.
+  \item Paste the key into mybibli.
+\end{enumerate}
+
+\section{Where the keys live}
+
+Keys travel through two layers:
+
+\begin{enumerate}
+  \item \textbf{Environment variables}\index{env vars!provider keys}
+        (\texttt{GOOGLE\_BOOKS\_API\_KEY}, \texttt{OMDB\_API\_KEY},
+        \texttt{TMDB\_API\_KEY}). These are migrated \emph{once} on
+        boot into the \texttt{settings} table — they are essentially
+        a deployment-time bootstrap.
+  \item \textbf{The \texttt{settings} table}, exposed through
+        \texttt{/admin > System > Metadata Providers}. This is the
+        live source of truth at request time. Rotating a key from
+        the UI takes effect on the very next metadata fetch.
+\end{enumerate}
+
+The implication is asymmetrical:
+
+\begin{itemize}
+  \item If you set a key only in the environment, the first boot
+        copies it into the database and afterwards the database
+        wins.
+  \item If you set a key only in the UI, the environment is never
+        consulted again.
+  \item If you set both and then \emph{Clear} the key from the UI,
+        the database value goes empty — but on the next boot, the
+        environment value is migrated back in. To make the UI clear
+        durable, also remove the environment variable from
+        \texttt{.env} / \texttt{docker-compose.yml}.
+\end{itemize}
+
+\section{Provider health}
+
+\texttt{/admin > Health} pings every registered provider every five
+minutes and reports their status as a green check or a red cross.
+A red cross does not always mean the provider is down — it can also
+mean the API key is missing or invalid. The Health tab includes the
+last-checked timestamp and the HTTP status code for diagnostics.
+
+\section{Rate limits and back-pressure}
+
+mybibli applies a small per-provider rate limit (a couple of
+requests per second). Bulk-cataloging a hundred volumes in a row
+will not trigger remote 429 responses. If a provider does return
+429, the request is logged and the next provider in the chain is
+consulted instead — the catalog flow never blocks waiting for a
+rate-limited provider.
+
+\begin{warning}
+Never commit a real API key to git. The \texttt{.env} file is in
+\texttt{.gitignore} for this reason; \texttt{.env.example} carries
+only placeholders. If a key leaks, rotate it at the provider
+console immediately — pasting a new key into mybibli takes effect
+within seconds.
+\end{warning}

--- a/docs/manual/en/06-roles-permissions.tex
+++ b/docs/manual/en/06-roles-permissions.tex
@@ -1,0 +1,116 @@
+\chapter{Roles and permissions}
+\label{ch:roles}
+
+mybibli has three user roles\index{roles} ordered by privilege:
+
+\begin{enumerate}
+  \item \textbf{Anonymous}\index{anonymous} — anyone who lands on
+        the site without a session cookie. Read-only access to the
+        catalog. Cannot loan, edit or delete anything.
+  \item \textbf{Librarian}\index{librarian} — authenticated user
+        whose role is \texttt{librarian}. Day-to-day cataloging,
+        loans, returns, location moves. Cannot manage users or
+        change system settings.
+  \item \textbf{Admin}\index{admin role} — authenticated user whose
+        role is \texttt{admin}. Everything a Librarian can do, plus
+        the \texttt{/admin} panel: users, reference data, trash,
+        system settings.
+\end{enumerate}
+
+\section{Who can do what}
+
+\begin{longtable}{@{} l c c c @{}}
+\toprule
+\textbf{Action} & \textbf{Anon} & \textbf{Lib} & \textbf{Admin} \\
+\midrule
+\endhead
+Browse / search the catalog        & yes & yes & yes \\
+View title and volume pages        & yes & yes & yes \\
+View location tree                 & yes & yes & yes \\
+\midrule
+Scan / catalog a new title         & no  & yes & yes \\
+Add or remove a volume             & no  & yes & yes \\
+Move a volume between locations    & no  & yes & yes \\
+Edit a title's metadata            & no  & yes & yes \\
+Create / edit borrowers            & no  & yes & yes \\
+Register / return loans            & no  & yes & yes \\
+Edit storage location tree         & no  & yes & yes \\
+\midrule
+Open \texttt{/admin}               & no  & no  & yes \\
+Create / deactivate users          & no  & no  & yes \\
+Edit reference data                & no  & no  & yes \\
+Restore from trash                 & no  & no  & yes \\
+Permanently delete from trash      & no  & no  & yes \\
+Edit system settings               & no  & no  & yes \\
+\bottomrule
+\end{longtable}
+
+\section{Sessions and the inactivity timeout}
+
+After login, mybibli sets a session cookie\index{session cookie}
+that travels with every subsequent request. The cookie is:
+
+\begin{itemize}
+  \item \texttt{HttpOnly} — not exposed to JavaScript;
+  \item \texttt{SameSite=Lax} — sent on top-level same-site
+        navigations but not on cross-site requests;
+  \item \texttt{Secure} (only when \texttt{MYBIBLI\_COOKIE\_SECURE}
+        is set to \texttt{true} — see chapter~\ref{ch:installation}).
+\end{itemize}
+
+The session has an \textbf{inactivity timeout}\index{inactivity
+timeout} (default 30 minutes, configurable from
+\texttt{/admin > System > Loans}). Every authenticated request resets
+the countdown; if no request lands within the timeout window, the
+session is wiped server-side and the next request redirects to the
+login page.
+
+A small \emph{keep-alive toast} appears in the corner of the screen
+roughly two minutes before expiry — click it to extend the session
+without leaving your current page.
+
+\section{The last-active-admin guard}
+
+mybibli refuses to leave the installation without any active admin.
+The guard applies to two actions:
+
+\begin{itemize}
+  \item \textbf{Deactivating a user.} If the user is the only
+        active admin, the request returns a 409 conflict and the
+        deactivation is refused.
+  \item \textbf{Permanently deleting a user from the trash.} Same
+        rule.
+\end{itemize}
+
+Self-deactivation is also blocked unconditionally (you cannot
+deactivate the account you are currently logged in as).
+
+\begin{warning}
+The guard counts only \emph{active} admins. If you mass-deactivate
+admins and the guard fires, undo by reactivating someone from the
+trash tab. There is no recovery path through the wizard or the
+database without manual SQL surgery.
+\end{warning}
+
+\section{Password reset}
+
+mybibli does not implement password-reset emails — household /
+small-community deployments rarely benefit from the email
+plumbing. An admin can reset another user's password by:
+
+\begin{enumerate}
+  \item Open \texttt{/admin > Users}.
+  \item Pick the user, click \textbf{Deactivate}.
+  \item Click \textbf{Reactivate} from the trash tab.
+  \item Re-create the user with a fresh password.
+\end{enumerate}
+
+A user who knows their own password can change it from the
+\texttt{/account} page.
+
+\section{Anonymous sessions}
+
+Anonymous visitors also get a session row (used for CSRF protection
+and pending HTMX updates). Anonymous sessions expire after seven
+days of inactivity and are garbage-collected by a daily background
+task — they do not affect logged-in users.

--- a/docs/manual/en/07-backup-restore.tex
+++ b/docs/manual/en/07-backup-restore.tex
@@ -1,0 +1,143 @@
+\chapter{Backup and restore}
+\label{ch:backup}
+
+A self-hosted library has no cloud safety net. This chapter covers
+what to back up, how often, and how to restore.
+
+\section{What to back up}
+
+Three artifacts together form a complete mybibli backup:
+
+\begin{enumerate}
+  \item \textbf{The MariaDB database.}\index{backup!database} Holds
+        every title, volume, location, contributor, loan, user,
+        audit log and setting. Lose this and you start from zero.
+  \item \textbf{The \texttt{covers/} directory.}\index{backup!covers}
+        Cover images downloaded during cataloging. Lose this and
+        the catalog still works, but every title page shows a
+        generic placeholder until you re-fetch metadata
+        title-by-title.
+  \item \textbf{The \texttt{.env} file.}\index{backup!.env} Holds
+        passwords (database, API keys not yet migrated). Lose this
+        and a re-deploy needs you to re-enter every credential.
+\end{enumerate}
+
+The Docker images themselves are \emph{not} backup-critical — you
+can always pull them again from Docker Hub.
+
+\section{Backup procedure}
+
+\subsection*{Database — bundled MariaDB}
+
+From the host running the compose stack:
+
+\begin{lstlisting}
+docker compose exec -T db mariadb-dump \
+    -u root -p"$MYSQL_ROOT_PASSWORD" \
+    --single-transaction --routines --triggers \
+    mybibli \
+    > backups/mybibli-$(date +%Y%m%d-%H%M%S).sql
+\end{lstlisting}
+
+The \texttt{--single-transaction} flag is important: it dumps a
+consistent snapshot without locking the table for the duration of
+the dump. \texttt{--routines --triggers} preserves any stored
+routines (mybibli does not currently use any, but the flag is cheap
+and future-proof).
+
+Compress the dump if disk space is a concern:
+
+\begin{lstlisting}
+gzip backups/mybibli-*.sql
+\end{lstlisting}
+
+\subsection*{Database — external MariaDB}
+
+Run \texttt{mariadb-dump} directly against the external server.
+Synology DSM users can also schedule a \emph{Hyper Backup} task that
+targets the MariaDB package — it produces a binary backup that
+restores faster than a SQL dump.
+
+\subsection*{Covers and \texttt{.env}}
+
+A plain \texttt{tar} archive is enough:
+
+\begin{lstlisting}
+tar czf backups/mybibli-files-$(date +%Y%m%d).tar.gz \
+    .env covers/
+\end{lstlisting}
+
+\section{Recommended cadence}
+
+\begin{itemize}
+  \item \textbf{Daily} — automated database dump. Even on a
+        seldom-changed catalog, a daily dump means worst-case data
+        loss is bounded to one day.
+  \item \textbf{Weekly} — covers and \texttt{.env}. These change
+        only when you catalog new titles or rotate keys; weekly
+        is plenty.
+  \item \textbf{Off-site copy} — at least monthly. Rsync the
+        \texttt{backups/} directory to a remote NAS, a USB drive
+        you swap in / out, or a cloud-storage bucket. A fire that
+        consumes the home server should not also consume your
+        backups.
+\end{itemize}
+
+\begin{tip}
+A backup that has never been restored is not a backup. Once a
+quarter, restore your latest dump into a throwaway docker
+environment and verify the title and loan counts match what
+\texttt{/admin > Health} reports on production.
+\end{tip}
+
+\section{Restore procedure}
+
+\subsection*{Database}
+
+For the bundled-database setup:
+
+\begin{lstlisting}
+docker compose stop mybibli
+docker compose exec -T db mariadb -u root -p"$MYSQL_ROOT_PASSWORD" \
+    -e "DROP DATABASE mybibli; CREATE DATABASE mybibli CHARACTER SET utf8mb4;"
+zcat backups/mybibli-20260513-1200.sql.gz | \
+    docker compose exec -T db mariadb -u root -p"$MYSQL_ROOT_PASSWORD" mybibli
+docker compose start mybibli
+\end{lstlisting}
+
+For external MariaDB, the same \texttt{mariadb} client commands work
+against the external server.
+
+\subsection*{Covers and \texttt{.env}}
+
+\begin{lstlisting}
+tar xzf backups/mybibli-files-20260513.tar.gz
+\end{lstlisting}
+
+Restart the stack so the mybibli container picks up the restored
+\texttt{.env}.
+
+\section{Migration to a new host}
+
+The backup procedure is also the migration procedure:
+
+\begin{enumerate}
+  \item On the old host: produce a fresh database dump and tar
+        archive.
+  \item Transfer both to the new host.
+  \item On the new host: install Docker, pull the compose file from
+        the release matching the dump's version, place \texttt{.env}
+        and \texttt{covers/} alongside, restore the database, start
+        the stack.
+  \item Verify by counting titles on \texttt{/admin > Health} and
+        spot-checking a few title pages.
+\end{enumerate}
+
+\begin{warning}
+The dump is tied to the \emph{schema} version. If the source host
+ran 1.1.0 and the new host pulls 1.5.0, the new host's migrations
+will upgrade the restored database in place — that is fine. The
+reverse (restoring a 1.5.0 dump onto a 1.1.0 install) is \emph{not}
+supported and will fail at boot. Always restore on a host running
+the same or newer mybibli release.
+\end{warning}

--- a/docs/manual/en/08-upgrade-migration.tex
+++ b/docs/manual/en/08-upgrade-migration.tex
@@ -1,0 +1,122 @@
+\chapter{Upgrade and migration}
+\label{ch:upgrade}
+
+Routine upgrades are designed to be safe. The exception is the
+1.0.x to 1.1.0 jump, which is a one-time breaking change documented
+below.
+
+\section{Routine upgrades (1.y to 1.z)}
+
+\begin{enumerate}
+  \item Read the release notes for every version between your
+        current and the target version.
+  \item Take a fresh \textbf{database backup} (chapter
+        \ref{ch:backup}).
+  \item Update the image tag in \texttt{docker-compose.yml} (or
+        repull \texttt{:latest} if you track that tag).
+  \item Run \texttt{docker compose up -d}. The new container boots,
+        runs any new migrations against the existing database, and
+        starts serving requests.
+  \item Watch the logs for migration errors:
+        \texttt{docker compose logs mybibli | grep -i migrate}.
+\end{enumerate}
+
+Migrations are append-only — schema changes are forward
+compatible. A 1.4 install upgraded to 1.5 keeps every row from 1.4
+and applies new tables / columns in place.
+
+\begin{tip}
+For homelab installs, the \texttt{:latest} Docker tag is a
+reasonable default. For production-style setups (a community
+library, an association), pin to an explicit version tag so an
+unattended pull does not bring in a release you have not read about.
+\end{tip}
+
+\section{The 1.0.x to 1.1.0 jump}\label{sec:upgrade-1.1.0}
+
+\begin{warning}
+\textbf{This is a one-time breaking change.}\index{1.1.0 upgrade}
+1.0.x installs are subject to the issue documented in
+\href{https://github.com/guycorbaz/mybibli/issues/173}{\#173}:
+the seed migrations create the credentials \texttt{admin/admin}
+and \texttt{librarian/librarian} on every fresh install, including
+production, and silently bypass the first-launch setup wizard.
+\end{warning}
+
+The recommended path depends on whether your 1.0.x install holds
+real data:
+
+\subsection*{If your 1.0.x install is empty (no titles cataloged)}
+
+The simplest path: wipe the database and reinstall on 1.1.0+.
+
+\begin{enumerate}
+  \item Stop the stack: \texttt{docker compose down}.
+  \item Remove the database volume:
+        \texttt{docker volume rm mybibli\_mybibli\_db\_data}
+        (or the equivalent volume name on your host —
+        \texttt{docker volume ls} lists them).
+  \item Pull the 1.1.0 image:
+        \texttt{docker compose pull}.
+  \item Update the image tag in \texttt{docker-compose.yml} if you
+        pinned a previous version.
+  \item Start: \texttt{docker compose up -d}.
+  \item Open \texttt{/setup} and walk through the wizard.
+\end{enumerate}
+
+\subsection*{If your 1.0.x install holds real data}
+
+\begin{enumerate}
+  \item Take a database backup (chapter \ref{ch:backup}).
+  \item Take a covers + \texttt{.env} backup.
+  \item Log in as the seeded admin and rotate the password
+        \emph{before} you upgrade. The 1.1.0 upgrade flow itself is
+        safe, but rotation closes the only window where the default
+        credentials could leak.
+  \item Update the image tag in \texttt{docker-compose.yml} and run
+        \texttt{docker compose up -d}.
+  \item The 1.1.0 boot detects the existing admin and does
+        \emph{not} re-enable the wizard — the rotated admin remains
+        the active admin.
+\end{enumerate}
+
+\subsection*{The new \texttt{MYBIBLI\_SEED\_DEV\_USERS} variable}
+
+Starting with 1.1.0, the seed migration is gated by
+\texttt{MYBIBLI\_SEED\_DEV\_USERS}\index{MYBIBLI\_SEED\_DEV\_USERS}.
+The default is \texttt{0} (no seed). Only set it to \texttt{1} for
+local-development workflows or automated tests — never in
+production. The first-launch wizard becomes the canonical
+onboarding path.
+
+\section{Reading the release notes}
+
+Every mybibli release publishes a GitHub Release page with:
+
+\begin{itemize}
+  \item a one-paragraph summary of the change set;
+  \item the migration impact (none / additive / breaking);
+  \item a link to the diff against the previous tag;
+  \item attached PDFs of this manual (English + French) once the
+        release-time PDF build is wired into CI.
+\end{itemize}
+
+Read the notes before upgrading. Breaking changes are tagged with a
+prominent \emph{Breaking} label.
+
+\section{Rollback}
+
+Rollback is \emph{not} a first-class flow. Schema migrations move
+forward only — there is no \texttt{down.sql}. The supported recovery
+strategy is:
+
+\begin{enumerate}
+  \item Restore the pre-upgrade database backup
+        (chapter~\ref{ch:backup}).
+  \item Pin the image tag back to the prior version.
+  \item Start the stack.
+\end{enumerate}
+
+This works because the backup is consistent with the prior schema.
+Trying to point an older image at a newly-migrated database will
+fail to boot.

--- a/docs/manual/en/09-best-practices.tex
+++ b/docs/manual/en/09-best-practices.tex
@@ -1,0 +1,119 @@
+\chapter{Best practices}
+\label{ch:bestpractices}
+
+Concentrated lessons from real-world deployments. Every section is
+optional — pick what fits your scale.
+
+\section{Storage hierarchy}
+
+\begin{itemize}
+  \item \textbf{Three levels are usually enough.} Room → shelf →
+        row covers most households. A fourth level (e.g.\ ``box
+        inside row'') becomes paperwork you have to maintain.
+  \item \textbf{Name locations the way you talk about them.}
+        ``Living-room shelf, top'' beats ``LR-S01-R01''. The names
+        are visible on barcode labels; treat them as user-facing.
+  \item \textbf{Print L-codes once.} Re-printing because you
+        rebalanced shelves is wasted effort — L-codes are stable
+        identifiers; the human-readable name on the label can drift
+        and that is fine.
+\end{itemize}
+
+\section{V-code rolls}
+
+\begin{itemize}
+  \item Print V-codes in rolls of 50 to 100. Pre-printed stickers in
+        a holder beside the scanner station make cataloging
+        \emph{fast}.
+  \item \textbf{Stick the V-code before scanning.} It removes a
+        future failure mode where you mislabel a book and have to
+        scan-find it again.
+  \item \textbf{Place the sticker consistently.} Inside back cover,
+        upper-right corner, parallel to the spine — pick a rule
+        and stick to it. Future-you doing an audit will thank
+        present-you.
+\end{itemize}
+
+\section{Genre versus Dewey}
+
+mybibli supports both broad genres and Dewey codes\index{Dewey}.
+Pick one as your primary navigation aid:
+
+\begin{itemize}
+  \item \textbf{Use genres} when the audience browses by mood
+        (``I want a thriller'') and the collection is small enough
+        that ``Thriller'' is granular enough.
+  \item \textbf{Use Dewey} when the audience browses by topic
+        (``books on 18th-century French history'') or when the
+        collection has reached the size where ``Non-fiction'' is no
+        longer a useful filter.
+  \item Using both is fine; mybibli does not force a choice.
+\end{itemize}
+
+\section{Audit cadence}
+
+\begin{itemize}
+  \item \textbf{Quarterly} for collections under a few hundred
+        volumes.
+  \item \textbf{Monthly} for collections above that, especially if
+        more than one person catalogs.
+  \item Always run an audit \emph{after} a major shelf rebalance —
+        moving books physically without telling mybibli is the
+        single biggest source of ``where is this volume?'' bugs.
+\end{itemize}
+
+\section{User accounts}
+
+\begin{itemize}
+  \item \textbf{One human, one account.} Sharing a single
+        \texttt{admin} account between two people loses the audit
+        trail and makes the last-active-admin guard less useful.
+  \item \textbf{Most editors should be Librarians, not Admins.} The
+        admin panel handles installation-time concerns and rare
+        cleanups; you do not need admin rights to catalog or loan.
+  \item \textbf{Rotate the seeded admin password on first login.}
+        On 1.1.0+ the setup wizard forces this; on legacy 1.0.x
+        installs do it manually before exposing the instance to a
+        network.
+\end{itemize}
+
+\section{Loans}
+
+\begin{itemize}
+  \item \textbf{Keep borrowers identifiable.} ``Marie L.'' beats
+        ``Marie'' the moment the second Marie shows up. Email or
+        phone in the notes field helps for chase-ups.
+  \item \textbf{Run the overdue list weekly.} The dashboard
+        indicator nags you for a reason — overdue loans
+        compounded over a year become books you no longer
+        own.
+  \item \textbf{Mark damage at return time.} Switching a returned
+        volume to \emph{Worn} or \emph{Damaged} captures the
+        information while the borrower is in front of you; chasing
+        the cost later from memory rarely works.
+\end{itemize}
+
+\section{Metadata providers}
+
+\begin{itemize}
+  \item \textbf{Keep keys minimal.} You do not need all three
+        keyed providers from day one — BnF + Open Library cover
+        books for free. Add OMDb + TMDb the day you catalog
+        your first DVD.
+  \item \textbf{Treat keys as secrets.} \texttt{.env} is in
+        \texttt{.gitignore}; keep backups of \texttt{.env}
+        encrypted (chapter~\ref{ch:backup}).
+\end{itemize}
+
+\section{Upgrades}
+
+\begin{itemize}
+  \item \textbf{Read release notes before pulling \texttt{:latest}.}
+        See chapter~\ref{ch:upgrade}.
+  \item \textbf{Back up immediately before any upgrade.} Even
+        ``additive'' migrations have non-zero failure surface;
+        a same-minute backup turns a worry into a chore.
+  \item \textbf{Pin a version tag for production.} Auto-updates
+        for a household instance are fine; for a community library,
+        an unattended major bump can interrupt service.
+\end{itemize}

--- a/docs/manual/en/10-troubleshooting.tex
+++ b/docs/manual/en/10-troubleshooting.tex
@@ -1,0 +1,164 @@
+\chapter{Troubleshooting}
+\label{ch:troubleshooting}
+
+When things go wrong, start with the logs and the
+\texttt{/admin > Health} dashboard. This chapter catalogues the
+problems users actually hit, in rough order of frequency.
+
+\section{Reading the logs}
+
+\begin{lstlisting}
+docker compose logs --since 10m mybibli
+docker compose logs -f mybibli
+\end{lstlisting}
+
+Logs are emitted as structured JSON. The most useful fields are
+\texttt{level}, \texttt{target} (which module logged this),
+\texttt{message}, and any contextual key=value pairs that the log
+line carries (\texttt{user\_id}, \texttt{volume\_id}, \dots).
+
+To filter:
+
+\begin{lstlisting}
+docker compose logs --since 10m mybibli | grep -i error
+\end{lstlisting}
+
+\section{App does not start}
+
+\subsection*{Symptom: container exits immediately}
+
+Run \texttt{docker compose logs mybibli} and look for one of:
+
+\begin{itemize}
+  \item \texttt{missing required environment variable:
+        DATABASE\_URL}\index{troubleshooting!DATABASE\_URL} — the
+        \texttt{.env} file is missing or the variable is unset. See
+        section~\ref{sec:env-vars}.
+  \item \texttt{Failed to create database pool} — the database
+        hostname / port / credentials in \texttt{DATABASE\_URL} are
+        wrong, or the DB is not reachable. From the host, try
+        \texttt{docker compose exec mybibli sh -c 'apk add curl;
+        curl <db-host>:<db-port>'} to confirm reachability.
+  \item \texttt{Failed to run database migrations} — usually a
+        permissions issue. Confirm the DB user has \texttt{ALL
+        PRIVILEGES} on the database (see
+        section~\ref{sec:install-external-db}).
+  \item \texttt{Address already in use} — the published host port
+        is taken. Change \texttt{HOST\_PORT} in \texttt{.env}.
+\end{itemize}
+
+\subsection*{Symptom: every page returns 404}
+
+The container is up but routes are missing. Most common cause:
+you pulled an image tag that does not exist (typo) and Docker
+fell back to a stale older tag. \texttt{docker compose pull} and
+restart.
+
+\section{Cannot log in}
+
+\subsection*{Symptom: ``Invalid credentials'' on a fresh 1.0.x install}
+
+The seed credentials are \texttt{admin/admin}. If they do not work
+either:
+
+\begin{itemize}
+  \item the database migration that creates them failed silently
+        — look for migration errors in the logs;
+  \item the previous admin already rotated the password (check
+        with whoever installed mybibli);
+  \item you are looking at a 1.1.0+ install, where no seed exists —
+        use the wizard at \texttt{/setup} instead.
+\end{itemize}
+
+\subsection*{Symptom: login redirects back to \texttt{/login}}
+
+The session cookie is being rejected by the browser. Causes:
+
+\begin{itemize}
+  \item \texttt{MYBIBLI\_COOKIE\_SECURE=true} on a plain-HTTP
+        deployment — the browser refuses to accept a Secure cookie
+        over HTTP. Set the variable to \texttt{false} or front the
+        instance with HTTPS.
+  \item Cookies blocked by browser policy (private window with
+        strict third-party blocking, etc.). Test in a default
+        profile.
+\end{itemize}
+
+\subsection*{Symptom: locked out — last admin deactivated}
+
+The last-active-admin guard should prevent this, but if a previous
+admin was deactivated then permanently deleted, recovery requires
+direct SQL access:
+
+\begin{lstlisting}
+docker compose exec db mariadb -u root -p"$MYSQL_ROOT_PASSWORD" mybibli \
+    -e "UPDATE users SET deleted_at=NULL, active=1 WHERE username='your-admin';"
+\end{lstlisting}
+
+Then log in normally.
+
+\section{Metadata never resolves}
+
+\subsection*{Symptom: skeleton title stays unresolved}
+
+Open \texttt{/admin > Health}. Look at each provider's status. A
+red cross usually means one of:
+
+\begin{itemize}
+  \item the provider is genuinely down (rare for BnF / Open Library;
+        more common for the smaller services);
+  \item the API key is missing or invalid — open
+        \texttt{/admin > System > Metadata Providers} and re-enter
+        the key;
+  \item the host cannot reach the upstream. Confirm with
+        \texttt{docker compose exec mybibli sh -c "wget -q
+        https://www.googleapis.com/books/v1 -O -"} or equivalent.
+\end{itemize}
+
+\subsection*{Symptom: only French ISBNs resolve}
+
+You disabled (or never set) the Google Books / Open Library keys.
+BnF is excellent for French-published titles but limited for
+foreign-language titles. Add at least Open Library (no key
+required).
+
+\section{Search returns too little}
+
+\subsection*{Symptom: known titles do not surface}
+
+\begin{itemize}
+  \item Confirm the title is not soft-deleted (check
+        \texttt{/admin > Trash}). Search hides soft-deleted items.
+  \item Confirm the title's contributors are spelled the way you
+        searched. mybibli's search is fuzzy but not magical;
+        ``Camus'' will find ``Albert Camus'' but ``Camu'' might
+        not.
+\end{itemize}
+
+\subsection*{Symptom: search is slow}
+
+For collections above 10,000 titles, queries that combine
+contributor + free-text can take a second or two. This is a known
+limitation; planned indexes will close the gap.
+
+\section{Cover images are missing}
+
+\subsection*{Symptom: every title shows the placeholder}
+
+The \texttt{covers/} directory is empty or unreadable. Confirm:
+
+\begin{itemize}
+  \item the volume mount in \texttt{docker-compose.yml} points to
+        a directory that exists and is writable by the container;
+  \item the metadata fetch actually returned a cover URL (check the
+        title page — if the URL is missing, the provider did not
+        supply one).
+\end{itemize}
+
+\section{Where to file bugs}
+
+Issues you cannot resolve, or behaviour that contradicts this
+manual: open a ticket at
+\url{https://github.com/guycorbaz/mybibli/issues}. The issue
+template asks for the version (visible in the page footer), the
+install method, and the steps to reproduce — please fill them in.

--- a/docs/manual/en/99-glossary.tex
+++ b/docs/manual/en/99-glossary.tex
@@ -1,0 +1,177 @@
+\chapter{Glossary}
+\label{ch:glossary}
+
+\begin{description}
+
+  \item[Admin]\index{admin role} A user account with role
+        \texttt{admin}. The only role that can open the
+        \texttt{/admin} panel and edit users, reference data, trash
+        or system settings.
+
+  \item[Anonymous]\index{anonymous} A visitor without a session
+        cookie. Read-only access to the public catalog. No
+        cataloging, no loans, no edits.
+
+  \item[Audit]\index{audit} The routine ``walk the shelves and
+        confirm everything is where the database says it is''
+        workflow described in section~\ref{sec:audit}.
+
+  \item[BDGest]\index{BDGest} A French-language comic / BD
+        catalogue used as a metadata source for that media type.
+
+  \item[BnF]\index{BnF} \textit{Bibliothèque nationale de France}.
+        The French national library catalogue, used as the primary
+        metadata source for French-language books.
+
+  \item[Borrower]\index{borrower} A person who loans volumes from
+        the library. Modeled as its own entity (name, optional
+        contact information, loan history).
+
+  \item[Cataloging] The act of registering a new title and / or
+        volume in the database. Typically barcode-driven: scan,
+        confirm, stick label, repeat.
+
+  \item[Cover image]\index{covers} The visual front of a book / disc
+        / record, downloaded from a metadata provider and cached
+        under \texttt{COVERS\_DIR} on disk.
+
+  \item[CSP] Content Security Policy. A browser-enforced
+        instructions header that restricts which scripts and styles
+        the page may execute. mybibli ships a strict policy that
+        forbids inline scripts and styles.
+
+  \item[CSRF token]\index{CSRF} A per-session secret embedded into
+        every form. mybibli rejects POST / PUT / DELETE requests
+        whose token does not match — a defense against cross-site
+        request forgery.
+
+  \item[Dewey code]\index{Dewey} The Dewey Decimal Classification
+        number, used for topic-based catalog navigation. Optional
+        per title.
+
+  \item[EAN-13] The 13-digit barcode standard. ISBNs are encoded
+        as EAN-13 since 2007; CDs, DVDs and other media carry
+        EAN-13 codes too.
+
+  \item[Exemplaire] Synonym for \emph{volume} (the physical copy).
+        Used by some French libraries; mybibli prefers
+        \emph{volume}.
+
+  \item[Genre]\index{genres} A free-form classification of a title's
+        subject (Fiction, Non-fiction, Mystery, \dots). Defined in
+        the genres reference table.
+
+  \item[Hard-delete] Deleting a row outright. mybibli only
+        hard-deletes from the \texttt{/admin > Trash} panel and
+        from the auto-purge background task; everything else is a
+        soft-delete.
+
+  \item[HTMX] The JavaScript library mybibli uses to swap fragments
+        of the page in place without full reloads. Operators do
+        not need to understand HTMX to use mybibli.
+
+  \item[ISBN] International Standard Book Number. Identifier
+        printed on the back cover of books, encoded as an EAN-13
+        barcode.
+
+  \item[Last-active-admin guard]\index{last-active-admin guard}
+        The rule that prevents deactivating or permanently
+        deleting the last user with the \texttt{admin} role. See
+        section~\ref{sec:users}.
+
+  \item[L-code]\index{L-code} A storage-location barcode label.
+        Format: \texttt{L} followed by a zero-padded number.
+
+  \item[Librarian]\index{librarian} A user account with role
+        \texttt{librarian}. Can catalog, loan, return and edit
+        most data but cannot administer users or settings.
+
+  \item[Loan]\index{loan} A record that a specific volume is
+        currently out with a specific borrower. Tracks the loan
+        date, due date, return date, and the volume's pre-loan
+        location.
+
+  \item[Location]\index{location} The physical place where a
+        volume lives. Modeled as a tree (room → shelf → row),
+        identified by an L-code.
+
+  \item[MariaDB] The database engine mybibli stores its data in.
+        A fork of MySQL.
+
+  \item[Media type]\index{media types} The kind of object a title
+        represents: Book, Comic / BD, Audio, Film / series. Drives
+        provider selection and field display.
+
+  \item[Multi-position volume]\index{multi-position} A single
+        physical volume that contains several positions in a
+        series — typically an omnibus comic album.
+
+  \item[MusicBrainz]\index{MusicBrainz} A volunteer-maintained
+        music metadata catalogue, used as the primary source for
+        audio media.
+
+  \item[Node type]\index{node type} A label applied to storage
+        locations to indicate what kind of container they are
+        (room, shelf, row, box). Pure label — no semantic
+        enforcement.
+
+  \item[OMDb]\index{OMDb} Open Movie Database. Metadata source
+        for films and TV series.
+
+  \item[Open Library]\index{Open Library} An open volunteer-driven
+        catalogue of books, used as a metadata source.
+
+  \item[Optimistic locking] The technique mybibli uses to detect
+        concurrent edits. Two users editing the same title get a
+        clear error on the second save instead of silently
+        overwriting each other.
+
+  \item[Reactivation] Restoring a soft-deleted row. For users,
+        clears \texttt{deleted\_at} and lets them log in again.
+        For reference data, the term also covers re-creating a
+        row with the same name as a soft-deleted one, which
+        transparently undoes the delete.
+
+  \item[Reference data] The four taxonomy tables: genres,
+        contributor roles, volume states, location node types.
+        Editable from \texttt{/admin > Reference data}.
+
+  \item[Series]\index{series} A named ordering of related titles
+        (e.g.\ a trilogy or an open-ended comic series). Each
+        title's position in the series is a small integer or a
+        range (for omnibuses).
+
+  \item[Setup wizard]\index{setup wizard} The four-step
+        first-launch flow at \texttt{/setup} that an empty
+        instance presents until an admin account exists.
+
+  \item[Soft-delete]\index{soft-delete} Setting a row's
+        \texttt{deleted\_at} column to ``now'' instead of
+        physically removing the row. Soft-deleted rows are
+        invisible to normal queries but surface in
+        \texttt{/admin > Trash} for 30 days, after which the
+        auto-purge hard-deletes them.
+
+  \item[Title] The bibliographic entity (a book, a film, an
+        album). A title can have multiple volumes — for example,
+        two copies of the same novel on different shelves.
+
+  \item[TMDb]\index{TMDb} The Movie Database. A community-curated
+        metadata source for films and TV series.
+
+  \item[Trash] The \texttt{/admin > Trash} tab. Lists soft-deleted
+        entities of every type and lets an admin restore them or
+        permanently delete them.
+
+  \item[V-code]\index{V-code} A per-volume barcode label. Format:
+        \texttt{V} followed by a zero-padded number.
+
+  \item[Volume]\index{volume} The physical object on a shelf — one
+        copy of a title. A title can have many volumes; each
+        carries its own V-code, location and state.
+
+  \item[Volume state]\index{volume state} A reference-data row
+        describing the condition of a volume: New, Good, Worn,
+        Damaged, \dots.
+
+\end{description}

--- a/docs/manual/en/main.tex
+++ b/docs/manual/en/main.tex
@@ -126,6 +126,9 @@ This manual covers mybibli version 1.1.0 and later.
 \input{99-glossary}
 
 \backmatter
+\cleardoublepage
+\phantomsection
+\label{index}
 \printindex
 
 \end{document}

--- a/docs/manual/en/main.tex
+++ b/docs/manual/en/main.tex
@@ -1,0 +1,131 @@
+% mybibli — User Manual (English)
+%
+% Build with:    latexmk -xelatex main.tex
+% or from the parent directory:
+%                ./build.sh en
+%
+% Requires XeLaTeX (for fontspec + polyglossia + Unicode).
+\documentclass[a4paper,11pt,oneside]{book}
+
+% ---- Fonts (XeLaTeX) -------------------------------------------------
+\usepackage{fontspec}
+\setmainfont{Latin Modern Roman}
+\setsansfont{Latin Modern Sans}
+\setmonofont{Latin Modern Mono}[Scale=0.92]
+
+% ---- Language --------------------------------------------------------
+\usepackage{polyglossia}
+\setdefaultlanguage{english}
+
+% ---- Page layout -----------------------------------------------------
+\usepackage[a4paper,margin=2.5cm,headheight=14pt]{geometry}
+\usepackage{microtype}
+\usepackage{parskip}
+
+% ---- Colors and hyperlinks ------------------------------------------
+\usepackage{xcolor}
+\definecolor{linkcolor}{HTML}{0B5394}
+\definecolor{codebg}{HTML}{F5F5F5}
+\usepackage[colorlinks=true,linkcolor=linkcolor,urlcolor=linkcolor,citecolor=linkcolor]{hyperref}
+
+% ---- Header / footer -------------------------------------------------
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[L]{\nouppercase{\leftmark}}
+\fancyhead[R]{\thepage}
+\renewcommand{\headrulewidth}{0.4pt}
+\fancypagestyle{plain}{%
+  \fancyhf{}
+  \fancyfoot[C]{\thepage}
+  \renewcommand{\headrulewidth}{0pt}}
+
+% ---- Tables ----------------------------------------------------------
+\usepackage{booktabs}
+\usepackage{array}
+\usepackage{longtable}
+\usepackage{tabularx}
+
+% ---- Lists -----------------------------------------------------------
+\usepackage{enumitem}
+\setlist{itemsep=2pt, topsep=4pt}
+
+% ---- Code listings ---------------------------------------------------
+\usepackage{listings}
+\lstdefinestyle{config}{
+  basicstyle=\ttfamily\small,
+  backgroundcolor=\color{codebg},
+  breaklines=true,
+  breakatwhitespace=false,
+  frame=single,
+  framerule=0pt,
+  rulecolor=\color{codebg},
+  columns=fullflexible,
+  keepspaces=true,
+  showstringspaces=false,
+  xleftmargin=4pt,
+  xrightmargin=4pt,
+  aboveskip=8pt,
+  belowskip=8pt,
+  literate=%
+    {é}{{\'e}}1 {è}{{\`e}}1 {ê}{{\^e}}1 {ë}{{\"e}}1
+    {à}{{\`a}}1 {â}{{\^a}}1 {ä}{{\"a}}1
+    {î}{{\^\i}}1 {ï}{{\"\i}}1
+    {ô}{{\^o}}1 {ö}{{\"o}}1
+    {ù}{{\`u}}1 {û}{{\^u}}1 {ü}{{\"u}}1
+    {ç}{{\c c}}1 {Ç}{{\c C}}1 {œ}{{\oe}}1 {Œ}{{\OE}}1
+    {’}{{'}}1 {–}{{--}}1 {—}{{---}}1
+}
+\lstset{style=config}
+
+% ---- Callout boxes ---------------------------------------------------
+\usepackage[most]{tcolorbox}
+\newtcolorbox{note}{colback=blue!4!white, colframe=blue!55!black,
+  fonttitle=\bfseries, title=Note, breakable, enhanced}
+\newtcolorbox{tip}{colback=green!4!white, colframe=green!50!black,
+  fonttitle=\bfseries, title=Tip, breakable, enhanced}
+\newtcolorbox{warning}{colback=red!4!white, colframe=red!70!black,
+  fonttitle=\bfseries, title=Warning, breakable, enhanced}
+
+% ---- Index -----------------------------------------------------------
+\usepackage{imakeidx}
+\makeindex[intoc,columns=2,title=Index]
+
+% ---- Document metadata ----------------------------------------------
+\title{\Huge\bfseries mybibli\\[6pt]\Large User Manual}
+\author{The mybibli authors\\\small \texttt{https://github.com/guycorbaz/mybibli}}
+\date{Version 1.1.0 — \today}
+
+% =====================================================================
+\begin{document}
+\frontmatter
+\maketitle
+
+\begin{center}
+\vspace*{2cm}
+\small
+Licensed under AGPL-3.0-or-later.\\
+This manual covers mybibli version 1.1.0 and later.
+\end{center}
+
+\tableofcontents
+
+\mainmatter
+
+\input{00-preface}
+\input{01-installation}
+\input{02-configuration}
+\input{03-usage}
+\input{04-multimedia}
+\input{05-metadata-providers}
+\input{06-roles-permissions}
+\input{07-backup-restore}
+\input{08-upgrade-migration}
+\input{09-best-practices}
+\input{10-troubleshooting}
+\input{99-glossary}
+
+\backmatter
+\printindex
+
+\end{document}

--- a/docs/manual/fr/00-preface.tex
+++ b/docs/manual/fr/00-preface.tex
@@ -1,0 +1,89 @@
+\chapter*{Préface}
+\addcontentsline{toc}{chapter}{Préface}
+\markboth{Préface}{Préface}
+
+\section*{À qui ce manuel s'adresse}
+
+Ce manuel s'adresse à la personne qui installe, configure et exploite
+une instance mybibli pour son foyer, une petite association ou une
+bibliothèque communautaire. Il suppose que vous savez :
+
+\begin{itemize}
+  \item ouvrir un terminal et lancer des commandes
+        \texttt{docker compose} ;
+  \item modifier un fichier texte de configuration dans l'éditeur de
+        votre choix ;
+  \item lire une URL imprimée dans une ligne de log et l'ouvrir dans
+        un navigateur.
+\end{itemize}
+
+Aucune connaissance de Rust, MariaDB ou HTMX n'est requise. Le manuel
+se limite délibérément au rôle d'\emph{exploitant} — compiler
+mybibli depuis les sources ou modifier son code est couvert par
+\texttt{CLAUDE.md} et les artefacts de planification du dépôt.
+
+\section*{Conventions}
+
+\textbf{Commandes.} Les fragments de shell sont présentés dans un
+encadré à largeur fixe :
+
+\begin{lstlisting}
+docker compose up -d
+\end{lstlisting}
+
+\textbf{Fichiers de configuration.} Les extraits de fichiers utilisent
+le même style, le nom du fichier étant indiqué dans le texte
+environnant. Les commentaires à l'intérieur du fragment utilisent le
+marqueur de commentaire propre au fichier.
+
+\textbf{Encadrés.} Trois types d'encadrés signalent les passages
+importants :
+
+\begin{note}
+Une \emph{note} fournit un contexte ou un éclairage qui aide à
+comprendre pourquoi quelque chose fonctionne comme cela. La sauter
+ne pose pas de problème.
+\end{note}
+
+\begin{tip}
+Une \emph{astuce} suggère une pratique qui rend l'usage quotidien
+plus fluide. Essayez-la une fois que les bases sont maîtrisées.
+\end{tip}
+
+\begin{warning}
+Un \emph{avertissement} signale une étape où une erreur peut
+entraîner une perte de données, vous verrouiller hors du panneau
+d'administration ou exposer l'instance à des accès non autorisés.
+Lisez ces encadrés en entier.
+\end{warning}
+
+\textbf{Renvois croisés.} Les chapitres et sections sont liés dans le
+PDF — cliquez sur un titre ou un numéro de page en bleu pour y
+sauter. L'\hyperref[index]{index} en fin d'ouvrage renvoie chaque
+terme important à sa page de premier usage.
+
+\section*{Demander de l'aide}
+
+La source de vérité canonique pour mybibli est le dépôt GitHub :
+
+\begin{center}
+\url{https://github.com/guycorbaz/mybibli}
+\end{center}
+
+Ouvrez une \emph{issue} sur le dépôt \texttt{guycorbaz/mybibli}
+lorsque vous rencontrez un bug, une lacune dans la documentation ou
+une fonctionnalité manquante. Les modèles d'issue demandent la
+version (visible en pied de page du panneau d'administration), votre
+méthode d'installation et les étapes pour reproduire le problème.
+
+\section*{Couverture du manuel}
+
+Ce manuel couvre mybibli \textbf{1.1.0 et versions ultérieures}. Les
+versions antérieures comportaient un bug de sécurité où l'assistant
+de première mise en service était silencieusement contourné — voir le
+chapitre~\ref{ch:upgrade} pour le chemin de mise à jour depuis 1.0.x.
+
+\vspace{1cm}
+\hrule
+\vspace{0.5cm}
+\textit{Bon catalogage.}

--- a/docs/manual/fr/01-installation.tex
+++ b/docs/manual/fr/01-installation.tex
@@ -232,11 +232,11 @@ comptent comme « activé ». Toute autre valeur (chaîne vide,
 évite le piège classique où une valeur shell éculée comme \texttt{0}
 se lit comme « positionnée » et bascule silencieusement un opt-out.
 
-\begin{longtable}{@{} l l p{6.5cm} @{}}
+\begin{center}\small
+\begin{tabular}{l l >{\raggedright\arraybackslash}p{6.2cm}}
 \toprule
 \textbf{Variable} & \textbf{Défaut} & \textbf{Rôle} \\
 \midrule
-\endhead
 \multicolumn{3}{l}{\emph{Base de données}} \\
 \texttt{DATABASE\_URL}        & --- (requis) & Chaîne de connexion MariaDB (DSN). \\
 \texttt{MYSQL\_HOST}          & \texttt{db}    & Hôte pour le service DB embarqué. \\
@@ -270,7 +270,8 @@ se lit comme « positionnée » et bascule silencieusement un opt-out.
 \texttt{MYBIBLI\_SKIP\_STARTUP\_PURGE} & \texttt{false} & Saute l'auto-purge au démarrage. \\
 \texttt{MYBIBLI\_SEED\_DEV\_USERS} & \texttt{false} & Crée les utilisateurs dev \texttt{admin/admin} + \texttt{librarian/librarian}. \emph{Jamais en prod.} \\
 \bottomrule
-\end{longtable}
+\end{tabular}
+\end{center}
 
 Les overrides d'URL de base des fournisseurs
 (\texttt{BNF\_API\_BASE\_URL},

--- a/docs/manual/fr/01-installation.tex
+++ b/docs/manual/fr/01-installation.tex
@@ -1,0 +1,333 @@
+\chapter{Installation}
+\label{ch:installation}
+
+Ce chapitre vous guide pour installer mybibli\index{installation} sur
+votre propre matériel. La cible de déploiement de référence est un
+serveur domestique, un NAS, ou toute machine Linux toujours allumée
+capable de faire tourner Docker.
+
+\section{Pré-requis système}
+
+\begin{itemize}
+  \item \textbf{Système d'exploitation :} toute distribution Linux,
+        macOS, ou hôte Windows capable de faire tourner Docker. Le
+        noyau hôte doit prendre en charge cgroups v2 (toute
+        distribution à partir de 2021).
+  \item \textbf{Docker :} version 24 ou ultérieure, avec le plugin
+        \texttt{compose}. Vérifiez avec
+        \texttt{docker compose version}.
+  \item \textbf{Disque :} au moins 1\,Go libre pour l'image de
+        l'application et la base de données. Les images de
+        couverture ajoutent environ 50\,Ko par titre.
+  \item \textbf{Mémoire :} 512\,Mo suffisent pour une bibliothèque de
+        taille familiale (quelques milliers de titres) ; 1\,Go offre
+        une marge confortable pour le pipeline de récupération de
+        métadonnées.
+  \item \textbf{Réseau :} HTTPS sortant vers les fournisseurs de
+        métadonnées\index{fournisseurs de métadonnées} que vous
+        choisissez d'utiliser (voir chapitre~\ref{ch:providers}). Les
+        déploiements en LAN uniquement fonctionnent sans aucune
+        redirection de port entrante.
+\end{itemize}
+
+\begin{warning}
+\textbf{N'installez pas mybibli en version inférieure à
+1.1.0.}\index{sécurité!seuil 1.1.0} Toute image publiée portant un
+tag inférieur à \texttt{1.1.0} contient une migration d'amorçage qui
+crée les identifiants \texttt{admin/admin} et
+\texttt{librarian/librarian} à \emph{chaque} installation neuve, y
+compris en production. L'assistant de première mise en service est
+silencieusement contourné. Utilisez 1.1.0 ou plus récent ; les images
+antérieures à 1.1.0 seront retirées de Docker Hub pour éviter toute
+utilisation accidentelle.
+\end{warning}
+
+\section{Checklist de pré-installation}
+
+Avant de commencer :
+
+\begin{enumerate}
+  \item Choisissez un répertoire hôte pour les fichiers mybibli
+        (par exemple \texttt{/srv/mybibli} sur Linux,
+        \texttt{/volume1/docker/mybibli} sur Synology DSM).
+  \item Choisissez un répertoire hôte pour le stockage des images de
+        couverture\index{couvertures!répertoire}
+        (par exemple \texttt{/srv/mybibli/covers}). Il sera monté
+        dans le conteneur.
+  \item Choisissez un mot de passe fort pour les utilisateurs
+        \texttt{root} et applicatif de la MariaDB embarquée — ou,
+        pour une base de données externe, créez à l'avance une base
+        dédiée et un utilisateur (voir
+        section~\ref{sec:install-external-db}).
+\end{enumerate}
+
+\section{Méthode 1 — Base de données embarquée}\label{sec:install-bundled}
+
+C'est le chemin le plus simple. Le fichier \texttt{docker-compose.yml}
+livré déclare deux services : l'application mybibli et une instance
+MariaDB épinglée à une version connue. Les deux sont gérés comme une
+seule unité.
+
+\subsection*{1. Récupérer le fichier compose et le \texttt{.env}}
+
+Téléchargez \texttt{docker-compose.yml} et \texttt{.env.example}
+depuis la version que vous comptez installer (ou clonez le dépôt sur
+le tag correspondant) :
+
+\begin{lstlisting}
+mkdir -p /srv/mybibli && cd /srv/mybibli
+curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/docker-compose.yml
+curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/.env.example
+cp .env.example .env
+\end{lstlisting}
+
+\subsection*{2. Éditer \texttt{.env}}
+
+Ouvrez \texttt{.env} dans votre éditeur. Chaque variable porte un
+commentaire explicatif ; les valeurs qui comptent pour une
+installation avec base embarquée sont :
+
+\begin{lstlisting}
+DATABASE_URL=mysql://mybibli:mybibli_password@db:3306/mybibli?charset=utf8mb4
+MYSQL_HOST=db
+MYSQL_DATABASE=mybibli
+MYSQL_USER=mybibli
+MYSQL_PASSWORD=<choisir-un-mot-de-passe-fort>
+MYSQL_ROOT_PASSWORD=<choisir-un-mot-de-passe-fort>
+
+HOST_PORT=8080         # à changer si 8080 est déjà pris sur l'hôte
+APP_LANGUAGE=fr        # ou 'en' pour l'interface en anglais par défaut
+
+MYBIBLI_COOKIE_SECURE=false   # mettre à true uniquement derrière HTTPS
+\end{lstlisting}
+
+L'URL \texttt{DATABASE\_URL} \emph{doit} référencer les mêmes
+utilisateur, mot de passe et nom de base que les valeurs
+\texttt{MYSQL\_*} — le fichier compose reconstruit l'URL à partir de
+ces parties mais le binaire Rust lit \texttt{DATABASE\_URL}
+directement, les deux doivent donc concorder.
+
+\begin{warning}
+Les mots de passe par défaut dans \texttt{.env.example}
+(\texttt{mybibli\_password}, \texttt{root\_password}) sont des
+remplaçants, pas des identifiants à conserver. Changez-les avant le
+premier \texttt{docker compose up}. Une fois la base créée, les faire
+tourner nécessite aussi de réécrire les entrées utilisateur dans
+MariaDB — autant le faire correctement du premier coup.
+\end{warning}
+
+\subsection*{3. Démarrer la pile}
+
+\begin{lstlisting}
+docker compose up -d
+docker compose logs -f mybibli
+\end{lstlisting}
+
+Au premier lancement :
+
+\begin{enumerate}
+  \item tire l'image \texttt{gcorbaz/mybibli:1.1.0} (ou ultérieure)
+        et l'image MariaDB ;
+  \item démarre la base de données et attend qu'elle soit saine ;
+  \item exécute les migrations de schéma mybibli
+        (initialisation unique) ;
+  \item démarre le serveur HTTP sur le port configuré.
+\end{enumerate}
+
+Vous pouvez arrêter le suivi des logs avec \texttt{Ctrl-C} ; les
+conteneurs continuent de tourner en arrière-plan.
+
+\subsection*{4. Ouvrir l'assistant de mise en service}
+
+Visitez \url{http://<hôte>:8080/setup} dans un navigateur. L'assistant
+de première mise en service\index{assistant de mise en service}
+apparaît (voir section~\ref{sec:first-boot}).
+
+\section{Méthode 2 — Base de données externe (exemple NAS Synology)}\label{sec:install-external-db}
+
+Si vous exploitez déjà MariaDB sur votre NAS — par exemple via le
+paquet \textbf{MariaDB 10} de Synology — vous pouvez pointer mybibli
+dessus au lieu de faire tourner une seconde base dans Docker. L'image
+mybibli ne change pas ; seuls le fichier compose et le \texttt{.env}
+diffèrent.
+
+\subsection*{1. Créer la base et l'utilisateur}
+
+Connectez-vous à la MariaDB externe en \texttt{root} et exécutez :
+
+\begin{lstlisting}
+CREATE DATABASE mybibli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER 'mybibli'@'%' IDENTIFIED BY 'choisir-un-mot-de-passe-fort';
+GRANT ALL PRIVILEGES ON mybibli.* TO 'mybibli'@'%';
+FLUSH PRIVILEGES;
+\end{lstlisting}
+
+\begin{note}
+Sur Synology DSM, MariaDB 10 écoute sur le port \texttt{3307} par
+défaut (et non 3306 — ce port est réservé à l'ancien paquet MySQL).
+Ouvrez \textbf{MariaDB 10 → Paramètres} et cochez \emph{Activer la
+connexion TCP/IP} pour que les conteneurs sur le même pont Docker
+puissent atteindre le serveur.
+\end{note}
+
+\subsection*{2. Élaguer le fichier compose}
+
+Modifiez \texttt{docker-compose.yml} et retirez la base embarquée :
+
+\begin{itemize}
+  \item supprimez (ou commentez) tout le service \texttt{db:} ;
+  \item supprimez (ou commentez) le bloc \texttt{depends\_on:} sur le
+        service \texttt{mybibli} ;
+  \item supprimez (ou commentez) le bloc \texttt{volumes:} en bas du
+        fichier.
+\end{itemize}
+
+\subsection*{3. Pointer \texttt{.env} vers la base externe}
+
+\begin{lstlisting}
+DATABASE_URL=mysql://mybibli:mot-de-passe-fort@host.docker.internal:3307/mybibli?charset=utf8mb4
+\end{lstlisting}
+
+Remplacez le nom d'hôte et le port qui correspondent à votre réseau.
+Depuis un conteneur mybibli qui tourne sur le même pont Docker que
+le NAS hôte, \texttt{host.docker.internal} résout vers l'hôte sur
+macOS et les installations Docker Linux récentes ; sur les moteurs
+Docker plus anciens, utilisez plutôt l'IP LAN du NAS (par exemple
+\texttt{192.168.1.10}).
+
+Les variables \texttt{MYSQL\_*} sont désormais inutilisées — laissez
+les vides ou supprimez-les.
+
+\subsection*{4. Démarrer l'application}
+
+\begin{lstlisting}
+docker compose up -d
+docker compose logs -f mybibli
+\end{lstlisting}
+
+Le premier lancement exécute les migrations de schéma sur la base
+externe. Le paquet MariaDB de Synology gardera ce schéma aussi
+longtemps que le paquet existe ; sa sauvegarde est couverte par les
+outils de backup du NAS (voir chapitre~\ref{ch:backup}).
+
+\begin{tip}
+La configuration avec base externe est le chemin recommandé lorsque
+vous maintenez déjà un serveur de bases de données, car elle vous
+donne un seul pipeline de sauvegarde à surveiller au lieu de deux. La
+configuration avec base embarquée est plus rapide à mettre en place
+si vous n'avez pas d'autre charge sur l'hôte.
+\end{tip}
+
+\section{Référence des variables d'environnement}\label{sec:env-vars}
+
+La référence complète vit dans le fichier
+\texttt{.env.example}\index{variables d'env!.env.example} à la racine
+du dépôt — chaque variable porte un commentaire en ligne. Le tableau
+ci-dessous résume où chaque variable s'applique.
+
+Toutes les variables booléennes suivent un \textbf{accept-set strict}
+: seules les chaînes \texttt{1}, \texttt{true} et \texttt{TRUE}
+comptent comme « activé ». Toute autre valeur (chaîne vide,
+\texttt{0}, \texttt{false}) est traitée comme « désactivé ». Cela
+évite le piège classique où une valeur shell éculée comme \texttt{0}
+se lit comme « positionnée » et bascule silencieusement un opt-out.
+
+\begin{longtable}{@{} l l p{6.5cm} @{}}
+\toprule
+\textbf{Variable} & \textbf{Défaut} & \textbf{Rôle} \\
+\midrule
+\endhead
+\multicolumn{3}{l}{\emph{Base de données}} \\
+\texttt{DATABASE\_URL}        & --- (requis) & Chaîne de connexion MariaDB (DSN). \\
+\texttt{MYSQL\_HOST}          & \texttt{db}    & Hôte pour le service DB embarqué. \\
+\texttt{MYSQL\_PORT}          & \texttt{3306}  & Port pour le service DB embarqué. \\
+\texttt{MYSQL\_DATABASE}      & \texttt{mybibli} & Nom de base pour le service embarqué. \\
+\texttt{MYSQL\_USER}          & \texttt{mybibli} & Utilisateur DB pour le service embarqué. \\
+\texttt{MYSQL\_PASSWORD}      & --- & Mot de passe utilisateur DB embarqué. \\
+\texttt{MYSQL\_ROOT\_PASSWORD}& --- & Mot de passe root pour le service embarqué. \\
+\midrule
+\multicolumn{3}{l}{\emph{Serveur HTTP}} \\
+\texttt{HOST}                 & \texttt{0.0.0.0} & Adresse de bind dans le conteneur. \\
+\texttt{PORT}                 & \texttt{8080}    & Port de bind dans le conteneur. \\
+\texttt{HOST\_PORT}           & \texttt{8080}    & Port publié par Docker sur l'hôte. \\
+\midrule
+\multicolumn{3}{l}{\emph{Application}} \\
+\texttt{RUST\_LOG}            & \texttt{mybibli=info} & Filtre tracing. \texttt{mybibli=debug} pour des logs verbeux. \\
+\texttt{APP\_LANGUAGE}        & \texttt{en}     & Langue d'interface par défaut pour les visiteurs anonymes. \\
+\texttt{COVERS\_DIR}          & \texttt{./covers} & Chemin de stockage des images de couverture. \\
+\midrule
+\multicolumn{3}{l}{\emph{Durcissement}} \\
+\texttt{MYBIBLI\_COOKIE\_SECURE} & \texttt{false} & Mettre à \texttt{true} uniquement derrière HTTPS. \\
+\texttt{CSP\_REPORT\_ONLY}     & \texttt{false} & Bascule l'en-tête CSP en mode report-only. \\
+\midrule
+\multicolumn{3}{l}{\emph{Fournisseurs de métadonnées (migrés en DB au premier boot)}} \\
+\texttt{GOOGLE\_BOOKS\_API\_KEY} & --- & Clé optionnelle pour Google Books. \\
+\texttt{OMDB\_API\_KEY}         & --- & Clé optionnelle pour OMDb (films/séries). \\
+\texttt{TMDB\_API\_KEY}         & --- & Clé optionnelle pour TMDb (films/séries). \\
+\midrule
+\multicolumn{3}{l}{\emph{Overrides optionnels dev / test}} \\
+\texttt{MYBIBLI\_SKIP\_SETUP}      & \texttt{false} & Contourne l'assistant de première mise en service. \emph{Jamais en prod.} \\
+\texttt{MYBIBLI\_SKIP\_STARTUP\_PURGE} & \texttt{false} & Saute l'auto-purge au démarrage. \\
+\texttt{MYBIBLI\_SEED\_DEV\_USERS} & \texttt{false} & Crée les utilisateurs dev \texttt{admin/admin} + \texttt{librarian/librarian}. \emph{Jamais en prod.} \\
+\bottomrule
+\end{longtable}
+
+Les overrides d'URL de base des fournisseurs
+(\texttt{BNF\_API\_BASE\_URL},
+\texttt{GOOGLE\_BOOKS\_API\_BASE\_URL}, \dots) n'existent que pour
+pointer le pipeline de métadonnées sur le serveur mock embarqué
+pendant les tests automatisés. Laissez-les vides en production.
+
+\section{Premier boot — l'assistant de mise en service}\label{sec:first-boot}
+
+Sur une installation neuve, toute requête est redirigée vers
+\texttt{/setup} tant que l'assistant\index{assistant de mise en
+service} n'est pas terminé. L'assistant comporte quatre étapes :
+
+\begin{enumerate}
+  \item \textbf{Compte administrateur.} Choisissez un nom
+        d'utilisateur et un mot de passe fort pour le premier
+        administrateur. Cette étape est toute la raison d'être de
+        l'assistant — une fois le compte créé, le prédicat de la
+        garde s'inverse et les visiteurs suivants atterrissent sur
+        le catalogue public au lieu de \texttt{/setup}.
+  \item \textbf{Fournisseurs de métadonnées.} Collez les clés d'API
+        que vous avez sous la main (Google Books, OMDb, TMDb). Tous
+        les fournisseurs à clé sont optionnels — vous pouvez sauter
+        cette étape et ajouter les clés plus tard depuis
+        \texttt{/admin > System > Metadata Providers}.
+  \item \textbf{Préférences.} Choisissez la langue d'interface par
+        défaut pour les visiteurs anonymes et le seuil de retard de
+        prêt (en jours).
+  \item \textbf{Terminé.} Un écran récapitulatif. Après confirmation,
+        l'assistant écrit \texttt{settings.setup\_completed\_at} et
+        se désactive pour la durée de vie de l'installation.
+\end{enumerate}
+
+L'assistant est idempotent : si vous fermez le navigateur entre les
+étapes, rouvrez \texttt{/setup} et l'assistant reprend côté serveur à
+la bonne étape (il interroge la base à chaque chargement — il n'y a
+pas d'état client à perdre).
+
+\section{Vérification de l'installation}
+
+Après la fin de l'assistant :
+
+\begin{itemize}
+  \item Connectez-vous sur \url{http://<hôte>:8080/login} avec les
+        identifiants admin que vous venez de créer.
+  \item Visitez \texttt{/admin > Health}. La page doit afficher des
+        compteurs d'entités non-nuls (zéro sur une installation
+        neuve — c'est normal) et une coche verte à côté de chaque
+        fournisseur de métadonnées qui a été joignable dans les
+        cinq dernières minutes.
+  \item Scannez un ISBN (le champ de recherche en haut de la page
+        d'accueil) pour confirmer que le pipeline de métadonnées
+        résout bien un vrai titre. Le premier scan prend quelques
+        secondes ; le résultat apparaît dans la timeline des ajouts
+        récents sur la page d'accueil une fois la récupération
+        d'arrière-plan terminée.
+\end{itemize}
+
+Si quelque chose tourne mal, sautez au
+chapitre~\ref{ch:troubleshooting}.

--- a/docs/manual/fr/02-configuration.tex
+++ b/docs/manual/fr/02-configuration.tex
@@ -1,0 +1,242 @@
+\chapter{Configuration}
+\label{ch:configuration}
+
+Une fois l'assistant de mise en service passé, le travail de
+configuration du jour 1 se compose de trois blocs : définir vos
+\emph{lieux de stockage}\index{lieux de stockage}, peupler les
+\emph{données de référence} (genres, rôles de contributeur, états de
+volume, types de nœud de localisation) et ajuster les
+\emph{paramètres globaux} (seuil de retard, cadence d'auto-purge,
+clés de fournisseurs).
+
+Tout se configure depuis le panneau
+\texttt{/admin}\index{panneau admin} — il n'y a pas de fichier de
+configuration séparé. Le panneau a cinq onglets :
+
+\begin{itemize}
+  \item \textbf{Health} — tableau de bord en lecture seule.
+  \item \textbf{Users} — créer/désactiver des utilisateurs, changer
+        de rôle.
+  \item \textbf{Reference data} — les quatre tables taxonomiques.
+  \item \textbf{Trash} — voir et restaurer les éléments
+        soft-deleted.
+  \item \textbf{System} — paramètres globaux.
+\end{itemize}
+
+Seul le rôle \texttt{Admin} voit le panneau ; les utilisateurs
+\texttt{Librarian} et \texttt{Anonymous} reçoivent un 403 sur toute
+route \texttt{/admin/*}.
+
+\section{Lieux de stockage et hiérarchie}\label{sec:locations}
+
+Les lieux de stockage sont les endroits physiques où vivent vos
+volumes\index{volume} : une pièce, une étagère, une rangée, une
+boîte numérotée, une case précise d'une armoire. mybibli les
+organise comme un \textbf{arbre}\index{arbre des lieux} — chaque lieu
+a au plus un parent. La hiérarchie est arbitraire : vous décidez à la
+fois des niveaux et des libellés.
+
+Une hiérarchie domestique exploitable peut tenir sur trois niveaux :
+
+\begin{lstlisting}
+Salon                (pièce)
+ |-- Bibliothèque A   (étagère)
+ |    |-- Rangée 1    (rangée)
+ |    |-- Rangée 2    (rangée)
+ |-- Bibliothèque B   (étagère)
+ |    |-- Rangée 1    (rangée)
+Chambre              (pièce)
+ |-- Table de nuit   (étagère)
+\end{lstlisting}
+
+Trois niveaux suffisent à retrouver n'importe quel volume en quelques
+secondes sans forcer la hiérarchie à épouser chaque recoin de votre
+intérieur. Une liste plate (une grosse « étagère » par étagère
+physique) fonctionne tout aussi bien pour des collections de
+quelques centaines de volumes.
+
+\subsection*{Éditer l'arbre}
+
+Ouvrez \texttt{/locations}. L'arbre est rendu sous forme de liste
+imbriquée avec des actions création / renommage / déplacement /
+suppression en ligne. Le glisser-déposer \emph{n'est pas} pris en
+charge (mybibli applique une CSP stricte sans JavaScript inline) ;
+les déplacements se font en éditant un nœud et en choisissant un
+nouveau parent dans un menu déroulant.
+
+\subsection*{Types de nœud de localisation}
+
+Chaque nœud de localisation porte un \textbf{type de
+nœud}\index{type de nœud} — « pièce », « étagère », « rangée »,
+« boîte », ce que vous voulez. Les types sont gérés depuis
+\texttt{/admin > Reference data > Location node types}. Ce sont de
+purs libellés ; mybibli n'impose pas qu'une « étagère » soit sous
+une « pièce ».
+
+\begin{tip}
+Renommer un type de nœud propage la modification à chaque lieu qui
+l'utilise (le type est stocké par nom dans la table des lieux).
+Supprimer un type est refusé tant qu'au moins un lieu y fait
+référence.
+\end{tip}
+
+\section{Étiquettes : codes V et codes L}\label{sec:labels}
+
+mybibli imprime deux types d'étiquettes à code-barres :
+
+\begin{itemize}
+  \item \textbf{Codes V}\index{code V} — un par
+        \emph{volume}\index{volume} (l'exemplaire physique sur
+        l'étagère). Format : \texttt{V} suivi d'un numéro
+        zéro-paddé (par exemple \texttt{V0042}).
+  \item \textbf{Codes L}\index{code L} — un par \emph{lieu de
+        stockage}. Format : \texttt{L} suivi d'un numéro zéro-paddé
+        (par exemple \texttt{L0007}).
+\end{itemize}
+
+Les codes V et L sont scannés avec la même douchette code-barres que
+vous utilisez pour les ISBN au moment du catalogage. Le préfixe
+(\texttt{V} ou \texttt{L}) indique à mybibli quel lookup effectuer.
+
+\subsection*{Imprimer les étiquettes}
+
+Ouvrez \texttt{/locations} ou la page du volume concerné et cliquez
+\textbf{Imprimer l'étiquette}. mybibli rend une page HTML
+imprimable avec le code-barres Code-128 et le texte lisible. Imprimez
+sur papier ordinaire ou sur planches autocollantes — l'encodage est
+suffisamment robuste pour qu'une imprimante jet d'encre bas de gamme
+suffise pour les codes V comme les codes L.
+
+\begin{tip}
+Imprimez vos étiquettes de codes V \emph{avant} de commencer un
+catalogage en série. Une planche pré-imprimée de V0001 à V0500
+permet de saisir un autocollant, de le coller au dos du livre et de
+scanner d'un même mouvement — sans aller-retour entre l'interface
+de catalogage et l'imprimante.
+\end{tip}
+
+\section{Données de référence}\label{sec:reference-data}
+
+Quatre tables taxonomiques pilotent les menus déroulants que vous
+voyez pendant le catalogage. Elles vivent sous \texttt{/admin >
+Reference data} :
+
+\begin{description}
+  \item[Genres]\index{genres} Les genres assignés aux titres.
+        mybibli livre un seed de base FR/EN (Fiction, Documentaire,
+        Biographie, \dots) — éditez ou étendez pour coller à votre
+        collection.
+  \item[Rôles de contributeur]\index{rôles de contributeur} Auteur,
+        Illustrateur, Traducteur, Éditeur, Narrateur, \dots Utilisés
+        sur les pages détail de titre pour attribuer les bonnes
+        personnes aux bons rôles.
+  \item[États de volume]\index{état de volume} L'état physique d'un
+        exemplaire — Neuf, Bon, Usé, Endommagé, \dots Utile pour les
+        retours de prêt (marquer un volume Usé quand un emprunteur
+        l'a abîmé).
+  \item[Types de nœud de localisation]\index{type de nœud} Voir
+        section~\ref{sec:locations}.
+\end{description}
+
+\subsection*{Sémantique CRUD}
+
+Les quatre tables partagent le même schéma CRUD :
+
+\begin{itemize}
+  \item \textbf{Créer} ajoute une ligne. Si le nom entre en collision
+        avec une ligne soft-deleted de la même table, la ligne
+        existante est réactivée et le résultat affiche
+        \emph{Réactivé} au lieu de \emph{Créé}.
+  \item \textbf{Renommer} met à jour le nom. Pour les types de nœud
+        de localisation, le nouveau nom cascade sur tous les lieux
+        qui utilisent ce type.
+  \item \textbf{Supprimer} effectue un soft-delete \emph{uniquement
+        si la ligne est inutilisée}. Si un titre référence encore
+        ce genre / rôle / état / type, la suppression est refusée
+        avec un comptage des dépendants.
+\end{itemize}
+
+\subsection*{Les données de référence ne sont pas traduites}
+
+Les valeurs des données de référence sont stockées telles quelles —
+le seed FR crée un genre appelé « Roman » et c'est ce texte
+littéral que verront les utilisateurs anglophones s'ils basculent
+l'interface en anglais. Seule l'ossature de l'interface\index{i18n}
+(libellés de boutons, navigation, messages d'erreur) est traduite.
+
+\section{Paramètres système}\label{sec:system}
+
+L'onglet \texttt{/admin > System} regroupe tous les paramètres
+globaux. Le panneau est divisé en trois formulaires, chacun avec
+son bouton de sauvegarde :
+
+\subsection*{Prêts}
+
+\begin{itemize}
+  \item \textbf{Seuil de retard (jours).} Définit combien de jours
+        un prêt peut courir avant d'apparaître comme en retard sur
+        le tableau de bord. Défaut : 30.
+  \item \textbf{Timeout d'inactivité de session (secondes).} Temps
+        d'inactivité après lequel une session authentifiée est
+        effacée. Défaut : 1800\,s (30\,minutes).
+  \item \textbf{Intervalle d'auto-purge (secondes).} Cadence à
+        laquelle le scheduler d'arrière-plan supprime
+        définitivement les éléments soft-deleted depuis plus de
+        30\,jours. Défaut : 86400\,s (24\,heures).
+\end{itemize}
+
+\subsection*{Fournisseurs de métadonnées}
+
+Une ligne par fournisseur à clé (Google Books, OMDb, TMDb). Chaque
+ligne a un champ clé et un bouton \emph{Effacer}. Sauvegarder une
+clé prend effet à la prochaine récupération de métadonnées — pas de
+redémarrage, pas de redéploiement.
+
+\begin{note}
+Si la même clé de fournisseur est positionnée dans \texttt{.env}
+\emph{et} effacée depuis l'interface, le prochain reboot re-migre la
+valeur depuis \texttt{.env}. L'intention de l'opérateur au moment du
+déploiement l'emporte au boot. Pour rendre l'effacement durable,
+retirez aussi la variable de \texttt{.env} (ou de
+\texttt{docker-compose.yml}).
+\end{note}
+
+\subsection*{Langue}
+
+Fixe la langue d'interface par défaut pour les visiteurs
+\emph{anonymes}. Les utilisateurs authentifiés outrepassent ce
+choix via le bouton bascule dans la barre de navigation — leur
+choix est stocké sur leur ligne utilisateur.
+
+\section{Utilisateurs}\label{sec:users}
+
+Ouvrez \texttt{/admin > Users} pour gérer les comptes utilisateur.
+Chaque ligne montre le nom d'utilisateur, le rôle, le drapeau
+actif et la date de dernière activité. Les actions disponibles :
+
+\begin{itemize}
+  \item \textbf{Créer un utilisateur} (haut de page) — nom, mot de
+        passe, rôle.
+  \item \textbf{Éditer} — changer le rôle ou renommer. Ne change
+        pas le mot de passe d'un autre utilisateur depuis cette
+        vue ; les changements de mot de passe passent par la page
+        \texttt{/account} de l'utilisateur lui-même.
+  \item \textbf{Désactiver} — soft-delete l'utilisateur. Ses
+        sessions sont effacées immédiatement ; il ne peut plus se
+        reconnecter.
+  \item \textbf{Réactiver} — défait une désactivation (depuis
+        l'onglet \texttt{Trash}).
+\end{itemize}
+
+Deux garde-fous s'appliquent :
+
+\begin{itemize}
+  \item \textbf{L'auto-désactivation est bloquée.} Vous ne pouvez
+        pas désactiver le compte avec lequel vous êtes connecté.
+  \item \textbf{Garde du dernier admin actif.} Le système maintient
+        toujours au moins un admin actif. Désactiver le dernier
+        est refusé avec un 409 et un message d'erreur clair.
+\end{itemize}
+
+Les trois rôles\index{rôles} (Anonyme, Bibliothécaire, Administrateur)
+sont détaillés au chapitre~\ref{ch:roles}.

--- a/docs/manual/fr/03-usage.tex
+++ b/docs/manual/fr/03-usage.tex
@@ -1,0 +1,181 @@
+\chapter{Usage au quotidien}
+\label{ch:usage}
+
+Ce chapitre parcourt les flux que vous lancerez des dizaines de
+fois une fois la bibliothèque opérationnelle : cataloguer un nouveau
+volume, chercher dans la collection, déplacer un volume, le prêter,
+le récupérer, et auditer ce qui est sur les étagères.
+
+\section{La page d'accueil}\label{sec:home}
+
+La page d'accueil est le tableau de bord. De haut en bas :
+
+\begin{itemize}
+  \item \textbf{Champ de scan.}\index{champ de scan} Un champ
+        focalisé qui accepte un ISBN, un code V ou un code L. La
+        couche scanner-guard route l'entrée vers la bonne page
+        selon le préfixe.
+  \item \textbf{Bandeau d'indicateurs.} Ajouts récents, prêts en
+        retard, séries avec lacunes, volumes non rangés — chaque
+        clic ouvre la liste filtrée correspondante.
+  \item \textbf{Activité récente.} Les sept derniers jours de
+        catalogage et de retours.
+\end{itemize}
+
+\section{Cataloguer un nouveau titre via code-barres}\label{sec:catalog-scan}
+
+\begin{enumerate}
+  \item Focalisez le champ de scan de la page d'accueil (il est
+        sélectionné par défaut au chargement). Scannez l'ISBN /
+        EAN-13 du dos de l'ouvrage.
+  \item mybibli redirige vers la page de catalogage, qui affiche un
+        titre squelette avec le code-barres scanné. Une tâche
+        d'arrière-plan lance des requêtes contre la chaîne de
+        fournisseurs de métadonnées.
+  \item En quelques secondes, le squelette se remplit : titre,
+        contributeurs, éditeur, année, image de couverture. Un
+        petit indicateur confirme quel fournisseur a résolu le
+        titre.
+  \item Choisissez un \textbf{lieu}\index{lieu} dans le menu
+        déroulant (ou scannez le code L du rayon de destination) et
+        un \textbf{état de volume}\index{état de volume}
+        (typiquement \emph{Neuf}). Cliquez \textbf{Ajouter un
+        volume}.
+  \item Imprimez et collez une étiquette de code V sur le volume.
+\end{enumerate}
+
+Si le pipeline de métadonnées échoue à résoudre l'ISBN, le titre
+apparaît avec un badge \emph{Non résolu}. Vous pouvez modifier les
+champs manuellement et le volume est créé malgré tout.
+
+\begin{tip}
+Le catalogage en série marche le mieux quand la planche de codes V,
+la douchette et l'imprimante sont à portée de main. La plupart du
+temps est consacré à scanner, pas à attendre mybibli — la
+récupération de métadonnées est asynchrone, vous n'avez donc pas à
+attendre qu'elle se termine avant de passer au volume suivant.
+\end{tip}
+
+\section{Rechercher dans la collection}\label{sec:search}
+
+La page \texttt{/search} accepte :
+
+\begin{itemize}
+  \item \textbf{titre} complet ou partiel ;
+  \item \textbf{nom de contributeur} (matche l'auteur par défaut ;
+        les autres rôles de contributeur sont scorés moins fort) ;
+  \item \textbf{ISBN / EAN-13} — match exact ;
+  \item \textbf{code V} ou \textbf{code L} — match exact ;
+  \item \textbf{code Dewey} (pour les bibliothèques qui utilisent
+        Dewey).
+\end{itemize}
+
+Les résultats sont triés par pertinence. Cliquez un résultat pour
+ouvrir la page du titre ; cliquez un contributeur pour filtrer le
+catalogue sur ses œuvres ; cliquez le libellé d'un lieu pour voir
+chaque volume actuellement à cet endroit.
+
+\begin{tip}
+Vous pouvez « rechercher » un seul volume en scannant son code V
+depuis n'importe quelle page qui dispose du champ de scan d'accueil
+— y compris la page d'accueil, \texttt{/search} et \texttt{/loans}.
+Plus rapide que la frappe.
+\end{tip}
+
+\section{Déplacer un volume vers un autre lieu}\label{sec:move-volume}
+
+\begin{enumerate}
+  \item Ouvrez la page du volume (recherche par code V ou clic
+        depuis la page du titre).
+  \item Cliquez \textbf{Déplacer}.
+  \item Scannez le code L du lieu de destination, ou choisissez-le
+        dans le menu déroulant.
+  \item Confirmez.
+\end{enumerate}
+
+mybibli enregistre le déplacement dans l'historique de lieu du
+volume, vous permettant de retracer où un livre a vécu au fil du
+temps.
+
+\section{Prêts}\label{sec:loans}
+
+\subsection*{Prêter un volume}
+
+\begin{enumerate}
+  \item Ouvrez \texttt{/loans} et cliquez \textbf{Nouveau prêt}.
+  \item Scannez ou choisissez l'\textbf{emprunteur}\index{emprunteur}.
+        Si l'emprunteur n'existe pas encore, cliquez \emph{Créer
+        l'emprunteur} en ligne.
+  \item Scannez ou choisissez le \textbf{volume} (code V).
+  \item Réglez optionnellement une \textbf{date de retour
+        prévue} ; sinon mybibli la calcule à partir du seuil de
+        retard (chapitre~\ref{ch:configuration}).
+  \item Confirmez.
+\end{enumerate}
+
+Le lieu actuel du volume est inscrit sur la ligne de prêt pour
+qu'un retour ultérieur puisse le restaurer au bon rayon.
+
+\subsection*{Retourner un volume}
+
+\begin{enumerate}
+  \item Ouvrez \texttt{/loans} et trouvez le prêt actif (filtre
+        \emph{Actifs} ou scan du code V).
+  \item Cliquez \textbf{Retourner}.
+  \item Choisissez l'état post-retour (\emph{Bon}, \emph{Usé},
+        \dots).
+  \item Confirmez. Le volume retourne automatiquement à son lieu
+        d'avant prêt.
+\end{enumerate}
+
+\subsection*{Prêts en retard}
+
+Les prêts qui dépassent le seuil de retard passent au rouge sur la
+page \texttt{/loans} et sur l'indicateur \emph{En retard} de la page
+d'accueil. \texttt{/loans?filter=overdue} donne une liste focalisée.
+
+\section{Audit de la bibliothèque}\label{sec:audit}
+
+Un \emph{audit}\index{audit} c'est le rituel « je parcours les
+étagères et je confirme que tout est bien à la place que la base
+indique ». mybibli ne livre pas un mode audit dédié — le flux
+équivalent est :
+
+\begin{enumerate}
+  \item Filtrez \texttt{/search} par le lieu que vous comptez
+        auditer, trié par code V.
+  \item Parcourez le rayon en scannant chaque code V.
+  \item Pour tout volume scanné qui \emph{n'est pas} dans la liste
+        filtrée, mybibli affiche un message \emph{Volume absent de
+        ce lieu}. Déplacez-le (section~\ref{sec:move-volume}) et
+        continuez.
+  \item Tout volume \emph{dans} la liste filtrée que vous
+        \emph{n'avez pas} scanné après avoir parcouru le rayon est
+        suspect — soit déplacé, soit manquant. Marquez-le pour
+        suivi.
+\end{enumerate}
+
+\begin{tip}
+Un audit trimestriel attrape les volumes mal rangés tôt — plus un
+livre traîne au mauvais rayon, plus il est difficile de se rappeler
+où il aurait dû être.
+\end{tip}
+
+\section{Rangement après retours}\label{sec:shelving}
+
+Après une fournée de retours, les volumes s'empilent près du poste
+de scan. Le flux de \emph{rangement}\index{rangement} de mybibli
+accélère la remise en rayon :
+
+\begin{enumerate}
+  \item Prenez un volume et scannez son code V.
+  \item mybibli affiche la page du volume avec le lieu d'origine
+        bien en évidence.
+  \item Portez le volume au rayon indiqué. Scannez le code L du
+        rayon pour confirmer.
+  \item Recommencez.
+\end{enumerate}
+
+La confirmation par code L est optionnelle mais recommandée — elle
+laisse une entrée fraîche dans l'historique du volume sur laquelle
+le prochain audit pourra s'appuyer.

--- a/docs/manual/fr/04-multimedia.tex
+++ b/docs/manual/fr/04-multimedia.tex
@@ -1,0 +1,90 @@
+\chapter{Types de médias multiples}
+\label{ch:multimedia}
+
+mybibli n'est pas réservé aux livres. Quatre types de
+médias\index{types de médias} sont des citoyens de première classe :
+
+\begin{itemize}
+  \item \textbf{Livre} — le défaut. Romans, essais, ouvrages de
+        référence, albums illustrés pour enfants.
+  \item \textbf{BD / comic}\index{BD / comic} — comic individuel ou
+        album omnibus multi-positions (par exemple une « anthologie
+        Tintin » qui réunit physiquement les volumes 1 à 5).
+  \item \textbf{Audio} — CD, vinyles, livres audio sur support
+        physique.
+  \item \textbf{Film / série}\index{film} — DVD, coffrets Blu-ray,
+        intégrales de séries TV.
+\end{itemize}
+
+Le type de média pilote trois choses :
+
+\begin{enumerate}
+  \item \textbf{Quel fournisseur de métadonnées est consulté en
+        premier.} Les ISBN routent vers BnF + Google Books + Open
+        Library ; les films routent vers TMDb + OMDb ; l'audio
+        route vers MusicBrainz.
+  \item \textbf{Quels champs sont exposés sur la page du titre.}
+        Les titres audio font apparaître une track list ; les
+        films font apparaître réalisateur, durée, restriction
+        d'âge.
+  \item \textbf{L'icône affichée à côté du titre} dans les
+        résultats de recherche et la liste de catalogue.
+\end{enumerate}
+
+\section{Livres}
+
+Le type de média par défaut. Catalogage tel que décrit en
+section~\ref{sec:catalog-scan}. Les séries multi-volumes
+(encyclopédies, trilogies, \dots) sont modélisées par une entité
+\emph{série}\index{série} au chapitre~\ref{ch:configuration}.
+
+\section{BD et comics}
+
+Un volume \textbf{omnibus}\index{omnibus} peut contenir plusieurs
+positions dans une série. mybibli gère cela via la fonctionnalité
+\emph{multi-position}\index{multi-position} : au moment de la
+création d'un volume, vous pouvez fixer la \emph{plage de
+positions} (par exemple « contient les volumes 5 à 7 »). La
+détection de lacunes de série (chapitre~\ref{ch:usage}) comprend ces
+plages et ne signalera pas les positions 5, 6 ou 7 comme manquantes
+une fois l'omnibus en rayon.
+
+\section{Sorties audio}
+
+Les titres audio utilisent MusicBrainz\index{MusicBrainz} comme
+source principale de métadonnées. Le code-barres au dos d'un CD
+(EAN-13) se résout de la même façon qu'un ISBN.
+
+\begin{itemize}
+  \item \textbf{Pistes.} MusicBrainz renvoie la liste des pistes ;
+        mybibli les affiche sur la page du titre.
+  \item \textbf{Support.} CD vs vinyle vs cassette est capturé sur
+        la ligne du volume (pas sur le titre) — deux pressages
+        identiques sur supports différents sont deux volumes du
+        même titre.
+\end{itemize}
+
+\section{Films et séries}
+
+Les films et séries TV utilisent OMDb\index{OMDb} et
+TMDb\index{TMDb} comme sources principales de métadonnées. Un
+coffret de série est modélisé comme un \emph{titre} avec un volume
+multi-position couvrant la plage de disques.
+
+\begin{tip}
+OMDb est gratuit pour de faibles volumes (moins de 1000 requêtes
+par jour) ; TMDb est gratuit avec attribution. L'un ou l'autre
+couvre largement une étagère DVD / Blu-ray familiale. Voir le
+chapitre~\ref{ch:providers} pour la mise en place.
+\end{tip}
+
+\section{Choisir le type de média au scan}
+
+Après scan d'un code-barres inconnu, mybibli devine le type de
+média depuis le préfixe EAN (le préfixe pays GS1 et la réponse du
+fournisseur). La devinette est affichée sur la page de catalogage ;
+vous pouvez la corriger avant de cliquer \textbf{Ajouter un volume}.
+Re-typer un titre plus tard se fait en quelques clics
+(\texttt{/title/<id>}) et la chaîne de fournisseurs ré-exécute
+contre le nouveau type si vous déclenchez \emph{Re-fetch
+metadata}.

--- a/docs/manual/fr/05-metadata-providers.tex
+++ b/docs/manual/fr/05-metadata-providers.tex
@@ -1,0 +1,138 @@
+\chapter{Fournisseurs de métadonnées}
+\label{ch:providers}
+
+Lorsque vous scannez un ISBN ou un EAN-13, mybibli ne cherche pas le
+titre dans un catalogue local — il interroge un ou plusieurs
+\emph{fournisseurs de métadonnées}\index{fournisseurs de métadonnées}
+externes jusqu'à ce que l'un d'eux renvoie une réponse propre. Ce
+chapitre explique la chaîne, où récupérer les clés d'API et comment
+les faire tourner en toute sécurité.
+
+\section{La chaîne de fournisseurs}
+
+mybibli parcourt les fournisseurs dans l'ordre le mieux adapté au
+type de média deviné :
+
+\begin{longtable}{@{} l l p{4.5cm} c @{}}
+\toprule
+\textbf{Fournisseur} & \textbf{Types de média} & \textbf{Notes} & \textbf{Clé ?} \\
+\midrule
+\endhead
+BnF\index{BnF}                  & Livres         & Catalogue de la
+Bibliothèque nationale de France ; idéal pour les titres en français. & non \\
+Open Library\index{Open Library} & Livres         & Catalogue
+bénévole ; large couverture anglaise / multilingue. & non \\
+Google Books\index{Google Books} & Livres         & Commercial ; bon
+sur les essais grand public. & optionnelle \\
+MusicBrainz\index{MusicBrainz}  & Audio          & Métadonnées musicales
+bénévoles ; très complet sur CD / vinyles. & non \\
+OMDb\index{OMDb}                & Films, séries  & Palier gratuit ; quotas. & requise \\
+TMDb\index{TMDb}                & Films, séries  & Gratuit avec attribution. & requise \\
+BDGest\index{BDGest}            & BD, comics     & Catalogue BD
+francophone (web-scraped). & non \\
+\bottomrule
+\end{longtable}
+
+Le premier fournisseur qui renvoie un enregistrement \emph{propre}
+l'emporte. « Propre » veut dire : titre présent, au moins un
+contributeur, et une année. Les correspondances partielles sont
+enregistrées mais mybibli continue à parcourir la chaîne jusqu'à
+trouver une correspondance propre ou épuiser les fournisseurs.
+
+\section{Clés d'API}
+
+Trois fournisseurs requièrent une clé d'API :
+
+\subsection*{Google Books}
+
+Optionnelle mais relève significativement le budget de requêtes
+quotidien.
+
+\begin{enumerate}
+  \item Connectez-vous sur \url{https://console.cloud.google.com/}.
+  \item Créez un nouveau projet (ou réutilisez-en un).
+  \item Activez l'\textbf{API Books}.
+  \item Créez une \textbf{clé d'API} sous \emph{APIs \& Services →
+        Credentials}.
+  \item Collez-la dans \texttt{/admin > System > Metadata
+        Providers} dans mybibli.
+\end{enumerate}
+
+\subsection*{OMDb}
+
+\begin{enumerate}
+  \item Visitez \url{https://www.omdbapi.com/apikey.aspx}.
+  \item Choisissez le palier gratuit (1000 requêtes/jour).
+  \item Confirmez via le courriel d'activation reçu.
+  \item Collez la clé dans mybibli.
+\end{enumerate}
+
+\subsection*{TMDb}
+
+\begin{enumerate}
+  \item Inscrivez-vous sur \url{https://www.themoviedb.org/}.
+  \item Ouvrez \emph{Settings → API} et demandez une clé pour
+        \emph{usage personnel / non-commercial}.
+  \item Collez la clé dans mybibli.
+\end{enumerate}
+
+\section{Où vivent les clés}
+
+Les clés transitent par deux couches :
+
+\begin{enumerate}
+  \item \textbf{Variables d'environnement}\index{variables d'env!clés
+        fournisseurs} (\texttt{GOOGLE\_BOOKS\_API\_KEY},
+        \texttt{OMDB\_API\_KEY}, \texttt{TMDB\_API\_KEY}). Elles sont
+        migrées \emph{une fois} au boot dans la table
+        \texttt{settings} — elles servent essentiellement
+        d'amorçage au moment du déploiement.
+  \item \textbf{La table \texttt{settings}}, exposée via
+        \texttt{/admin > System > Metadata Providers}. C'est la
+        source de vérité au moment de la requête. La rotation d'une
+        clé depuis l'interface prend effet à la toute prochaine
+        récupération de métadonnées.
+\end{enumerate}
+
+L'implication est asymétrique :
+
+\begin{itemize}
+  \item Si vous positionnez une clé uniquement en variable
+        d'environnement, le premier boot la copie dans la base et
+        ensuite c'est la base qui fait foi.
+  \item Si vous positionnez une clé uniquement dans l'interface,
+        la variable d'environnement n'est plus jamais consultée.
+  \item Si vous positionnez les deux puis \emph{Effacez} la clé
+        depuis l'interface, la valeur en base devient vide — mais
+        au boot suivant, la valeur d'environnement y est
+        re-migrée. Pour rendre l'effacement durable, retirez
+        aussi la variable d'environnement de \texttt{.env} /
+        \texttt{docker-compose.yml}.
+\end{itemize}
+
+\section{Santé des fournisseurs}
+
+\texttt{/admin > Health} pingue chaque fournisseur enregistré toutes
+les cinq minutes et rapporte son état sous forme de coche verte ou
+de croix rouge. Une croix rouge ne signifie pas toujours que le
+fournisseur est en panne — cela peut aussi vouloir dire que la clé
+d'API est absente ou invalide. L'onglet Health inclut le timestamp
+du dernier check et le code HTTP pour faciliter le diagnostic.
+
+\section{Quotas et back-pressure}
+
+mybibli applique un petit quota par fournisseur (quelques requêtes
+par seconde). Cataloguer cent volumes à la suite ne déclenchera pas
+de 429 distant. Si un fournisseur renvoie quand même 429, la
+requête est loguée et le fournisseur suivant de la chaîne est
+consulté — le flux de catalogage ne se bloque jamais sur un
+fournisseur en quota.
+
+\begin{warning}
+Ne committez jamais une vraie clé d'API dans git. Le fichier
+\texttt{.env} est dans \texttt{.gitignore} pour cette raison ;
+\texttt{.env.example} ne porte que des placeholders. Si une clé
+fuit, faites-la tourner immédiatement sur la console du
+fournisseur — coller une nouvelle clé dans mybibli prend effet en
+quelques secondes.
+\end{warning}

--- a/docs/manual/fr/06-roles-permissions.tex
+++ b/docs/manual/fr/06-roles-permissions.tex
@@ -1,0 +1,125 @@
+\chapter{Rôles et permissions}
+\label{ch:roles}
+
+mybibli a trois rôles\index{rôles} utilisateur, ordonnés par
+privilège :
+
+\begin{enumerate}
+  \item \textbf{Anonyme}\index{anonyme} — quiconque arrive sur le
+        site sans cookie de session. Accès en lecture seule au
+        catalogue. Ne peut ni prêter, ni éditer, ni supprimer.
+  \item \textbf{Bibliothécaire}\index{bibliothécaire} — utilisateur
+        authentifié de rôle \texttt{librarian}. Catalogage au
+        quotidien, prêts, retours, déplacements de lieu. Ne peut
+        ni gérer les utilisateurs ni changer les paramètres
+        système.
+  \item \textbf{Administrateur}\index{administrateur} — utilisateur
+        authentifié de rôle \texttt{admin}. Tout ce qu'un
+        bibliothécaire peut faire, plus le panneau \texttt{/admin}
+        : utilisateurs, données de référence, corbeille,
+        paramètres système.
+\end{enumerate}
+
+\section{Qui peut faire quoi}
+
+\begin{longtable}{@{} l c c c @{}}
+\toprule
+\textbf{Action} & \textbf{Anon} & \textbf{Bibl.} & \textbf{Admin} \\
+\midrule
+\endhead
+Parcourir / rechercher dans le catalogue & oui & oui & oui \\
+Voir les pages de titre et de volume     & oui & oui & oui \\
+Voir l'arbre des lieux                   & oui & oui & oui \\
+\midrule
+Scanner / cataloguer un nouveau titre    & non & oui & oui \\
+Ajouter ou retirer un volume             & non & oui & oui \\
+Déplacer un volume entre lieux           & non & oui & oui \\
+Éditer les métadonnées d'un titre        & non & oui & oui \\
+Créer / éditer les emprunteurs           & non & oui & oui \\
+Enregistrer / retourner des prêts        & non & oui & oui \\
+Éditer l'arbre des lieux                 & non & oui & oui \\
+\midrule
+Ouvrir \texttt{/admin}                   & non & non & oui \\
+Créer / désactiver des utilisateurs      & non & non & oui \\
+Éditer les données de référence          & non & non & oui \\
+Restaurer depuis la corbeille            & non & non & oui \\
+Supprimer définitivement de la corbeille & non & non & oui \\
+Éditer les paramètres système            & non & non & oui \\
+\bottomrule
+\end{longtable}
+
+\section{Sessions et timeout d'inactivité}
+
+Après la connexion, mybibli pose un cookie de
+session\index{cookie de session} qui voyage avec chaque requête
+suivante. Le cookie est :
+
+\begin{itemize}
+  \item \texttt{HttpOnly} — non exposé à JavaScript ;
+  \item \texttt{SameSite=Lax} — envoyé sur les navigations
+        same-site de haut niveau mais pas sur les requêtes
+        cross-site ;
+  \item \texttt{Secure} (uniquement si
+        \texttt{MYBIBLI\_COOKIE\_SECURE} est positionné à
+        \texttt{true} — voir chapitre~\ref{ch:installation}).
+\end{itemize}
+
+La session a un \textbf{timeout d'inactivité}\index{timeout
+d'inactivité} (défaut 30 minutes, configurable depuis
+\texttt{/admin > System > Loans}). Chaque requête authentifiée
+réinitialise le compte à rebours ; si aucune requête n'arrive dans
+la fenêtre, la session est effacée côté serveur et la requête
+suivante redirige vers la page de connexion.
+
+Un petit \emph{toast de keep-alive} apparaît dans un coin de l'écran
+environ deux minutes avant l'expiration — cliquez-le pour
+prolonger la session sans quitter la page courante.
+
+\section{Garde du dernier admin actif}
+
+mybibli refuse de laisser l'installation sans aucun admin actif.
+La garde s'applique à deux actions :
+
+\begin{itemize}
+  \item \textbf{Désactiver un utilisateur.} Si l'utilisateur est le
+        seul admin actif, la requête renvoie un 409 conflict et la
+        désactivation est refusée.
+  \item \textbf{Supprimer définitivement un utilisateur depuis la
+        corbeille.} Même règle.
+\end{itemize}
+
+L'auto-désactivation est également bloquée sans condition (vous ne
+pouvez pas désactiver le compte avec lequel vous êtes connecté).
+
+\begin{warning}
+La garde ne compte que les admins \emph{actifs}. Si vous
+désactivez en masse des admins et que la garde se déclenche,
+défaites en réactivant quelqu'un depuis l'onglet corbeille. Il n'y
+a aucun chemin de récupération via l'assistant ou la base sans
+SQL manuel.
+\end{warning}
+
+\section{Réinitialisation de mot de passe}
+
+mybibli n'implémente pas l'envoi de courriels de réinitialisation
+de mot de passe — les déploiements familiaux / petite communauté
+tirent rarement profit de la plomberie email. Un admin peut
+réinitialiser le mot de passe d'un autre utilisateur en :
+
+\begin{enumerate}
+  \item Ouvrant \texttt{/admin > Users}.
+  \item Choisissant l'utilisateur, cliquant \textbf{Désactiver}.
+  \item Cliquant \textbf{Réactiver} depuis l'onglet corbeille.
+  \item Re-créant l'utilisateur avec un mot de passe frais.
+\end{enumerate}
+
+Un utilisateur qui connaît son mot de passe actuel peut le changer
+depuis la page \texttt{/account}.
+
+\section{Sessions anonymes}
+
+Les visiteurs anonymes obtiennent aussi une ligne de session
+(utilisée pour la protection CSRF et la livraison des mises à jour
+HTMX en cours). Les sessions anonymes expirent après sept jours
+d'inactivité et sont collectées par une tâche d'arrière-plan
+quotidienne — elles n'affectent pas les utilisateurs connectés.

--- a/docs/manual/fr/07-backup-restore.tex
+++ b/docs/manual/fr/07-backup-restore.tex
@@ -1,0 +1,149 @@
+\chapter{Sauvegarde et restauration}
+\label{ch:backup}
+
+Une bibliothèque auto-hébergée n'a pas de filet de sécurité dans le
+cloud. Ce chapitre couvre quoi sauvegarder, à quelle fréquence, et
+comment restaurer.
+
+\section{Quoi sauvegarder}
+
+Trois artefacts forment ensemble une sauvegarde mybibli complète :
+
+\begin{enumerate}
+  \item \textbf{La base MariaDB.}\index{sauvegarde!base} Contient
+        chaque titre, volume, lieu, contributeur, prêt,
+        utilisateur, journal d'audit et paramètre. La perdre,
+        c'est repartir de zéro.
+  \item \textbf{Le répertoire \texttt{covers/}.}\index{sauvegarde!covers}
+        Les images de couverture téléchargées au catalogage. Le
+        perdre, le catalogue fonctionne toujours mais chaque page
+        de titre affiche un placeholder générique tant que vous
+        n'avez pas re-fetché les métadonnées titre par titre.
+  \item \textbf{Le fichier \texttt{.env}.}\index{sauvegarde!.env}
+        Contient les mots de passe (base, clés d'API non encore
+        migrées). Le perdre, un re-déploiement vous oblige à
+        re-saisir chaque credential.
+\end{enumerate}
+
+Les images Docker elles-mêmes ne sont \emph{pas} critiques — vous
+pouvez toujours les re-tirer depuis Docker Hub.
+
+\section{Procédure de sauvegarde}
+
+\subsection*{Base de données — MariaDB embarquée}
+
+Depuis l'hôte qui exécute la pile compose :
+
+\begin{lstlisting}
+docker compose exec -T db mariadb-dump \
+    -u root -p"$MYSQL_ROOT_PASSWORD" \
+    --single-transaction --routines --triggers \
+    mybibli \
+    > backups/mybibli-$(date +%Y%m%d-%H%M%S).sql
+\end{lstlisting}
+
+Le drapeau \texttt{--single-transaction} est important : il fait un
+snapshot cohérent sans verrouiller les tables pendant la durée du
+dump. \texttt{--routines --triggers} préserve les routines stockées
+(mybibli n'en utilise pas pour l'instant, mais le drapeau est peu
+coûteux et future-proof).
+
+Compressez le dump si l'espace disque est une préoccupation :
+
+\begin{lstlisting}
+gzip backups/mybibli-*.sql
+\end{lstlisting}
+
+\subsection*{Base de données — MariaDB externe}
+
+Lancez \texttt{mariadb-dump} directement contre le serveur externe.
+Les utilisateurs DSM Synology peuvent aussi planifier une tâche
+\emph{Hyper Backup} qui cible le paquet MariaDB — elle produit une
+sauvegarde binaire qui se restaure plus vite qu'un dump SQL.
+
+\subsection*{Covers et \texttt{.env}}
+
+Une simple archive \texttt{tar} suffit :
+
+\begin{lstlisting}
+tar czf backups/mybibli-files-$(date +%Y%m%d).tar.gz \
+    .env covers/
+\end{lstlisting}
+
+\section{Cadence recommandée}
+
+\begin{itemize}
+  \item \textbf{Quotidien} — dump de base automatisé. Même sur un
+        catalogue rarement modifié, un dump journalier garantit que
+        la pire perte de données est bornée à une journée.
+  \item \textbf{Hebdomadaire} — covers et \texttt{.env}. Ils ne
+        changent que quand vous cataloguez de nouveaux titres ou
+        faites tourner des clés ; hebdomadaire est amplement
+        suffisant.
+  \item \textbf{Copie hors-site} — au moins mensuelle. Rsync du
+        répertoire \texttt{backups/} vers un NAS distant, un
+        disque USB que vous échangez ou un bucket de stockage
+        cloud. Un incendie qui consume le serveur domestique ne
+        doit pas aussi consumer vos sauvegardes.
+\end{itemize}
+
+\begin{tip}
+Une sauvegarde qui n'a jamais été restaurée n'est pas une
+sauvegarde. Une fois par trimestre, restaurez votre dernier dump
+dans un environnement Docker jetable et vérifiez que les compteurs
+de titres et de prêts correspondent à ce que rapporte
+\texttt{/admin > Health} en production.
+\end{tip}
+
+\section{Procédure de restauration}
+
+\subsection*{Base de données}
+
+Pour le setup avec base embarquée :
+
+\begin{lstlisting}
+docker compose stop mybibli
+docker compose exec -T db mariadb -u root -p"$MYSQL_ROOT_PASSWORD" \
+    -e "DROP DATABASE mybibli; CREATE DATABASE mybibli CHARACTER SET utf8mb4;"
+zcat backups/mybibli-20260513-1200.sql.gz | \
+    docker compose exec -T db mariadb -u root -p"$MYSQL_ROOT_PASSWORD" mybibli
+docker compose start mybibli
+\end{lstlisting}
+
+Pour MariaDB externe, les mêmes commandes client \texttt{mariadb}
+fonctionnent contre le serveur externe.
+
+\subsection*{Covers et \texttt{.env}}
+
+\begin{lstlisting}
+tar xzf backups/mybibli-files-20260513.tar.gz
+\end{lstlisting}
+
+Redémarrez la pile pour que le conteneur mybibli prenne en compte
+le \texttt{.env} restauré.
+
+\section{Migration vers un nouvel hôte}
+
+La procédure de sauvegarde est aussi la procédure de migration :
+
+\begin{enumerate}
+  \item Sur l'ancien hôte : produire un dump de base et une archive
+        tar frais.
+  \item Transférer les deux sur le nouvel hôte.
+  \item Sur le nouvel hôte : installer Docker, récupérer le fichier
+        compose depuis la release correspondant à la version du
+        dump, placer \texttt{.env} et \texttt{covers/} à côté,
+        restaurer la base, démarrer la pile.
+  \item Vérifier en comptant les titres sur \texttt{/admin >
+        Health} et en contrôlant quelques pages de titre au
+        hasard.
+\end{enumerate}
+
+\begin{warning}
+Le dump est lié à la version de \emph{schéma}. Si l'hôte source
+tournait en 1.1.0 et que le nouvel hôte tire 1.5.0, les migrations
+du nouvel hôte mettront à niveau la base restaurée — c'est OK.
+L'inverse (restaurer un dump 1.5.0 sur une installation 1.1.0)
+n'est \emph{pas} supporté et échouera au boot. Restaurez toujours
+sur un hôte exécutant la même version mybibli ou plus récente.
+\end{warning}

--- a/docs/manual/fr/08-upgrade-migration.tex
+++ b/docs/manual/fr/08-upgrade-migration.tex
@@ -1,0 +1,128 @@
+\chapter{Mise à jour et migration}
+\label{ch:upgrade}
+
+Les mises à jour de routine sont conçues pour être sûres.
+L'exception est le saut 1.0.x → 1.1.0, un breaking change unique
+documenté ci-dessous.
+
+\section{Mises à jour de routine (1.y → 1.z)}
+
+\begin{enumerate}
+  \item Lisez les notes de version pour chaque version entre votre
+        version courante et la cible.
+  \item Prenez une \textbf{sauvegarde de base} fraîche
+        (chapitre~\ref{ch:backup}).
+  \item Mettez à jour le tag d'image dans
+        \texttt{docker-compose.yml} (ou re-tirez \texttt{:latest}
+        si vous suivez ce tag).
+  \item Lancez \texttt{docker compose up -d}. Le nouveau conteneur
+        boote, exécute les nouvelles migrations contre la base
+        existante, et reprend le service.
+  \item Surveillez les logs pour les erreurs de migration :
+        \texttt{docker compose logs mybibli | grep -i migrate}.
+\end{enumerate}
+
+Les migrations sont append-only — les changements de schéma sont
+forward-compatibles. Une installation 1.4 mise à jour en 1.5 garde
+toutes les lignes de 1.4 et applique les nouvelles tables /
+colonnes sur place.
+
+\begin{tip}
+Pour les installations homelab, le tag Docker \texttt{:latest} est
+un défaut raisonnable. Pour des montages production
+(bibliothèque communautaire, association), épinglez une version
+explicite pour qu'un \texttt{pull} non surveillé n'amène pas une
+release sur laquelle vous n'avez pas lu les notes.
+\end{tip}
+
+\section{Le saut 1.0.x → 1.1.0}\label{sec:upgrade-1.1.0}
+
+\begin{warning}
+\textbf{Ceci est un breaking change unique.}\index{mise à jour 1.1.0}
+Les installations 1.0.x sont sujettes au bug documenté dans
+\href{https://github.com/guycorbaz/mybibli/issues/173}{\#173} :
+les migrations seed créent les identifiants \texttt{admin/admin}
+et \texttt{librarian/librarian} à chaque installation neuve, y
+compris en production, et contournent silencieusement l'assistant
+de première mise en service.
+\end{warning}
+
+Le chemin recommandé dépend de si votre installation 1.0.x détient
+des données réelles :
+
+\subsection*{Si votre installation 1.0.x est vide (aucun titre catalogué)}
+
+Le chemin le plus simple : effacer la base et réinstaller en 1.1.0+.
+
+\begin{enumerate}
+  \item Arrêter la pile : \texttt{docker compose down}.
+  \item Supprimer le volume de base :
+        \texttt{docker volume rm mybibli\_mybibli\_db\_data}
+        (ou l'équivalent sur votre hôte —
+        \texttt{docker volume ls} les liste).
+  \item Tirer l'image 1.1.0 : \texttt{docker compose pull}.
+  \item Mettre à jour le tag d'image dans
+        \texttt{docker-compose.yml} si vous aviez épinglé une
+        version antérieure.
+  \item Démarrer : \texttt{docker compose up -d}.
+  \item Ouvrir \texttt{/setup} et parcourir l'assistant.
+\end{enumerate}
+
+\subsection*{Si votre installation 1.0.x détient des données réelles}
+
+\begin{enumerate}
+  \item Prenez une sauvegarde de base (chapitre~\ref{ch:backup}).
+  \item Prenez une sauvegarde covers + \texttt{.env}.
+  \item Connectez-vous comme l'admin seedé et changez le mot de
+        passe \emph{avant} la mise à jour. La mise à jour 1.1.0
+        elle-même est sûre, mais la rotation ferme la dernière
+        fenêtre pendant laquelle les identifiants par défaut
+        pourraient fuiter.
+  \item Mettre à jour le tag d'image dans
+        \texttt{docker-compose.yml} et lancer
+        \texttt{docker compose up -d}.
+  \item Le boot 1.1.0 détecte l'admin existant et n'active
+        \emph{pas} l'assistant — l'admin avec mot de passe tourné
+        reste l'admin actif.
+\end{enumerate}
+
+\subsection*{La nouvelle variable \texttt{MYBIBLI\_SEED\_DEV\_USERS}}
+
+À partir de 1.1.0, la migration seed est gardée par
+\texttt{MYBIBLI\_SEED\_DEV\_USERS}\index{MYBIBLI\_SEED\_DEV\_USERS}.
+Le défaut est \texttt{0} (pas de seed). Ne la positionnez à
+\texttt{1} que pour des flux de dev local ou des tests automatisés
+— jamais en production. L'assistant de première mise en service
+devient le chemin canonique d'onboarding.
+
+\section{Lire les notes de version}
+
+Chaque release mybibli publie une page GitHub Release avec :
+
+\begin{itemize}
+  \item un paragraphe résumant le changement ;
+  \item l'impact migration (aucun / additif / breaking) ;
+  \item un lien vers le diff contre le tag précédent ;
+  \item les PDF de ce manuel (anglais + français) en pièce jointe
+        une fois le build PDF de release câblé dans la CI.
+\end{itemize}
+
+Lisez les notes avant de mettre à jour. Les breaking changes
+portent une étiquette \emph{Breaking} bien visible.
+
+\section{Rollback}
+
+Le rollback \emph{n'est pas} un flux de première classe. Les
+migrations de schéma avancent uniquement — il n'y a pas de
+\texttt{down.sql}. La stratégie de récupération supportée est :
+
+\begin{enumerate}
+  \item Restaurer la sauvegarde de base pré-mise-à-jour
+        (chapitre~\ref{ch:backup}).
+  \item Réépingler le tag d'image à la version antérieure.
+  \item Démarrer la pile.
+\end{enumerate}
+
+Cela fonctionne car la sauvegarde est cohérente avec le schéma
+antérieur. Tenter de pointer une image plus ancienne sur une base
+fraîchement migrée échoue au boot.

--- a/docs/manual/fr/09-best-practices.tex
+++ b/docs/manual/fr/09-best-practices.tex
@@ -1,0 +1,131 @@
+\chapter{Bonnes pratiques}
+\label{ch:bestpractices}
+
+Leçons concentrées tirées de déploiements réels. Chaque section est
+optionnelle — prenez ce qui colle à votre échelle.
+
+\section{Hiérarchie de stockage}
+
+\begin{itemize}
+  \item \textbf{Trois niveaux suffisent en général.} Pièce →
+        étagère → rangée couvre la plupart des foyers. Un quatrième
+        niveau (par exemple « boîte à l'intérieur de la rangée »)
+        devient de la paperasse à maintenir.
+  \item \textbf{Nommez les lieux comme vous en parlez.} « Étagère
+        du salon, en haut » bat « SAL-E01-R01 ». Les noms
+        apparaissent sur les étiquettes ; traitez-les comme du
+        contenu visible.
+  \item \textbf{Imprimez les codes L une seule fois.} Réimprimer
+        parce que vous avez rééquilibré les étagères est du
+        travail perdu — les codes L sont des identifiants
+        stables ; le nom humain sur l'étiquette peut dériver et
+        c'est OK.
+\end{itemize}
+
+\section{Planches de codes V}
+
+\begin{itemize}
+  \item Imprimez les codes V en planches de 50 à 100. Des
+        autocollants pré-imprimés dans un porte-étiquettes près du
+        poste de scan rendent le catalogage \emph{rapide}.
+  \item \textbf{Collez le code V avant de scanner.} Cela élimine
+        un futur mode de panne où vous mal-étiquetez un livre et
+        devez le re-trouver par scan.
+  \item \textbf{Placez l'étiquette toujours au même endroit.}
+        Intérieur de la 4\textsuperscript{e} de couverture, coin
+        supérieur droit, parallèle au dos — choisissez une règle
+        et tenez-vous-y. Le futur-vous lors d'un audit remerciera
+        le présent-vous.
+\end{itemize}
+
+\section{Genre versus Dewey}
+
+mybibli supporte à la fois des genres larges et des codes
+Dewey\index{Dewey}. Choisissez l'un des deux comme aide principale
+à la navigation :
+
+\begin{itemize}
+  \item \textbf{Utilisez les genres} quand le public navigue par
+        humeur (« je veux un thriller ») et que la collection est
+        assez petite pour que « Thriller » soit suffisamment
+        granulaire.
+  \item \textbf{Utilisez Dewey} quand le public navigue par sujet
+        (« livres sur l'histoire de France du XVIII\textsuperscript{e}
+        siècle ») ou quand la collection a atteint la taille où
+        « Documentaire » n'est plus un filtre utile.
+  \item Utiliser les deux est OK ; mybibli ne force pas le choix.
+\end{itemize}
+
+\section{Cadence d'audit}
+
+\begin{itemize}
+  \item \textbf{Trimestriel} pour les collections sous quelques
+        centaines de volumes.
+  \item \textbf{Mensuel} pour les collections au-dessus,
+        spécialement si plus d'une personne catalogue.
+  \item Lancez toujours un audit \emph{après} un grand
+        rééquilibrage de rayons — déplacer des livres
+        physiquement sans le dire à mybibli est la première
+        source de bugs « où est ce volume ? ».
+\end{itemize}
+
+\section{Comptes utilisateur}
+
+\begin{itemize}
+  \item \textbf{Un humain, un compte.} Partager un seul compte
+        \texttt{admin} entre deux personnes fait perdre la piste
+        d'audit et rend la garde du dernier admin moins utile.
+  \item \textbf{La plupart des éditeurs doivent être
+        Bibliothécaires, pas Admins.} Le panneau admin gère des
+        préoccupations d'installation et de nettoyage rare ; vous
+        n'avez pas besoin de droits admin pour cataloguer ou
+        prêter.
+  \item \textbf{Changez le mot de passe admin seedé au premier
+        login.} Sur 1.1.0+ l'assistant le force ; sur les
+        installations 1.0.x existantes, faites-le manuellement
+        avant d'exposer l'instance sur un réseau.
+\end{itemize}
+
+\section{Prêts}
+
+\begin{itemize}
+  \item \textbf{Gardez des emprunteurs identifiables.} « Marie L. »
+        bat « Marie » dès la seconde Marie qui pointe son nez.
+        Email ou téléphone dans le champ notes aide pour les
+        relances.
+  \item \textbf{Parcourez la liste des retards une fois par
+        semaine.} L'indicateur du dashboard vous houspille pour
+        une raison — les prêts en retard cumulés sur un an
+        deviennent des livres que vous ne possédez plus.
+  \item \textbf{Notez les dégâts au retour.} Basculer un volume
+        retourné en \emph{Usé} ou \emph{Endommagé} capture
+        l'information pendant que l'emprunteur est devant vous ;
+        chasser le coût plus tard de mémoire fonctionne rarement.
+\end{itemize}
+
+\section{Fournisseurs de métadonnées}
+
+\begin{itemize}
+  \item \textbf{Limitez les clés.} Vous n'avez pas besoin des
+        trois fournisseurs à clé dès le premier jour — BnF + Open
+        Library couvrent les livres gratuitement. Ajoutez OMDb +
+        TMDb le jour où vous cataloguez votre premier DVD.
+  \item \textbf{Traitez les clés comme des secrets.} \texttt{.env}
+        est dans \texttt{.gitignore} ; conservez les sauvegardes
+        de \texttt{.env} chiffrées (chapitre~\ref{ch:backup}).
+\end{itemize}
+
+\section{Mises à jour}
+
+\begin{itemize}
+  \item \textbf{Lisez les notes de version avant de tirer
+        \texttt{:latest}.} Voir chapitre~\ref{ch:upgrade}.
+  \item \textbf{Sauvegardez juste avant chaque mise à jour.} Même
+        les migrations « additives » ont une surface de panne
+        non-nulle ; une sauvegarde minute-avant transforme une
+        inquiétude en formalité.
+  \item \textbf{Épinglez une version pour la production.} Les
+        auto-updates conviennent à une instance familiale ; pour
+        une bibliothèque communautaire, un saut majeur non
+        surveillé peut interrompre le service.
+\end{itemize}

--- a/docs/manual/fr/10-troubleshooting.tex
+++ b/docs/manual/fr/10-troubleshooting.tex
@@ -1,0 +1,170 @@
+\chapter{Dépannage}
+\label{ch:troubleshooting}
+
+Quand quelque chose tourne mal, commencez par les logs et le tableau
+de bord \texttt{/admin > Health}. Ce chapitre catalogue les
+problèmes que les utilisateurs rencontrent vraiment, par ordre de
+fréquence approximatif.
+
+\section{Lire les logs}
+
+\begin{lstlisting}
+docker compose logs --since 10m mybibli
+docker compose logs -f mybibli
+\end{lstlisting}
+
+Les logs sortent en JSON structuré. Les champs les plus utiles sont
+\texttt{level}, \texttt{target} (quel module a logué cette ligne),
+\texttt{message}, et toute paire clé=valeur contextuelle que la
+ligne porte (\texttt{user\_id}, \texttt{volume\_id}, \dots).
+
+Pour filtrer :
+
+\begin{lstlisting}
+docker compose logs --since 10m mybibli | grep -i error
+\end{lstlisting}
+
+\section{L'application ne démarre pas}
+
+\subsection*{Symptôme : le conteneur s'arrête immédiatement}
+
+Lancez \texttt{docker compose logs mybibli} et cherchez l'une des
+lignes :
+
+\begin{itemize}
+  \item \texttt{missing required environment variable:
+        DATABASE\_URL}\index{dépannage!DATABASE\_URL} — le fichier
+        \texttt{.env} est absent ou la variable n'est pas
+        positionnée. Voir section~\ref{sec:env-vars}.
+  \item \texttt{Failed to create database pool} — l'hôte / port /
+        identifiants dans \texttt{DATABASE\_URL} sont faux, ou la
+        base n'est pas joignable. Depuis l'hôte, essayez
+        \texttt{docker compose exec mybibli sh -c 'apk add curl;
+        curl <db-host>:<db-port>'} pour confirmer la joignabilité.
+  \item \texttt{Failed to run database migrations} — généralement
+        un souci de permission. Confirmez que l'utilisateur DB a
+        \texttt{ALL PRIVILEGES} sur la base (voir
+        section~\ref{sec:install-external-db}).
+  \item \texttt{Address already in use} — le port hôte publié est
+        pris. Changez \texttt{HOST\_PORT} dans \texttt{.env}.
+\end{itemize}
+
+\subsection*{Symptôme : chaque page renvoie 404}
+
+Le conteneur est levé mais les routes manquent. Cause la plus
+fréquente : vous avez tiré un tag d'image qui n'existe pas (faute
+de frappe) et Docker est retombé sur un vieux tag obsolète.
+\texttt{docker compose pull} puis redémarrez.
+
+\section{Impossible de se connecter}
+
+\subsection*{Symptôme : « Invalid credentials » sur une installation 1.0.x neuve}
+
+Les identifiants seedés sont \texttt{admin/admin}. S'ils ne marchent
+pas non plus :
+
+\begin{itemize}
+  \item la migration de base qui les crée a échoué silencieusement
+        — cherchez les erreurs de migration dans les logs ;
+  \item l'admin précédent a déjà tourné le mot de passe (vérifiez
+        avec qui a installé mybibli) ;
+  \item vous regardez une installation 1.1.0+, où il n'y a pas de
+        seed — utilisez plutôt l'assistant à \texttt{/setup}.
+\end{itemize}
+
+\subsection*{Symptôme : la connexion redirige vers \texttt{/login}}
+
+Le cookie de session est rejeté par le navigateur. Causes :
+
+\begin{itemize}
+  \item \texttt{MYBIBLI\_COOKIE\_SECURE=true} sur un déploiement
+        plain-HTTP — le navigateur refuse d'accepter un cookie
+        Secure en HTTP. Positionnez la variable à \texttt{false}
+        ou frontez l'instance en HTTPS.
+  \item Cookies bloqués par politique du navigateur (fenêtre
+        privée avec blocage strict des cookies tiers, etc.).
+        Testez dans un profil par défaut.
+\end{itemize}
+
+\subsection*{Symptôme : verrouillé dehors — dernier admin désactivé}
+
+La garde du dernier admin actif devrait empêcher cela, mais si un
+admin précédent a été désactivé puis supprimé définitivement, la
+récupération demande un accès SQL direct :
+
+\begin{lstlisting}
+docker compose exec db mariadb -u root -p"$MYSQL_ROOT_PASSWORD" mybibli \
+    -e "UPDATE users SET deleted_at=NULL, active=1 WHERE username='votre-admin';"
+\end{lstlisting}
+
+Ensuite connectez-vous normalement.
+
+\section{Les métadonnées ne se résolvent jamais}
+
+\subsection*{Symptôme : le titre squelette reste non résolu}
+
+Ouvrez \texttt{/admin > Health}. Regardez l'état de chaque
+fournisseur. Une croix rouge veut généralement dire :
+
+\begin{itemize}
+  \item le fournisseur est vraiment down (rare pour BnF / Open
+        Library ; plus fréquent pour les services plus petits) ;
+  \item la clé d'API est absente ou invalide — ouvrez
+        \texttt{/admin > System > Metadata Providers} et re-saisissez
+        la clé ;
+  \item l'hôte ne peut pas joindre l'upstream. Confirmez avec
+        \texttt{docker compose exec mybibli sh -c "wget -q
+        https://www.googleapis.com/books/v1 -O -"} ou équivalent.
+\end{itemize}
+
+\subsection*{Symptôme : seuls les ISBN français se résolvent}
+
+Vous avez désactivé (ou jamais positionné) les clés Google Books /
+Open Library. BnF est excellent pour les titres édités en France
+mais limité pour les titres en langues étrangères. Ajoutez au
+moins Open Library (sans clé requise).
+
+\section{La recherche renvoie trop peu de résultats}
+
+\subsection*{Symptôme : des titres connus ne remontent pas}
+
+\begin{itemize}
+  \item Confirmez que le titre n'est pas soft-deleted (vérifiez
+        \texttt{/admin > Trash}). La recherche cache les éléments
+        soft-deleted.
+  \item Confirmez que les contributeurs du titre sont orthographiés
+        comme vous avez cherché. La recherche mybibli est floue
+        mais pas magique ; « Camus » trouvera « Albert Camus »
+        mais « Camu » peut ne rien donner.
+\end{itemize}
+
+\subsection*{Symptôme : la recherche est lente}
+
+Pour les collections au-delà de 10\,000 titres, les requêtes qui
+combinent contributeur et texte libre peuvent prendre une
+seconde ou deux. C'est une limitation connue ; des index prévus
+combleront l'écart.
+
+\section{Images de couverture manquantes}
+
+\subsection*{Symptôme : chaque titre affiche le placeholder}
+
+Le répertoire \texttt{covers/} est vide ou illisible. Confirmez :
+
+\begin{itemize}
+  \item que le volume monté dans \texttt{docker-compose.yml} pointe
+        vers un répertoire qui existe et est accessible en écriture
+        au conteneur ;
+  \item que la récupération de métadonnées a effectivement renvoyé
+        une URL de couverture (regardez la page du titre — si l'URL
+        manque, le fournisseur ne l'a pas fournie).
+\end{itemize}
+
+\section{Où signaler un bug}
+
+Problèmes que vous ne pouvez pas résoudre, ou comportement qui
+contredit ce manuel : ouvrez un ticket sur
+\url{https://github.com/guycorbaz/mybibli/issues}. Le template
+d'issue demande la version (visible en pied de page), la méthode
+d'installation et les étapes pour reproduire — merci de les
+renseigner.

--- a/docs/manual/fr/99-glossary.tex
+++ b/docs/manual/fr/99-glossary.tex
@@ -1,0 +1,173 @@
+\chapter{Glossaire}
+\label{ch:glossary}
+
+\begin{description}
+
+  \item[Administrateur]\index{administrateur} Compte utilisateur
+        avec le rôle \texttt{admin}. Le seul rôle qui peut ouvrir
+        le panneau \texttt{/admin} et éditer les utilisateurs, les
+        données de référence, la corbeille ou les paramètres
+        système.
+
+  \item[Anonyme]\index{anonyme} Visiteur sans cookie de session.
+        Accès en lecture seule au catalogue public. Pas de
+        catalogage, pas de prêt, pas d'édition.
+
+  \item[Audit]\index{audit} Le rituel « je parcours les étagères
+        et je confirme que tout est à la place que la base
+        indique » décrit en section~\ref{sec:audit}.
+
+  \item[BDGest]\index{BDGest} Catalogue BD francophone utilisé comme
+        source de métadonnées pour ce type de média.
+
+  \item[BnF]\index{BnF} \textit{Bibliothèque nationale de France}.
+        Catalogue de la BNF, utilisé comme source principale de
+        métadonnées pour les livres en français.
+
+  \item[Catalogage] L'acte d'enregistrer un nouveau titre et/ou
+        volume dans la base. Typiquement piloté au code-barres :
+        scanner, confirmer, coller l'étiquette, recommencer.
+
+  \item[Code L]\index{code L} Étiquette code-barres d'un lieu de
+        stockage. Format : \texttt{L} suivi d'un numéro
+        zéro-paddé.
+
+  \item[Code V]\index{code V} Étiquette code-barres d'un volume.
+        Format : \texttt{V} suivi d'un numéro zéro-paddé.
+
+  \item[Couverture]\index{couvertures} La face visuelle avant d'un
+        livre / disque / vinyle, téléchargée depuis un fournisseur
+        de métadonnées et mise en cache sous \texttt{COVERS\_DIR}
+        sur disque.
+
+  \item[CSP] Content Security Policy. En-tête imposé par le
+        navigateur qui restreint quels scripts et styles la page
+        peut exécuter. mybibli applique une politique stricte qui
+        interdit scripts et styles inline.
+
+  \item[CSRF (jeton)]\index{CSRF} Secret par session intégré dans
+        chaque formulaire. mybibli rejette les requêtes POST /
+        PUT / DELETE dont le jeton ne correspond pas — défense
+        contre les forgeries de requête inter-sites.
+
+  \item[Dewey (code)]\index{Dewey} Le numéro de la Classification
+        décimale de Dewey, utilisé pour la navigation par sujet
+        du catalogue. Optionnel par titre.
+
+  \item[EAN-13] Le standard de code-barres à 13 chiffres. Les ISBN
+        sont encodés en EAN-13 depuis 2007 ; les CD, DVD et autres
+        supports portent aussi des codes EAN-13.
+
+  \item[Emprunteur]\index{emprunteur} Personne qui emprunte des
+        volumes à la bibliothèque. Modélisé comme sa propre entité
+        (nom, contact optionnel, historique de prêts).
+
+  \item[Exemplaire] Synonyme de \emph{volume} (l'objet physique).
+        Utilisé par certaines bibliothèques françaises ; mybibli
+        préfère \emph{volume}.
+
+  \item[État de volume]\index{état de volume} Ligne de données de
+        référence décrivant l'état d'un volume : Neuf, Bon, Usé,
+        Endommagé, \dots.
+
+  \item[Garde du dernier admin actif]\index{garde du dernier admin}
+        Règle qui empêche de désactiver ou supprimer définitivement
+        le dernier utilisateur de rôle \texttt{admin}. Voir
+        section~\ref{sec:users}.
+
+  \item[Genre]\index{genres} Classification libre du sujet d'un
+        titre (Fiction, Documentaire, Polar, \dots). Définie dans
+        la table de référence des genres.
+
+  \item[Hard-delete] Suppression d'une ligne pour de bon. mybibli
+        ne hard-delete que depuis le panneau \texttt{/admin >
+        Trash} et la tâche d'auto-purge en arrière-plan ; tout le
+        reste est un soft-delete.
+
+  \item[HTMX] Bibliothèque JavaScript qu'utilise mybibli pour
+        échanger des fragments de page sans rechargement complet.
+        Les exploitants n'ont pas besoin de comprendre HTMX pour
+        utiliser mybibli.
+
+  \item[ISBN] International Standard Book Number. Identifiant
+        imprimé au dos des livres, encodé en code-barres EAN-13.
+
+  \item[Lieu]\index{lieu} L'endroit physique où vit un volume.
+        Modélisé comme un arbre (pièce → étagère → rangée),
+        identifié par un code L.
+
+  \item[MariaDB] Le moteur de base où mybibli stocke ses données.
+        Fork de MySQL.
+
+  \item[Multi-position (volume)]\index{multi-position} Un volume
+        physique unique qui contient plusieurs positions dans une
+        série — typiquement un album BD omnibus.
+
+  \item[MusicBrainz]\index{MusicBrainz} Catalogue de métadonnées
+        musicales maintenu par des bénévoles, utilisé comme source
+        principale pour les médias audio.
+
+  \item[OMDb]\index{OMDb} Open Movie Database. Source de
+        métadonnées pour films et séries TV.
+
+  \item[Open Library]\index{Open Library} Catalogue ouvert de
+        livres porté par des bénévoles, utilisé comme source de
+        métadonnées.
+
+  \item[Optimistic locking] Technique qu'utilise mybibli pour
+        détecter les éditions concurrentes. Deux utilisateurs qui
+        éditent le même titre obtiennent une erreur claire à la
+        seconde sauvegarde au lieu de s'écraser silencieusement.
+
+  \item[Prêt]\index{prêt} Enregistrement qu'un volume précis est
+        actuellement sorti chez un emprunteur précis. Note la date
+        de prêt, la date de retour prévue, la date de retour, et
+        le lieu pré-prêt du volume.
+
+  \item[Réactivation] Restauration d'une ligne soft-deleted. Pour
+        les utilisateurs, efface \texttt{deleted\_at} et leur
+        permet de se reconnecter. Pour les données de référence,
+        le terme couvre aussi le fait de re-créer une ligne avec
+        le même nom qu'une soft-deleted, ce qui défait la
+        suppression de manière transparente.
+
+  \item[Série]\index{série} Suite ordonnée et nommée de titres
+        liés (par exemple une trilogie ou une série BD en cours).
+        La position de chaque titre dans la série est un petit
+        entier ou une plage (pour les omnibus).
+
+  \item[Setup wizard]\index{setup wizard} Le flux en quatre étapes
+        à \texttt{/setup} qu'une instance vide présente jusqu'à
+        ce qu'un compte admin existe.
+
+  \item[Soft-delete]\index{soft-delete} Positionnement de la
+        colonne \texttt{deleted\_at} d'une ligne à « maintenant »
+        au lieu de supprimer physiquement la ligne. Les lignes
+        soft-deleted sont invisibles aux requêtes normales mais
+        apparaissent dans \texttt{/admin > Trash} pendant
+        30\,jours, après quoi l'auto-purge les hard-delete.
+
+  \item[Titre] L'entité bibliographique (un livre, un film, un
+        album). Un titre peut avoir plusieurs volumes — par
+        exemple, deux exemplaires du même roman sur des étagères
+        différentes.
+
+  \item[TMDb]\index{TMDb} The Movie Database. Source de
+        métadonnées communautaire pour films et séries TV.
+
+  \item[Type de média]\index{types de médias} La nature de l'objet
+        que représente un titre : Livre, BD / comic, Audio, Film /
+        série. Pilote la sélection des fournisseurs et l'affichage
+        des champs.
+
+  \item[Type de nœud]\index{type de nœud} Libellé appliqué aux
+        lieux de stockage pour indiquer quel type de contenant
+        ils sont (pièce, étagère, rangée, boîte). Pur libellé —
+        aucune contrainte sémantique.
+
+  \item[Volume]\index{volume} L'objet physique sur l'étagère — un
+        exemplaire d'un titre. Un titre peut avoir plusieurs
+        volumes ; chacun porte son propre code V, son lieu et son
+        état.
+
+\end{description}

--- a/docs/manual/fr/main.tex
+++ b/docs/manual/fr/main.tex
@@ -1,0 +1,131 @@
+% mybibli — Manuel utilisateur (français)
+%
+% Compilation :   latexmk -xelatex main.tex
+% ou depuis le répertoire parent :
+%                 ./build.sh fr
+%
+% Requiert XeLaTeX (pour fontspec + polyglossia + Unicode).
+\documentclass[a4paper,11pt,oneside]{book}
+
+% ---- Polices (XeLaTeX) ----------------------------------------------
+\usepackage{fontspec}
+\setmainfont{Latin Modern Roman}
+\setsansfont{Latin Modern Sans}
+\setmonofont{Latin Modern Mono}[Scale=0.92]
+
+% ---- Langue ---------------------------------------------------------
+\usepackage{polyglossia}
+\setdefaultlanguage{french}
+
+% ---- Mise en page ---------------------------------------------------
+\usepackage[a4paper,margin=2.5cm,headheight=14pt]{geometry}
+\usepackage{microtype}
+\usepackage{parskip}
+
+% ---- Couleurs et hyperliens -----------------------------------------
+\usepackage{xcolor}
+\definecolor{linkcolor}{HTML}{0B5394}
+\definecolor{codebg}{HTML}{F5F5F5}
+\usepackage[colorlinks=true,linkcolor=linkcolor,urlcolor=linkcolor,citecolor=linkcolor]{hyperref}
+
+% ---- En-tête / pied de page -----------------------------------------
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[L]{\nouppercase{\leftmark}}
+\fancyhead[R]{\thepage}
+\renewcommand{\headrulewidth}{0.4pt}
+\fancypagestyle{plain}{%
+  \fancyhf{}
+  \fancyfoot[C]{\thepage}
+  \renewcommand{\headrulewidth}{0pt}}
+
+% ---- Tableaux -------------------------------------------------------
+\usepackage{booktabs}
+\usepackage{array}
+\usepackage{longtable}
+\usepackage{tabularx}
+
+% ---- Listes ---------------------------------------------------------
+\usepackage{enumitem}
+\setlist{itemsep=2pt, topsep=4pt}
+
+% ---- Blocs de code --------------------------------------------------
+\usepackage{listings}
+\lstdefinestyle{config}{
+  basicstyle=\ttfamily\small,
+  backgroundcolor=\color{codebg},
+  breaklines=true,
+  breakatwhitespace=false,
+  frame=single,
+  framerule=0pt,
+  rulecolor=\color{codebg},
+  columns=fullflexible,
+  keepspaces=true,
+  showstringspaces=false,
+  xleftmargin=4pt,
+  xrightmargin=4pt,
+  aboveskip=8pt,
+  belowskip=8pt,
+  literate=%
+    {é}{{\'e}}1 {è}{{\`e}}1 {ê}{{\^e}}1 {ë}{{\"e}}1
+    {à}{{\`a}}1 {â}{{\^a}}1 {ä}{{\"a}}1
+    {î}{{\^\i}}1 {ï}{{\"\i}}1
+    {ô}{{\^o}}1 {ö}{{\"o}}1
+    {ù}{{\`u}}1 {û}{{\^u}}1 {ü}{{\"u}}1
+    {ç}{{\c c}}1 {Ç}{{\c C}}1 {œ}{{\oe}}1 {Œ}{{\OE}}1
+    {’}{{'}}1 {–}{{--}}1 {—}{{---}}1
+}
+\lstset{style=config}
+
+% ---- Encadrés -------------------------------------------------------
+\usepackage[most]{tcolorbox}
+\newtcolorbox{note}{colback=blue!4!white, colframe=blue!55!black,
+  fonttitle=\bfseries, title=Note, breakable, enhanced}
+\newtcolorbox{tip}{colback=green!4!white, colframe=green!50!black,
+  fonttitle=\bfseries, title=Astuce, breakable, enhanced}
+\newtcolorbox{warning}{colback=red!4!white, colframe=red!70!black,
+  fonttitle=\bfseries, title=Attention, breakable, enhanced}
+
+% ---- Index ----------------------------------------------------------
+\usepackage{imakeidx}
+\makeindex[intoc,columns=2,title=Index]
+
+% ---- Métadonnées du document ---------------------------------------
+\title{\Huge\bfseries mybibli\\[6pt]\Large Manuel utilisateur}
+\author{Les auteurs de mybibli\\\small \texttt{https://github.com/guycorbaz/mybibli}}
+\date{Version 1.1.0 — \today}
+
+% =====================================================================
+\begin{document}
+\frontmatter
+\maketitle
+
+\begin{center}
+\vspace*{2cm}
+\small
+Distribué sous licence AGPL-3.0-or-later.\\
+Ce manuel couvre mybibli version 1.1.0 et ultérieures.
+\end{center}
+
+\tableofcontents
+
+\mainmatter
+
+\input{00-preface}
+\input{01-installation}
+\input{02-configuration}
+\input{03-usage}
+\input{04-multimedia}
+\input{05-metadata-providers}
+\input{06-roles-permissions}
+\input{07-backup-restore}
+\input{08-upgrade-migration}
+\input{09-best-practices}
+\input{10-troubleshooting}
+\input{99-glossary}
+
+\backmatter
+\printindex
+
+\end{document}

--- a/docs/manual/fr/main.tex
+++ b/docs/manual/fr/main.tex
@@ -126,6 +126,9 @@ Ce manuel couvre mybibli version 1.1.0 et ultérieures.
 \input{99-glossary}
 
 \backmatter
+\cleardoublepage
+\phantomsection
+\label{index}
 \printindex
 
 \end{document}


### PR DESCRIPTION
## Summary

12-chapter user manual, one self-contained PDF per language, written in pure LaTeX and built via XeLaTeX + latexmk. Targeted at the **operator** role — the person who installs, configures and runs a mybibli instance for a household, small association or community library.

## Layout

\`\`\`
docs/manual/
├── en/   main.tex + 12 chapter files + images/
├── fr/   main.tex + 12 chapter files + images/   (full mirror — independent preamble)
├── build.sh           xelatex/latexmk dispatch + toolchain check
├── README.md          prerequisites + build commands
└── .gitignore         LaTeX build artifacts
\`\`\`

Each language is self-contained — no shared preamble. PDFs are not committed (gitignored — attach to releases).

## Chapter coverage

| # | Chapter | Notes |
|---|---|---|
| 00 | Preface | Audience, conventions, callouts (Note / Tip / Warning), how to file bugs |
| 01 | Installation | **Two variants**: bundled DB + external DB (Synology NAS example). Full env-var reference table. Setup-wizard walkthrough. |
| 02 | Configuration | Storage locations + tree, V-code / L-code labels, reference data (4 taxonomy tables), system settings, user management |
| 03 | Everyday use | Catalog via scan, search, move, loans, audit workflow, shelving |
| 04 | Multimedia | Books, comics/BD (omnibus multi-position), audio (CD/LP), films/series |
| 05 | Metadata providers | BnF, Open Library, Google Books, MusicBrainz, OMDb, TMDb, BDGest — chain semantics, where to get keys, key rotation |
| 06 | Roles & permissions | Anonymous / Librarian / Admin matrix, sessions, last-active-admin guard |
| 07 | Backup & restore | DB + covers/ + .env, cadence, migration to new host |
| 08 | Upgrade & migration | Routine 1.y → 1.z + the 1.0.x → 1.1.0 breaking change |
| 09 | Best practices | Hierarchy depth, label rolls, audit cadence, account hygiene |
| 10 | Troubleshooting | Symptom matrix: won't start, can't login, metadata stuck, slow search, missing covers |
| 99 | Glossary | V-code, L-code, title vs volume, exemplaire, etc. |

Each chapter sprinkles \`\\index{...}\` calls; a two-column index is printed at the back via \`imakeidx\`.

## Build

\`\`\`bash
./docs/manual/build.sh        # both languages
./docs/manual/build.sh en     # English only
./docs/manual/build.sh fr     # French only
\`\`\`

Prerequisites are documented in \`docs/manual/README.md\` with one-line install commands for Debian/Ubuntu, Fedora, Arch and macOS.

## Known unknown

XeLaTeX is **not installed** in the environment used to author this manual, so the LaTeX has been written following standard patterns but **not test-compiled**. A first local build is expected to surface minor issues — please run \`./docs/manual/build.sh\` on your machine and report anything that breaks (likely candidates: a missing package on a minimal TeX Live install, an unescaped special character in one of the longtable rows).

## Test plan

- [ ] \`./docs/manual/build.sh\` produces \`mybibli-manual-en.pdf\` and \`mybibli-manual-fr.pdf\` without errors.
- [ ] Each PDF has a clickable TOC and clickable cross-references.
- [ ] The index at the back has at least one entry per chapter and resolves to a real page.
- [ ] FR special characters render correctly (accents, guillemets « »).
- [ ] Both PDFs read as natural EN / FR (not Google-translate quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)