### PR TITLE
fix(locations): plumb CSRF token through inline add-child form (fixes #185)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 

--- a/src/routes/locations.rs
+++ b/src/routes/locations.rs
@@ -170,16 +170,23 @@ fn build_subtree(
 }
 
 /// Render the tree as HTML string (avoids recursive template which crashes Askama compiler).
+///
+/// `csrf_token` is the per-session synchronizer token (see CLAUDE.md → CSRF
+/// synchronizer token / story 8-2). It is injected as a hidden input on every
+/// inline "add child" form. Forgetting it causes issue #185: the middleware
+/// rejects the POST, redirects authenticated users to `/login` which itself
+/// redirects to `/` — the action silently fails with no UI feedback.
 fn render_tree_html(
     nodes: &[TreeNode],
     node_types: &[(u64, String)],
     next_lcode: &str,
     can_edit: bool,
     loc: &str,
+    csrf_token: &str,
 ) -> String {
     let mut html = String::new();
     for node in nodes {
-        render_node_html(node, &mut html, node_types, next_lcode, can_edit, loc);
+        render_node_html(node, &mut html, node_types, next_lcode, can_edit, loc, csrf_token);
     }
     html
 }
@@ -191,10 +198,12 @@ fn render_node_html(
     next_lcode: &str,
     can_edit: bool,
     loc: &str,
+    csrf_token: &str,
 ) {
-    render_node_at_depth(node, html, node_types, next_lcode, 0, can_edit, loc);
+    render_node_at_depth(node, html, node_types, next_lcode, 0, can_edit, loc, csrf_token);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_node_at_depth(
     node: &TreeNode,
     html: &mut String,
@@ -203,6 +212,7 @@ fn render_node_at_depth(
     depth: usize,
     can_edit: bool,
     loc: &str,
+    csrf_token: &str,
 ) {
     let name = crate::utils::html_escape(&node.location.name);
     let label = crate::utils::html_escape(&node.location.label);
@@ -267,6 +277,7 @@ fn render_node_at_depth(
             ),
             format!(
                 r#"<form id="{form_id}" method="POST" action="/locations" class="hidden {child_margin_class} px-3 py-2 space-y-2 bg-stone-50 dark:bg-stone-800/50 rounded-md mt-1 mb-2">
+<input type="hidden" name="_csrf_token" value="{csrf_token_escaped}">
 <input type="hidden" name="parent_id" value="{id}">
 <div class="grid grid-cols-1 md:grid-cols-3 gap-2">
 <div><label class="block text-xs text-stone-600 dark:text-stone-400">{name_lbl}</label><input type="text" name="name" required class="w-full px-2 py-1 text-sm border border-stone-300 dark:border-stone-600 rounded bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100"></div>
@@ -277,6 +288,7 @@ fn render_node_at_depth(
 </form>"#,
                 id = node.location.id,
                 next_lcode = crate::utils::html_escape(next_lcode),
+                csrf_token_escaped = crate::utils::html_escape(csrf_token),
             ),
         )
     } else {
@@ -306,6 +318,7 @@ fn render_node_at_depth(
             depth + 1,
             can_edit,
             loc,
+            csrf_token,
         );
     }
 }
@@ -371,7 +384,14 @@ pub async fn locations_page(
 
     let tree = build_tree(&locations, &volume_counts);
     let can_edit = session.role >= Role::Librarian;
-    let tree_html = render_tree_html(&tree, &node_types, &next_lcode, can_edit, loc);
+    let tree_html = render_tree_html(
+        &tree,
+        &node_types,
+        &next_lcode,
+        can_edit,
+        loc,
+        &session.csrf_token,
+    );
 
     let template = LocationsTemplate {
         lang: loc.to_string(),
@@ -669,6 +689,98 @@ mod tests {
         assert_eq!(tree[0].children.len(), 1);
         assert_eq!(tree[0].children[0].children.len(), 1);
         assert_eq!(tree[0].children[0].children[0].volume_count, 5);
+    }
+
+    /// Issue #185 regression lock: the inline "add child" form rendered by
+    /// `render_tree_html` MUST include the CSRF synchronizer token as a
+    /// hidden input. Forgetting it causes the middleware to reject the POST
+    /// with a 303 → /login → / silent redirect.
+    ///
+    /// This sits outside the Askama `forms_include_csrf_token` audit
+    /// (issue #48) because that audit scans templates only, not HTML
+    /// produced by Rust code. Keep this test until #48 lands.
+    #[test]
+    fn render_tree_html_includes_csrf_token_in_inline_form() {
+        let locations = vec![LocationModel {
+            id: 42,
+            parent_id: None,
+            name: "Salon".to_string(),
+            node_type: "room".to_string(),
+            label: "L0001".to_string(),
+        }];
+        let tree = build_tree(&locations, &HashMap::new());
+        let token = "test-csrf-token-abcdef0123456789";
+        let html = render_tree_html(
+            &tree,
+            &[(1, "room".to_string())],
+            "L0002",
+            /* can_edit */ true,
+            "en",
+            token,
+        );
+        let needle = format!(r#"<input type="hidden" name="_csrf_token" value="{token}">"#);
+        assert!(
+            html.contains(&needle),
+            "inline add-child form must include the CSRF token (issue #185). \
+             Looked for {needle:?} in rendered HTML."
+        );
+    }
+
+    /// When the viewer cannot edit, no form is rendered — the CSRF token
+    /// should NOT leak into the read-only HTML.
+    #[test]
+    fn render_tree_html_omits_csrf_token_when_read_only() {
+        let locations = vec![LocationModel {
+            id: 42,
+            parent_id: None,
+            name: "Salon".to_string(),
+            node_type: "room".to_string(),
+            label: "L0001".to_string(),
+        }];
+        let tree = build_tree(&locations, &HashMap::new());
+        let html = render_tree_html(
+            &tree,
+            &[(1, "room".to_string())],
+            "L0002",
+            /* can_edit */ false,
+            "en",
+            "should-not-appear",
+        );
+        assert!(
+            !html.contains("_csrf_token"),
+            "no form, no token: read-only tree leaked CSRF token in HTML"
+        );
+        assert!(
+            !html.contains("should-not-appear"),
+            "read-only tree leaked the CSRF token value"
+        );
+    }
+
+    /// CSRF token must be HTML-escaped when injected into the hidden input's
+    /// `value=` attribute (defense in depth — tokens are constant-time-compared
+    /// against the session row, so a non-escaped token wouldn't directly cause
+    /// XSS, but the audit-friendly contract is "every dynamic attribute value
+    /// goes through html_escape").
+    #[test]
+    fn render_tree_html_escapes_csrf_token() {
+        let locations = vec![LocationModel {
+            id: 1,
+            parent_id: None,
+            name: "Salon".to_string(),
+            node_type: "room".to_string(),
+            label: "L0001".to_string(),
+        }];
+        let tree = build_tree(&locations, &HashMap::new());
+        let html = render_tree_html(
+            &tree,
+            &[(1, "room".to_string())],
+            "L0002",
+            true,
+            "en",
+            r#"a"b<c>"#,
+        );
+        assert!(html.contains(r#"value="a&quot;b&lt;c&gt;""#));
+        assert!(!html.contains(r#"value="a"b<c>""#));
     }
 
     #[test]

--- a/tests/e2e/specs/journeys/locations.spec.ts
+++ b/tests/e2e/specs/journeys/locations.spec.ts
@@ -168,4 +168,62 @@ test.describe("Location Hierarchy CRUD (Story 2-1)", () => {
   // AC4/AC5: Delete guards tested via API (HTMX delete returns error HTML)
   // These are harder to test in E2E without seeded data with volumes/children,
   // but the unit tests cover the service logic. The E2E verifies the UI flow.
+
+  // Issue #185 regression — inline "add child" form must carry the CSRF token
+  // and create the sub-location in-place (not silently redirect to /).
+  test("inline add-child form creates the sub-location and stays on /locations", async ({
+    page,
+  }) => {
+    await page.goto("/locations");
+
+    // Create the parent.
+    await page.locator("summary").filter({ hasText: /add root/i }).click();
+    await page.locator("#new-name").fill("LO-IssueOneEightFive-Parent");
+    await page.locator("#new-lcode").fill("L5185");
+    await page.locator("#add-root-submit").click();
+    await expect(page).toHaveURL(/\/locations\/?$/, { timeout: 5000 });
+    await expect(
+      page.locator("text=LO-IssueOneEightFive-Parent"),
+    ).toBeVisible();
+
+    // Extract the parent's id from its edit link so we can target its own
+    // inline "add child" toggle button (`data-locations-toggle="add-child-{id}"`).
+    const parentEditLink = page
+      .locator('a[aria-label*="LO-IssueOneEightFive-Parent"][href*="/edit"]')
+      .first();
+    await expect(parentEditLink).toBeVisible({ timeout: 3000 });
+    const parentHref = await parentEditLink.getAttribute("href");
+    const parentId = parentHref?.match(/\/locations\/(\d+)/)?.[1];
+    expect(parentId).toBeTruthy();
+
+    // Expand the inline child form (issue #185: this form is rendered by Rust
+    // HTML literal, not via Askama template — it bypassed the CSRF audit).
+    await page
+      .locator(`[data-locations-toggle="add-child-${parentId}"]`)
+      .click();
+
+    const childForm = page.locator(`#add-child-${parentId}`);
+    await expect(childForm).toBeVisible();
+
+    // The CSRF synchronizer token MUST be present as a hidden input — this is
+    // exactly what was missing in 1.1.0 and what caused the silent redirect.
+    await expect(
+      childForm.locator('input[name="_csrf_token"]'),
+    ).toHaveCount(1);
+
+    // Fill the form and submit.
+    await childForm.locator('input[name="name"]').fill(
+      "LO-IssueOneEightFive-Child",
+    );
+    await childForm.locator('input[name="label"]').fill("L5186");
+    await childForm.locator('button[type="submit"]').click();
+
+    // Before the fix: the POST was rejected, the user landed on /. After the
+    // fix: the POST succeeds and we redirect back to /locations.
+    await expect(page).toHaveURL(/\/locations\/?$/, { timeout: 5000 });
+    await expect(page).not.toHaveURL(/^\/(\?|$)/);
+    await expect(
+      page.locator("text=LO-IssueOneEightFive-Child"),
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
Fixes #185.

## Summary

The inline "add child location" form rendered on `/locations` was missing the `_csrf_token` hidden input, causing a silent redirect to `/` (catalog) when a Librarian or Admin tried to submit it. The sub-location was never created and no UI feedback was shown.

## Root cause

The form is rendered in a Rust HTML literal in `src/routes/locations.rs::render_node_at_depth` (around line 268). It bypassed the `forms_include_csrf_token` audit in `src/templates_audit.rs` because that audit only scans Askama templates, not server-rendered HTML strings. The contrast was direct: the root-level "Add root location" form in `templates/pages/locations.html:26-27` already included the token correctly.

Once the POST hit `src/middleware/csrf.rs`, the missing token triggered the plain-form rejection path (lines 267-273): `303 → /login`. The login handler then redirected the already-authenticated session back to `/`. Hence the symptom.

The audit gap is pre-existing and tracked as **#48**. The silent-redirect UX symptom is the plain-form branch of **#45** (medium).

## What changed

- Plumbed `csrf_token: &str` through `render_tree_html` → `render_node_html` → `render_node_at_depth`.
- Injected `<input type="hidden" name="_csrf_token" value="...">` as the first child of the inline form, ahead of `parent_id`, per the established convention.
- Token value goes through `utils::html_escape` (defense in depth — tokens are constant-time-compared server-side but every dynamic HTML-attribute value should be escaped uniformly).
- Bumped version 1.1.0 → 1.1.1 in a separate `chore:` commit (mirrors prior commit `1369f02`).

## Tests

### Unit (regression locks — survive issue #48 still being deferred)

- `render_tree_html_includes_csrf_token_in_inline_form` — hidden input present when `can_edit=true`.
- `render_tree_html_omits_csrf_token_when_read_only` — no form, no leaked token when `can_edit=false`.
- `render_tree_html_escapes_csrf_token` — special characters in the token are properly escaped.

Full lib suite: 789 / 789 passing locally (with rust-test DB on `:3307`).

### E2E

New Playwright spec in `tests/e2e/specs/journeys/locations.spec.ts`:

> `inline add-child form creates the sub-location and stays on /locations`

The spec exercises the real broken flow: create a parent → click ➕ to expand the inline form → assert the `_csrf_token` hidden input is present → fill name/L-code → submit → assert (a) the URL stays on `/locations` (no silent redirect to `/`), (b) the sub-location appears in the tree.

### Local stack verification

Per Foundation Rule #13: `./scripts/e2e-reset.sh` rebuilt the test stack from the fix branch; the new spec passes against the rebuilt image.

## Test plan (reviewer checklist)

- [ ] CI green on `cargo clippy`, `cargo test` (lib + DB-backed), Playwright E2E
- [ ] Manual smoke on `/locations`: scan tree → click ➕ on a row → submit form with name/type/L-code → sub-location appears, no redirect to home
- [ ] `cargo sqlx prepare --check` clean (no query changes in this PR)
- [ ] Version in `Cargo.toml` reads `1.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
