### PR TITLE
chore: sprint-status — 10-1 → done (belated transition)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-29
-# last_updated: 2026-05-14 (Epic 10 spec added — mobile UX + sécurité closeout)
+# last_updated: 2026-05-14 (Story 10-1 → done — auth-threat-model doc closes #17)
 # project: mybibli
 # project_key: NOKEY
 # tracking_system: file-system
@@ -194,7 +194,7 @@ development_status:
   # Closes GitHub issues: #17, #45, #159, #160, #162.
   # Sequencing: 10-1 → 10-2 → 10-3 → 10-4 → 10-5 (series, per Foundation Rule #14).
   epic-10: backlog
-  10-1-auth-threat-model-doc: backlog
+  10-1-auth-threat-model-doc: done
   10-2-csrf-rejection-ux-and-mobile-logout: backlog
   10-3-mobile-datatable-card-mode: backlog
   10-4-admin-tabs-mobile-dropdown: backlog


### PR DESCRIPTION
Belated transition update for story 10-1. Should have shipped in PR #190; touches only the 10-1 line + the last_updated header per Foundation Rule #16.