### PR TITLE
docs: post-1.1.0 feedback — stray users + scanner hardware

### DIFF
--- a/docs/manual/en/02-configuration.tex
+++ b/docs/manual/en/02-configuration.tex
@@ -106,6 +106,78 @@ stick it on the back cover, and scan in one motion — no
 context-switch between the cataloging UI and the printer.
 \end{tip}
 
+\section{Hardware: barcode scanner}\label{sec:scanner-hardware}
+
+mybibli is designed around a barcode scanner but does not strictly
+require one — every ISBN, V-code and L-code field accepts manual
+keyboard input as a fallback. That said, for any collection beyond
+a handful of titles, a cheap USB scanner pays for itself within the
+first dozen scans.
+
+\subsection*{What to buy}
+
+Any \emph{HID-keyboard-mode}\index{HID keyboard mode} USB scanner in
+the 15--30~\euro{} range works. The HID mode is what makes the
+scanner driver-free: the OS sees it as a regular keyboard and the
+scanned digits land directly in whatever input field has focus.
+Almost every general-purpose USB scanner on the market ships in this
+mode by default; look for the words ``HID'', ``keyboard
+emulation'' or ``plug-and-play'' on the product page.
+
+The scanner must support the two symbologies mybibli uses:
+
+\begin{itemize}
+  \item \textbf{EAN-13}\index{EAN-13} — the 13-digit code on the
+        back cover of books, CDs, DVDs, and most consumer products.
+        Universally supported.
+  \item \textbf{Code-128}\index{Code-128} — the symbology mybibli
+        uses to encode V-codes and L-codes on the labels it prints
+        (see section~\ref{sec:labels}). Universally supported.
+\end{itemize}
+
+You do \emph{not} need a 2D imager (the kind that reads QR codes) —
+a basic 1D laser or LED scanner is enough. mybibli does not use QR
+codes.
+
+\subsection*{Configuration}
+
+Three settings on the scanner matter. Most scanners ship them
+correctly out of the box; if your scans behave strangely, check the
+scanner's manual or the configuration sheet of barcodes that comes
+in the box:
+
+\begin{itemize}
+  \item \textbf{Terminator / suffix:} \texttt{Enter} (also called
+        \texttt{CR} or \texttt{Carriage Return}). mybibli's
+        cataloging form auto-submits on Enter, so this turns each
+        scan into one round-trip. Anything else (\texttt{Tab}, no
+        terminator) will not work without manual key presses.
+  \item \textbf{Prefix:} none. Some scanners can prepend a fixed
+        string before the payload — leave it disabled.
+  \item \textbf{Keyboard layout:} \emph{must} match the layout of
+        the host the browser runs on. If your laptop uses an AZERTY
+        layout but the scanner is configured for QWERTY, the digits
+        come out as letters (e.g.\ \texttt{1234567890} arrives as
+        \texttt{\&é"'(-è\_çà}) and no ISBN ever resolves. The
+        scanner's manual will have a code chart to switch.
+\end{itemize}
+
+\begin{tip}
+USB scanners on a Synology NAS host: it does not matter that the
+scanner is plugged into the laptop you use to access the mybibli
+web UI rather than the NAS itself. The scanner is a keyboard for
+the browser, not for the server. The same setup works with a
+phone-side scanner app, an industrial Bluetooth scanner paired to
+the laptop, or any USB stick scanner.
+\end{tip}
+
+\subsection*{What to do when the scanner is unavailable}
+
+Every scan field also accepts hand-typed input. Click into the field
+labelled ``Scan ISBN'' (or ``Scan V-code'' / ``Scan L-code''
+elsewhere), type the digits, press Enter. The form behaves
+identically.
+
 \section{Reference data}\label{sec:reference-data}
 
 Four taxonomy tables drive the dropdowns you see while

--- a/docs/manual/en/10-troubleshooting.tex
+++ b/docs/manual/en/10-troubleshooting.tex
@@ -66,9 +66,63 @@ either:
         — look for migration errors in the logs;
   \item the previous admin already rotated the password (check
         with whoever installed mybibli);
-  \item you are looking at a 1.1.0+ install, where no seed exists —
-        use the wizard at \texttt{/setup} instead.
+  \item you are looking at a 1.1.0+ install, where the seed
+        credentials are planted by the migration but immediately
+        soft-deleted by the issue-\#173 seed gate at startup — use
+        the wizard at \texttt{/setup} instead.
 \end{itemize}
+
+\section{Stray users in the \texttt{users} table after the wizard}
+\label{sec:troubleshoot-seeded-users}
+
+\subsection*{Symptom: four users in the database, only one was created in the wizard}
+
+If you inspect the \texttt{users} table directly (via phpMyAdmin or
+the MariaDB CLI) right after completing \texttt{/setup}, you will
+see \emph{four} rows even though you only entered one username and
+password. This is by design. Three of the rows cannot be used to
+log in.
+
+\begin{longtable}{@{} l l c l @{}}
+\toprule
+\textbf{username} & \textbf{role} & \textbf{active} & \textbf{deleted\_at} \\
+\midrule
+\endhead
+\texttt{admin}     & \texttt{admin}     & 1 & set, $\approx$ first-boot time \\
+\texttt{librarian} & \texttt{librarian} & 1 & set, $\approx$ first-boot time \\
+\texttt{SYSTEM}    & \texttt{system}    & 0 & NULL \\
+\texttt{<your-username>} & \texttt{admin} & 1 & NULL \\
+\bottomrule
+\end{longtable}
+
+\begin{itemize}
+  \item \texttt{admin} and \texttt{librarian} are planted by the
+        seed migrations (which run on every fresh install for the
+        dev / E2E workflow) and immediately \emph{soft-deleted}
+        by the issue-\#173 seed gate at startup. Their
+        \texttt{deleted\_at} is set, so the login query (which
+        filters \texttt{deleted\_at IS NULL}) refuses them.
+  \item \texttt{SYSTEM}\index{SYSTEM user} is a non-loginable
+        utility account used to attribute the audit-log entries
+        produced by the 30-day auto-purge background task. Its role
+        is \texttt{system} (outside the login enum
+        \texttt{admin/librarian}), its \texttt{password\_hash} is
+        the literal string
+        \texttt{NO\_LOGIN\_SYSTEM\_USER\_HASH\_NOT\_A\_VALID\_ARGON2\_STRING},
+        and its \texttt{active} flag is \texttt{0}.
+\end{itemize}
+
+\begin{tip}
+To confirm the soft-deleted rows are inert, try logging in as
+\texttt{admin/admin} — it returns an authentication failure. The
+\texttt{/admin > Users} panel filters out both the \texttt{SYSTEM}
+row and any \texttt{deleted\_at}-set row, so the admin UI shows the
+single account you created in the wizard.
+\end{tip}
+
+The two soft-deleted rows are physically removed from the table by
+the 30-day auto-purge scheduler — expect them to disappear roughly
+one month after the boot date stamped in \texttt{deleted\_at}.
 
 \subsection*{Symptom: login redirects back to \texttt{/login}}
 

--- a/docs/manual/fr/02-configuration.tex
+++ b/docs/manual/fr/02-configuration.tex
@@ -115,6 +115,85 @@ scanner d'un même mouvement — sans aller-retour entre l'interface
 de catalogage et l'imprimante.
 \end{tip}
 
+\section{Matériel : douchette code-barres}\label{sec:scanner-hardware}
+
+mybibli est conçu autour d'une douchette code-barres mais n'en exige
+pas strictement une : tous les champs ISBN, code V et code L
+acceptent la saisie clavier comme repli. Cela dit, dès que la
+collection dépasse une poignée de titres, une douchette USB
+bon marché est rentabilisée après la première douzaine de scans.
+
+\subsection*{Quoi acheter}
+
+N'importe quelle douchette USB en \emph{mode clavier HID}\index{mode
+HID clavier} dans la gamme 15--30~\euro{} convient. Le mode HID est
+ce qui rend la douchette sans pilote : l'OS la voit comme un clavier
+ordinaire et les chiffres scannés atterrissent directement dans le
+champ qui a le focus. Presque toutes les douchettes USB grand public
+sortent d'usine dans ce mode ; cherchez les mots ``HID'',
+``émulation clavier'' ou ``plug-and-play'' sur la fiche produit.
+
+La douchette doit prendre en charge les deux symbologies que
+mybibli utilise :
+
+\begin{itemize}
+  \item \textbf{EAN-13}\index{EAN-13} — le code à 13 chiffres au dos
+        des livres, CD, DVD et de la plupart des produits grand
+        public. Universellement supporté.
+  \item \textbf{Code-128}\index{Code-128} — la symbologie utilisée
+        par mybibli pour encoder les codes V et codes L sur les
+        étiquettes qu'il imprime (voir section~\ref{sec:labels}).
+        Universellement supporté.
+\end{itemize}
+
+Vous n'avez \emph{pas} besoin d'un imageur 2D (le type qui lit les
+QR codes) — une douchette laser ou LED 1D basique suffit. mybibli
+n'utilise pas les QR codes.
+
+\subsection*{Configuration}
+
+Trois réglages comptent côté douchette. La plupart sortent d'usine
+correctement configurées ; si vos scans se comportent bizarrement,
+consultez le manuel de la douchette ou la planche de codes-barres de
+configuration livrée dans la boîte :
+
+\begin{itemize}
+  \item \textbf{Terminateur / suffixe :} \texttt{Enter} (parfois
+        appelé \texttt{CR} ou \texttt{Carriage Return}). Le
+        formulaire de catalogage de mybibli soumet
+        automatiquement à la pression d'Entrée, donc ce réglage
+        transforme chaque scan en un seul aller-retour. Toute autre
+        valeur (\texttt{Tab}, pas de terminateur) ne marchera pas
+        sans intervention clavier manuelle.
+  \item \textbf{Préfixe :} aucun. Certaines douchettes peuvent
+        préfixer une chaîne fixe au début du payload — laissez
+        cette option désactivée.
+  \item \textbf{Disposition clavier :} \emph{doit} correspondre à
+        la disposition de l'hôte sur lequel tourne le navigateur. Si
+        votre ordinateur utilise AZERTY mais la douchette est
+        configurée en QWERTY, les chiffres sortent en lettres (p.~ex.
+        \texttt{1234567890} arrive comme \texttt{\&é"'(-è\_çà}) et
+        aucun ISBN ne résout. Le manuel de la douchette contient une
+        planche de codes pour changer la disposition.
+\end{itemize}
+
+\begin{tip}
+Douchettes USB sur NAS Synology : peu importe que la douchette soit
+branchée sur l'ordinateur portable depuis lequel vous accédez à
+l'interface web de mybibli plutôt que sur le NAS lui-même. La
+douchette est un clavier pour le navigateur, pas pour le serveur. Le
+même montage marche avec une appli scanner sur téléphone, une
+douchette Bluetooth industrielle appairée à l'ordinateur, ou
+n'importe quelle douchette USB clé.
+\end{tip}
+
+\subsection*{Quand la douchette n'est pas disponible}
+
+Chaque champ de scan accepte aussi la saisie clavier. Cliquez dans
+le champ étiqueté ``Scanner ISBN'' (ou ``Scanner code V'' /
+``Scanner code L'' ailleurs), tapez les chiffres, pressez Entrée. Le
+formulaire se comporte à l'identique.
+
 \section{Données de référence}\label{sec:reference-data}
 
 Quatre tables taxonomiques pilotent les menus déroulants que vous

--- a/docs/manual/fr/10-troubleshooting.tex
+++ b/docs/manual/fr/10-troubleshooting.tex
@@ -68,9 +68,66 @@ pas non plus :
         — cherchez les erreurs de migration dans les logs ;
   \item l'admin précédent a déjà tourné le mot de passe (vérifiez
         avec qui a installé mybibli) ;
-  \item vous regardez une installation 1.1.0+, où il n'y a pas de
-        seed — utilisez plutôt l'assistant à \texttt{/setup}.
+  \item vous regardez une installation 1.1.0+, où les identifiants
+        seedés sont bien plantés par la migration mais immédiatement
+        soft-deleted par la garde issue-\#173 au démarrage —
+        utilisez plutôt l'assistant à \texttt{/setup}.
 \end{itemize}
+
+\section{Utilisateurs résiduels dans la table \texttt{users} après l'assistant}
+\label{sec:troubleshoot-seeded-users}
+
+\subsection*{Symptôme : quatre utilisateurs en base, un seul créé dans l'assistant}
+
+Si vous inspectez la table \texttt{users} directement (via
+phpMyAdmin ou le CLI MariaDB) juste après avoir terminé
+\texttt{/setup}, vous verrez \emph{quatre} lignes alors que vous
+n'avez saisi qu'un seul nom d'utilisateur et un seul mot de passe.
+C'est intentionnel. Trois de ces lignes ne peuvent pas servir à se
+connecter.
+
+\begin{longtable}{@{} l l c l @{}}
+\toprule
+\textbf{username} & \textbf{role} & \textbf{active} & \textbf{deleted\_at} \\
+\midrule
+\endhead
+\texttt{admin}     & \texttt{admin}     & 1 & rempli, $\approx$ heure du premier boot \\
+\texttt{librarian} & \texttt{librarian} & 1 & rempli, $\approx$ heure du premier boot \\
+\texttt{SYSTEM}    & \texttt{system}    & 0 & NULL \\
+\texttt{<votre-username>} & \texttt{admin} & 1 & NULL \\
+\bottomrule
+\end{longtable}
+
+\begin{itemize}
+  \item \texttt{admin} et \texttt{librarian} sont plantés par les
+        migrations de seed (qui tournent à chaque installation neuve
+        pour le flux dev / E2E) puis immédiatement
+        \emph{soft-deleted} par la garde issue-\#173 au démarrage.
+        Leur \texttt{deleted\_at} est rempli, donc la requête de
+        login (qui filtre \texttt{deleted\_at IS NULL}) les refuse.
+  \item \texttt{SYSTEM}\index{utilisateur SYSTEM} est un compte
+        utilitaire non connectable, utilisé pour attribuer les
+        entrées du journal d'audit produites par la tâche de fond
+        de purge automatique à 30 jours. Son rôle est \texttt{system}
+        (hors de l'énum de login \texttt{admin/librarian}), son
+        \texttt{password\_hash} est la chaîne littérale
+        \texttt{NO\_LOGIN\_SYSTEM\_USER\_HASH\_NOT\_A\_VALID\_ARGON2\_STRING},
+        et son flag \texttt{active} vaut \texttt{0}.
+\end{itemize}
+
+\begin{tip}
+Pour vérifier que les lignes soft-deleted sont inertes, essayez de
+vous connecter avec \texttt{admin/admin} : la tentative est
+refusée. Le panneau \texttt{/admin > Utilisateurs} filtre la ligne
+\texttt{SYSTEM} ainsi que toute ligne avec \texttt{deleted\_at}
+rempli, donc l'interface admin n'affiche que le compte que vous
+avez créé dans l'assistant.
+\end{tip}
+
+Les deux lignes soft-deleted sont physiquement supprimées de la
+table par le planificateur de purge automatique à 30 jours —
+attendez-vous à les voir disparaître environ un mois après la date
+de boot inscrite dans \texttt{deleted\_at}.
 
 \subsection*{Symptôme : la connexion redirige vers \texttt{/login}}
 


### PR DESCRIPTION
## Summary

Two manual additions driven by real-operator feedback during the 1.1.0 deployment on 2026-05-14:

1. **Troubleshooting (chapter 10)** — new section *"Stray users in the `users` table after the wizard"* explaining why four rows appear after the setup wizard even though only one admin account was created. Covers the soft-deleted `admin`/`librarian` seed rows and the `SYSTEM` utility account. Also corrects the inaccurate *"no seed exists on 1.1.0+"* bullet in the existing login-failure section.

2. **Configuration (chapter 02)** — new section *"Hardware: barcode scanner"* covering HID-keyboard mode, the two required symbologies (EAN-13 + Code-128), the Enter suffix, host keyboard-layout match, and the hand-typed fallback. Adjacent to the V-code / L-code labels section so scanning- and printing-side symbologies are documented together.

Both mirrored in `en/` and `fr/`. The matching paragraph was already added to the v1.1.0 GitHub Release notes for the stray-users topic.

## Test plan

- [ ] `./docs/manual/build.sh en` produces `mybibli-manual-en.pdf` without LaTeX errors
- [ ] `./docs/manual/build.sh fr` produces `mybibli-manual-fr.pdf` without LaTeX errors
- [ ] New sections appear in both PDFs' tables of contents
- [ ] `\index{}` entries (HID keyboard mode, EAN-13, Code-128, SYSTEM user) land in the back-of-book index

🤖 Generated with [Claude Code](https://claude.com/claude-code)