### PR TITLE
fix(ci): use GitHub API for highest-semver check in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,18 @@ jobs:
 
       - name: Check if pushed tag is the highest semver
         id: is-highest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git fetch --tags --quiet
-          HIGHEST=$(git tag -l 'v*.*.*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          HIGHEST=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/tags" --jq '.[].name' \
+            | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
+            | sort -V \
+            | tail -1)
+          if [ -z "$HIGHEST" ]; then
+            echo "::error::Could not determine highest semver tag via GitHub API"
+            exit 1
+          fi
           if [ "$HIGHEST" = "$GITHUB_REF_NAME" ]; then
             echo "is_highest=true" >> "$GITHUB_OUTPUT"
             echo "Tag $GITHUB_REF_NAME is the highest semver — :latest will be updated"


### PR DESCRIPTION
## Summary

- `git tag -l` returns empty on the GitHub Actions runner under `actions/checkout@v4` even with `fetch-depth: 0` + `git fetch --tags --quiet`. Combined with `set -o pipefail`, the subsequent `grep` exits 1 on empty input and the publish job fails before reaching the Docker Hub push step.
- Observed on the v1.1.0 tag push (run 25852597080) — failed twice deterministically (fresh run + `--failed` rerun) at the `Check if pushed tag is the highest semver` step.
- Replaces the local-tag enumeration with `gh api repos/<owner>/<repo>/tags`. The API is the source of truth and immune to checkout/fetch quirks.
- Adds `|| true` around the grep to be robust against an empty match, plus an explicit empty-check that fails with a clear message so a future API regression doesn't fail silently.

## Test plan

- [x] Workflow lints (gates job runs on this PR via push-trigger? actually `release.yml` is tag-triggered only — gates run via the `_gates.yml` reusable workflow on `ci.yml` for `push:` to branches). CI on this branch covers the standard gates.
- [ ] After merge: delete the existing remote `v1.1.0` tag (no image was published — safe), re-tag on the new `main` HEAD, push, and verify the `Release` workflow completes through the Docker Hub publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)