### PR TITLE
fix(docs): replace \euro{} with Unicode € in manual

### DIFF
--- a/docs/manual/en/02-configuration.tex
+++ b/docs/manual/en/02-configuration.tex
@@ -117,7 +117,7 @@ first dozen scans.
 \subsection*{What to buy}
 
 Any \emph{HID-keyboard-mode}\index{HID keyboard mode} USB scanner in
-the 15--30~\euro{} range works. The HID mode is what makes the
+the 15--30~€ range works. The HID mode is what makes the
 scanner driver-free: the OS sees it as a regular keyboard and the
 scanned digits land directly in whatever input field has focus.
 Almost every general-purpose USB scanner on the market ships in this

--- a/docs/manual/fr/02-configuration.tex
+++ b/docs/manual/fr/02-configuration.tex
@@ -126,7 +126,7 @@ bon marché est rentabilisée après la première douzaine de scans.
 \subsection*{Quoi acheter}
 
 N'importe quelle douchette USB en \emph{mode clavier HID}\index{mode
-HID clavier} dans la gamme 15--30~\euro{} convient. Le mode HID est
+HID clavier} dans la gamme 15--30~€ convient. Le mode HID est
 ce qui rend la douchette sans pilote : l'OS la voit comme un clavier
 ordinaire et les chiffres scannés atterrissent directement dans le
 champ qui a le focus. Presque toutes les douchettes USB grand public


### PR DESCRIPTION
The \`\euro{}\` control sequence comes from the \`eurosym\` package which is NOT loaded by the manual's preamble. Building the manual via \`./docs/manual/build.sh\` fails on \`02-configuration.tex\` line 120 with \`Undefined control sequence\`.

Switched both EN and FR occurrences to the literal \`€\` character — idiomatic XeLaTeX with \`fontspec\`, consistent with the rest of the manual's Unicode-first conventions (€, «, », accented letters all appear as literals elsewhere).

## Why post-1.1.1 not pre-1.1.1

Discovered during the v1.1.1 PDF rebuild on 2026-05-14, immediately after the \`docs/post-1.1.0-feedback\` merge (PR #186) that introduced the scanner-hardware section. The v1.1.1 release is already tagged; this fix lands as a documentation patch.

The rebuilt PDFs attached to GitHub Release v1.1.1 reflect this fix (built from working tree after applying it locally).

## Test plan

- [ ] \`./docs/manual/build.sh en\` produces \`mybibli-manual-en.pdf\` without errors
- [ ] \`./docs/manual/build.sh fr\` produces \`mybibli-manual-fr.pdf\` without errors
- [ ] The "Hardware: barcode scanner" section displays \`15--30 €\` correctly in both PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)