### PR TITLE
Story 10-2: CSRF rejection UX + session-timeout 403 handling (closes #45)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-29
-# last_updated: 2026-05-14 (Story 10-1 → done — auth-threat-model doc closes #17)
+# last_updated: 2026-05-14 (Story 10-2 → done — CSRF drift full-chrome page closes #45)
 # project: mybibli
 # project_key: NOKEY
 # tracking_system: file-system
@@ -195,7 +195,7 @@ development_status:
   # Sequencing: 10-1 → 10-2 → 10-3 → 10-4 → 10-5 (series, per Foundation Rule #14).
   epic-10: backlog
   10-1-auth-threat-model-doc: done
-  10-2-csrf-rejection-ux-and-mobile-logout: backlog
+  10-2-csrf-rejection-ux-and-mobile-logout: done
   10-3-mobile-datatable-card-mode: backlog
   10-4-admin-tabs-mobile-dropdown: backlog
   10-5-a11y-entity-detail-coverage: backlog

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -260,6 +260,9 @@ error:
     body: Your account does not have permission to perform this action. Ask an administrator if you need access.
   csrf_rejected_title: Session expired
   csrf_rejected_message: Your CSRF token is missing or expired. Please refresh the page and retry your action.
+  csrf_session_drifted_title: Session expired — please reload
+  csrf_session_drifted_message: Your action was rejected because the security token attached to your session has expired. This typically happens after a tab has been left open for several days. Click Reload to refresh your session and try again.
+  csrf_session_drifted_reload_button: Reload page
   csrf_payload_too_large_title: Request too large
   csrf_payload_too_large_message: The submitted form exceeded the server's size limit. Please shorten your input and retry.
   title:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -260,6 +260,9 @@ error:
     body: Votre compte ne dispose pas des droits nécessaires pour cette action. Contactez un administrateur si vous avez besoin d'un accès.
   csrf_rejected_title: Session expirée
   csrf_rejected_message: Votre jeton CSRF est manquant ou expiré. Actualisez la page et réessayez.
+  csrf_session_drifted_title: Session expirée — veuillez recharger
+  csrf_session_drifted_message: Votre action a été refusée parce que le jeton de sécurité associé à votre session a expiré. Cela se produit généralement lorsqu'un onglet est resté ouvert plusieurs jours. Cliquez sur Recharger pour rafraîchir votre session et réessayer.
+  csrf_session_drifted_reload_button: Recharger la page
   csrf_payload_too_large_title: Requête trop volumineuse
   csrf_payload_too_large_message: Le formulaire envoyé dépasse la limite de taille du serveur. Raccourcissez votre saisie et réessayez.
   title:

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -23,6 +23,7 @@
 //! Exempt routes are frozen at one entry (`POST /login`) and policed by
 //! `src/templates_audit.rs::csrf_exempt_routes_frozen`.
 
+use askama::Template;
 use axum::body::Body;
 use axum::extract::{FromRequestParts, Request, State};
 use axum::http::{HeaderValue, Method, StatusCode, header};
@@ -33,6 +34,21 @@ use crate::AppState;
 use crate::error::AppError;
 use crate::middleware::auth::Session;
 use crate::middleware::locale::Locale;
+
+/// Full-chrome page emitted to authenticated users whose plain-form
+/// POST is CSRF-rejected (story 10-2, issue #45 H4). Without this page,
+/// the old behaviour was a silent 303 → /login → / round-trip that ate
+/// the user's action without any feedback.
+#[derive(Template)]
+#[template(path = "pages/csrf_drifted.html")]
+struct CsrfDriftedTemplate<'a> {
+    lang: &'a str,
+    role: &'a str,
+    csrf_token: &'a str,
+    title: String,
+    message: String,
+    reload_button: String,
+}
 
 /// Frozen allowlist of `(method, path)` tuples that skip CSRF validation.
 /// Login is the only legitimate case — no authenticated session exists at
@@ -133,7 +149,7 @@ pub async fn csrf_middleware(
         // `is_form` not yet computed here; pass false to get the HTMX /
         // JSON envelope response. Plain-form attackers would need to
         // bypass SameSite=Lax to reach this path anyway.
-        return build_rejection_response(locale, &parts, false);
+        return build_rejection_response(locale, &parts, false, Some(&session));
     }
     let header_token: Option<String> = header_values
         .first()
@@ -198,7 +214,7 @@ pub async fn csrf_middleware(
                         .get::<Locale>()
                         .map(|l| l.0)
                         .unwrap_or("fr");
-                    return build_rejection_response(locale, &parts, is_form);
+                    return build_rejection_response(locale, &parts, is_form, Some(&session));
                 }
                 first.map(|(_, v)| v)
             }
@@ -226,7 +242,7 @@ pub async fn csrf_middleware(
             .get::<Locale>()
             .map(|l| l.0)
             .unwrap_or("fr");
-        return build_rejection_response(locale, &parts, is_form);
+        return build_rejection_response(locale, &parts, is_form, Some(&session));
     }
 
     // Re-attach the (possibly body-consumed) bytes so the handler sees
@@ -257,14 +273,65 @@ fn build_rejection_response(
     locale: &str,
     parts: &axum::http::request::Parts,
     is_form: bool,
+    session: Option<&Session>,
 ) -> Response {
     // Plain-browser form submitters (no HTMX, classic `<form method="POST">`)
     // cannot consume the HTMX envelope — they would render a bare feedback
-    // fragment with no page chrome. Redirect them to /login so the user
-    // lands on a fully-rendered page where re-establishing a session also
-    // refreshes the CSRF token. API / JSON / fetch() clients still get the
-    // 403 envelope so they can handle the failure programmatically.
+    // fragment with no page chrome.
+    //
+    // Story 10-2 (issue #45 H4): differentiate by session state:
+    //
+    //   * **Authenticated** session whose token has drifted (browser
+    //     extension stripping the meta tag, 7+ days open tab,
+    //     post-redeploy) — render a full-chrome 403 page with a "Reload
+    //     page" CTA. The previous silent 303 → /login → / round-trip
+    //     ate the user's action without any feedback.
+    //
+    //   * **Anonymous** session — keep the 303 → /login redirect. The
+    //     /login page is the natural recovery surface for a not-yet-
+    //     authenticated visitor.
+    //
+    // API / JSON / fetch() clients still get the 403 envelope below so
+    // they can handle the failure programmatically.
     if is_form && !is_htmx_request(parts) {
+        if let Some(sess) = session
+            && sess.user_id.is_some()
+        {
+            let title = rust_i18n::t!("error.csrf_session_drifted_title", locale = locale)
+                .to_string();
+            let message =
+                rust_i18n::t!("error.csrf_session_drifted_message", locale = locale).to_string();
+            let reload_button =
+                rust_i18n::t!("error.csrf_session_drifted_reload_button", locale = locale)
+                    .to_string();
+            let role_str = sess.role.to_string();
+            let tpl = CsrfDriftedTemplate {
+                lang: locale,
+                role: &role_str,
+                csrf_token: &sess.csrf_token,
+                title,
+                message,
+                reload_button,
+            };
+            match tpl.render() {
+                Ok(html) => {
+                    let mut response: Response = (StatusCode::FORBIDDEN, html).into_response();
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static("text/html; charset=utf-8"),
+                    );
+                    headers
+                        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+                    return response;
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "csrf_drifted template render failed");
+                    // Fall through to the 303 path below as a degraded
+                    // fallback; better a /login redirect than a 500.
+                }
+            }
+        }
         let mut response: Response = StatusCode::SEE_OTHER.into_response();
         let headers = response.headers_mut();
         headers.insert(header::LOCATION, HeaderValue::from_static("/login"));
@@ -693,5 +760,76 @@ mod tests {
             logs_contain("csrf_multiple_headers"),
             "expected tracing::warn! with reason=csrf_multiple_headers"
         );
+    }
+
+    /// Story 10-2 (issue #45 H4): an *authenticated* user whose plain
+    /// form submission drifts on the CSRF token must NOT be silently
+    /// redirected to `/login`. They must see a full-chrome 403 page so
+    /// they know their action failed and can reload to recover.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authenticated_plain_form_drift_returns_403_full_chrome(
+        pool: crate::db::DbPool,
+    ) {
+        let state = state_with_pool(pool);
+        let token = "real-token";
+        let authenticated = Session {
+            token: Some("sess-xyz".to_string()),
+            user_id: Some(42),
+            role: crate::middleware::auth::Role::Librarian,
+            csrf_token: token.to_string(),
+            preferred_language: None,
+        };
+        let app = build_app(state, authenticated);
+
+        let body = "_csrf_token=wrong";
+        let req = HttpRequest::post("/echo")
+            .header("content-type", "application/x-www-form-urlencoded")
+            // No hx-request header → plain-browser submission path
+            .body(AxumBody::from(body))
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        // Cache-Control: no-store ensures the 403 page does not get
+        // served from the browser back-cache.
+        assert_eq!(
+            res.headers().get("cache-control").unwrap(),
+            "no-store"
+        );
+        // Body is the rendered full-chrome HTML, not a 303 redirect.
+        let body_bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+        assert!(
+            body_str.contains("<!DOCTYPE html>"),
+            "expected full-chrome HTML page in 403 body"
+        );
+        assert!(
+            body_str.contains("Reload page") || body_str.contains("Recharger"),
+            "expected reload-CTA i18n string in body"
+        );
+    }
+
+    /// Anonymous-session counterpart of the test above: an anonymous
+    /// visitor who hits a CSRF mismatch on a plain form is still
+    /// redirected to /login (preserves the existing pre-10-2 behaviour
+    /// for the not-yet-authenticated case).
+    #[sqlx::test(migrations = "./migrations")]
+    async fn anonymous_plain_form_drift_keeps_303_to_login(
+        pool: crate::db::DbPool,
+    ) {
+        let state = state_with_pool(pool);
+        let session = Session::anonymous_with_token("real-token".to_string());
+        let app = build_app(state, session);
+
+        let body = "_csrf_token=wrong";
+        let req = HttpRequest::post("/echo")
+            .header("content-type", "application/x-www-form-urlencoded")
+            // No hx-request header → plain-browser submission path
+            .body(AxumBody::from(body))
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        assert_eq!(res.headers().get(header::LOCATION).unwrap(), "/login");
     }
 }

--- a/static/js/session-timeout.js
+++ b/static/js/session-timeout.js
@@ -112,6 +112,20 @@
             fetch("/session/keepalive", {
                 method: "POST",
                 headers: { "X-CSRF-Token": token },
+            }).then(function (r) {
+                // Issue #45 B-M1: if the CSRF token drifted (rotation in
+                // another tab, post-redeploy, browser extension stripping
+                // the meta tag), the keepalive POST returns 403 and the
+                // user's session is effectively unreachable. Don't swallow
+                // the rejection — re-show the warning so the user knows
+                // to reload.
+                if (r && r.status === 403) {
+                    showWarning(0);
+                }
+            }).catch(function () {
+                // Network errors fall through silently — the next user
+                // action will surface the disconnection via the
+                // connection-lost overlay (story 9-16).
             });
         }
         hideWarning();

--- a/templates/pages/csrf_drifted.html
+++ b/templates/pages/csrf_drifted.html
@@ -1,0 +1,17 @@
+{% extends "layouts/bare.html" %}
+
+{% block title %}{{ title }} — mybibli{% endblock %}
+
+{% block content %}
+<div class="min-h-screen flex items-center justify-center px-4">
+    <div class="max-w-lg w-full bg-white dark:bg-stone-800 border border-amber-300 dark:border-amber-700 rounded-lg shadow-md p-6">
+        <h1 class="text-xl font-semibold text-amber-700 dark:text-amber-400 mb-3">{{ title }}</h1>
+        <p class="text-stone-700 dark:text-stone-300 mb-5">{{ message }}</p>
+        <form method="GET" action="/" class="contents">
+            <button type="submit" class="inline-flex items-center px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2">
+                {{ reload_button }}
+            </button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/tests/e2e/specs/security/csrf.spec.ts
+++ b/tests/e2e/specs/security/csrf.spec.ts
@@ -129,4 +129,34 @@ test.describe("Story 8-2 smoke — CSRF", () => {
     await frButton.click();
     await expect(page).toHaveURL(/\/$/);
   });
+
+  /**
+   * Story 10-2 (issue #45 H4): an authenticated user whose plain-form POST
+   * drifts on the CSRF token sees a full-chrome 403 page with a Reload CTA,
+   * NOT a silent 303 → /login → / redirect that eats the action.
+   */
+  test("authenticated plain-form CSRF drift renders 403 full-chrome page", async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+    await page.goto("/catalog");
+
+    // Plain form POST with a wrong `_csrf_token` body, no `hx-request` header.
+    // Routes the middleware down the authenticated-form-drift branch.
+    const response = await page.request.post("/language", {
+      form: { _csrf_token: "tampered-by-test", next: "/catalog", lang: "fr" },
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(403);
+    // The response is a full HTML page, not a 303 redirect — body must
+    // contain a doctype and the EN/FR reload-CTA i18n strings.
+    const body = await response.text();
+    expect(body).toContain("<!DOCTYPE html>");
+    expect(body).toMatch(/Reload page|Recharger la page/);
+    // Cache-Control: no-store prevents the browser back-cache from serving
+    // a stale rejection after the user reloads and re-establishes a session.
+    expect(response.headers()["cache-control"]).toBe("no-store");
+  });
 });


### PR DESCRIPTION
Closes #45. Story 10-2 of Epic 10 (Mobile UX & sécurité closeout).

## Three deliverables per AC

### 1. Authenticated CSRF drift → full-chrome 403 (was: silent 303 → /login → /)

`build_rejection_response` in `src/middleware/csrf.rs` now takes `session: Option<&Session>` and differentiates the plain-form non-HTMX path:

- **Authenticated session** → renders a full-chrome 403 page (`templates/pages/csrf_drifted.html` extending `bare.html`) with a localized banner + "Reload page" CTA. The user finally learns their action failed and gets a clear recovery action.
- **Anonymous session** → keeps the previous 303 → `/login` (login is the natural recovery surface for a not-yet-authed visitor).

3 new i18n keys in `locales/{en,fr}.yml`: `error.csrf_session_drifted_title`, `_message`, `_reload_button`.

### 2. `session-timeout.js` fetch fallback handles 403

The bare-`fetch()` keepalive path now inspects `r.status === 403` and re-shows the warning toast so the user knows their session is effectively unreachable. Network errors fall through to the connection-lost overlay (story 9-16) as before — `.catch(...)` is a no-op since 9-16 already owns that surface.

### 3. Mobile-nav logout — already shipped

Issue #150 already added the POST `/logout` form to the mobile nav menu's `{% if role != "anonymous" %}` branch with the CSRF hidden input. E2E coverage exists in `tests/e2e/specs/journeys/navbar-role-visibility.spec.ts` (3 tests asserting `form[action='/logout']` count per role). No code change needed here — sub-AC retained for completeness and documented in the commit body.

## Tests

### Unit (lib)

Two new tests in `src/middleware/csrf.rs`:

- `authenticated_plain_form_drift_returns_403_full_chrome` — Session with `user_id: Some(42)`, role Librarian, plain `application/x-www-form-urlencoded` body, no `hx-request` header → expects status 403, `Cache-Control: no-store`, body contains `<!DOCTYPE html>` + reload CTA i18n
- `anonymous_plain_form_drift_keeps_303_to_login` — Same shape, anonymous session → preserves the existing 303 → /login behaviour

Full lib suite: 791 / 791 passing locally.

### E2E

New spec in `tests/e2e/specs/security/csrf.spec.ts`:

- `authenticated plain-form CSRF drift renders 403 full-chrome page` — logs in as admin, POSTs `/language` with `_csrf_token=tampered-by-test`, asserts 403 + doctype + reload-CTA text + `no-store` cache header

Existing CSRF spec (`csrf.spec.ts`): 7 / 7 passing on the rebuilt stack.
NavBar role-visibility spec (covers mobile logout from #150): 3 / 3 passing.

### Sprint status

`sprint-status.yaml` transition for 10-2 (`backlog → done`) lands in this PR per Foundation Rule #16.

## Test plan

- [ ] CI green on `cargo clippy`, `cargo test` (lib + DB-backed), Playwright E2E
- [ ] Manual smoke: leave a tab open with the FR/EN button. Tamper the meta CSRF token via DevTools → click FR. Expected: full-chrome 403 with reload CTA, not a redirect to /.
- [ ] Manual smoke (mobile viewport): click the hamburger menu → click "Log out" → expected to land on `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)