### PR TITLE
Story 10-3: mobile DataTable card mode (closes #159)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-29
-# last_updated: 2026-05-14 (Story 10-2 → done — CSRF drift full-chrome page closes #45)
+# last_updated: 2026-05-14 (Story 10-3 → done — mobile DataTable card mode closes #159)
 # project: mybibli
 # project_key: NOKEY
 # tracking_system: file-system
@@ -196,7 +196,7 @@ development_status:
   epic-10: backlog
   10-1-auth-threat-model-doc: done
   10-2-csrf-rejection-ux-and-mobile-logout: done
-  10-3-mobile-datatable-card-mode: backlog
+  10-3-mobile-datatable-card-mode: done
   10-4-admin-tabs-mobile-dropdown: backlog
   10-5-a11y-entity-detail-coverage: backlog
   epic-10-retrospective: backlog

--- a/src/routes/borrowers.rs
+++ b/src/routes/borrowers.rs
@@ -592,4 +592,150 @@ mod tests {
         assert_eq!(form.name, "Marie");
         assert_eq!(form.phone.as_deref(), Some("+33612345678"));
     }
+
+    /// Story 10-3: the borrowers list page must render both the
+    /// mobile-card list (md:hidden) and the desktop table (hidden
+    /// md:block) with the same borrower data.
+    #[test]
+    fn borrowers_template_renders_both_mobile_cards_and_desktop_table() {
+        use crate::models::PaginatedList;
+        use askama::Template;
+        let borrower = BorrowerModel {
+            id: 11,
+            name: "Mobile-List-User".to_string(),
+            email: Some("mobile@example.com".to_string()),
+            phone: Some("+33611111111".to_string()),
+            address: None,
+            version: 1,
+        };
+        let template = BorrowersTemplate {
+            lang: "en".to_string(),
+            role: "librarian".to_string(),
+            current_page: "borrowers",
+            skip_label: "Skip".to_string(),
+            connection_status: crate::utils::ConnectionStatusContext::new("en"),
+            shortcuts_cheat_sheet: crate::utils::ShortcutsCheatSheetContext::new("en"),
+            session_timeout_secs: 1800,
+            csrf_token: "tok".to_string(),
+            nav_catalog: "Catalog".to_string(),
+            nav_loans: "Loans".to_string(),
+            nav_locations: "Locations".to_string(),
+            nav_series: "Series".to_string(),
+            nav_borrowers: "Borrowers".to_string(),
+            nav_admin: "Admin".to_string(),
+            nav_login: "Log in".to_string(),
+            nav_logout: "Log out".to_string(),
+            nav_menu_open: "Open menu".to_string(),
+            list_title: "Borrowers".to_string(),
+            add_label: "Add".to_string(),
+            name_label: "Name".to_string(),
+            email_label: "Email".to_string(),
+            phone_label: "Phone".to_string(),
+            address_label: "Address".to_string(),
+            save_label: "Save".to_string(),
+            cancel_label: "Cancel".to_string(),
+            empty_heading: "No borrowers".to_string(),
+            empty_body: "Add one".to_string(),
+            empty_cta: "Add".to_string(),
+            prev_label: "Previous".to_string(),
+            next_label: "Next".to_string(),
+            pagination_aria: "Pagination".to_string(),
+            borrowers: PaginatedList::new(vec![borrower], 1, 1, None, None, None),
+            current_url: "/borrowers".to_string(),
+            lang_toggle_aria: "Change language".to_string(),
+            email_help: crate::utils::TooltipData::placeholder_only("borrower-email-help", "Email"),
+            phone_help: crate::utils::TooltipData::placeholder_only("borrower-phone-help", "Phone"),
+        };
+        let html = template.render().unwrap();
+
+        assert!(html.contains(r#"id="borrowers-cards-mobile""#));
+        assert!(html.contains(r#"id="borrower-card-11""#));
+        assert!(html.contains(r#"class="md:hidden"#));
+        assert!(html.contains(r#"class="hidden md:block overflow-x-auto""#));
+        // Same data in both surfaces (the borrower name appears in both)
+        assert_eq!(
+            html.matches("Mobile-List-User").count(),
+            2,
+            "borrower name must appear in both card and row"
+        );
+    }
+
+    /// Story 10-3: borrower-detail page's active-loans section must
+    /// render both the mobile-card list and the desktop table.
+    #[test]
+    fn borrower_detail_active_loans_renders_both_surfaces() {
+        use askama::Template;
+        let borrower = BorrowerModel {
+            id: 22,
+            name: "Detail-User".to_string(),
+            email: None,
+            phone: None,
+            address: None,
+            version: 1,
+        };
+        let loan = LoanWithDetails {
+            id: 99,
+            volume_id: 500,
+            borrower_id: 22,
+            borrower_name: "Detail-User".to_string(),
+            volume_label: "V0099".to_string(),
+            title_name: "Detail Test Book".to_string(),
+            loaned_at: chrono::NaiveDate::from_ymd_opt(2026, 5, 14)
+                .unwrap()
+                .and_hms_opt(9, 0, 0)
+                .unwrap(),
+            duration_days: 1,
+        };
+        let template = BorrowerDetailTemplate {
+            lang: "en".to_string(),
+            role: "librarian".to_string(),
+            current_page: "borrowers",
+            skip_label: "Skip".to_string(),
+            connection_status: crate::utils::ConnectionStatusContext::new("en"),
+            shortcuts_cheat_sheet: crate::utils::ShortcutsCheatSheetContext::new("en"),
+            session_timeout_secs: 1800,
+            csrf_token: "tok".to_string(),
+            nav_catalog: "Catalog".to_string(),
+            nav_loans: "Loans".to_string(),
+            nav_locations: "Locations".to_string(),
+            nav_series: "Series".to_string(),
+            nav_borrowers: "Borrowers".to_string(),
+            nav_admin: "Admin".to_string(),
+            nav_login: "Log in".to_string(),
+            nav_logout: "Log out".to_string(),
+            nav_menu_open: "Open menu".to_string(),
+            borrower,
+            address_label: "Address".to_string(),
+            email_label: "Email".to_string(),
+            phone_label: "Phone".to_string(),
+            edit_label: "Edit".to_string(),
+            delete_label: "Delete".to_string(),
+            active_loans: vec![loan],
+            active_loans_label: "Active loans".to_string(),
+            no_active_loans_label: "No active loans".to_string(),
+            overdue_threshold: 30,
+            days_label: "days".to_string(),
+            return_label: "Return".to_string(),
+            overdue_label: "Overdue".to_string(),
+            col_volume: "V-code".to_string(),
+            col_title: "Title".to_string(),
+            col_date: "Date".to_string(),
+            col_duration: "Duration".to_string(),
+            col_action: "Action".to_string(),
+            current_url: "/borrower/22".to_string(),
+            lang_toggle_aria: "Change language".to_string(),
+        };
+        let html = template.render().unwrap();
+
+        assert!(html.contains(r#"id="borrower-loans-cards-mobile""#));
+        assert!(html.contains(r#"id="borrower-loan-card-99""#));
+        assert!(html.contains(r#"class="md:hidden"#));
+        assert!(html.contains(r#"class="hidden md:block overflow-x-auto""#));
+        // Same V-code appears in both card and table
+        assert_eq!(
+            html.matches("V0099").count(),
+            2,
+            "volume label must appear in both card and row"
+        );
+    }
 }

--- a/src/routes/loans.rs
+++ b/src/routes/loans.rs
@@ -564,4 +564,115 @@ mod tests {
         assert!(!html.contains("<script>"));
         assert!(html.contains("&amp;"));
     }
+
+    /// Story 10-3: build a minimal LoansTemplate with one loan for
+    /// the mobile-cards rendering tests below.
+    fn build_loans_template_for_test(loan: LoanWithDetails) -> LoansTemplate {
+        use crate::models::PaginatedList;
+        LoansTemplate {
+            lang: "en".to_string(),
+            role: "librarian".to_string(),
+            current_page: "loans",
+            skip_label: "Skip".to_string(),
+            connection_status: crate::utils::ConnectionStatusContext::new("en"),
+            shortcuts_cheat_sheet: crate::utils::ShortcutsCheatSheetContext::new("en"),
+            session_timeout_secs: 1800,
+            csrf_token: "tok".to_string(),
+            nav_catalog: "Catalog".to_string(),
+            nav_loans: "Loans".to_string(),
+            nav_locations: "Locations".to_string(),
+            nav_series: "Series".to_string(),
+            nav_borrowers: "Borrowers".to_string(),
+            nav_admin: "Admin".to_string(),
+            nav_login: "Log in".to_string(),
+            nav_logout: "Log out".to_string(),
+            nav_menu_open: "Open menu".to_string(),
+            list_title: "Loans".to_string(),
+            new_loan_label: "New".to_string(),
+            volume_label_label: "V-code".to_string(),
+            borrower_label: "Borrower".to_string(),
+            borrower_search_label: "Search".to_string(),
+            register_label: "Register".to_string(),
+            col_borrower: "Borrower".to_string(),
+            col_volume: "V-code".to_string(),
+            col_title: "Title".to_string(),
+            col_date: "Date".to_string(),
+            col_duration: "Duration".to_string(),
+            days_label: "days".to_string(),
+            scan_placeholder: "Scan".to_string(),
+            empty_heading: "No active loans".to_string(),
+            empty_body: "Create one".to_string(),
+            prev_label: "Previous".to_string(),
+            next_label: "Next".to_string(),
+            pagination_aria: "Pagination".to_string(),
+            return_label: "Return".to_string(),
+            overdue_label: "Overdue".to_string(),
+            col_action: "Action".to_string(),
+            overdue_threshold: 30,
+            current_sort: "date".to_string(),
+            current_dir: "desc".to_string(),
+            loans: PaginatedList::new(vec![loan], 1, 1, None, Some("date".to_string()), Some("desc".to_string())),
+            highlight_loan_id: None,
+            current_url: "/loans".to_string(),
+            lang_toggle_aria: "Change language".to_string(),
+        }
+    }
+
+    /// Story 10-3: the loans page must render BOTH the mobile-card list
+    /// (md:hidden) AND the desktop table (hidden md:block), each carrying
+    /// the same loan data, so the layout switches purely via the Tailwind
+    /// breakpoint — no JS, no duplicated data fetch.
+    #[test]
+    fn loans_template_renders_both_mobile_cards_and_desktop_table() {
+        let loan = LoanWithDetails {
+            id: 7,
+            volume_id: 100,
+            borrower_id: 200,
+            borrower_name: "Mobile-Card-User".to_string(),
+            volume_label: "V0007".to_string(),
+            title_name: "Mobile Test Title".to_string(),
+            loaned_at: chrono::NaiveDate::from_ymd_opt(2026, 5, 14)
+                .unwrap()
+                .and_hms_opt(9, 0, 0)
+                .unwrap(),
+            duration_days: 2,
+        };
+        let html = build_loans_template_for_test(loan).render().unwrap();
+
+        // Mobile-cards surface
+        assert!(
+            html.contains(r#"id="loans-cards-mobile""#),
+            "expected mobile-cards container"
+        );
+        assert!(
+            html.contains(r#"id="loan-card-7""#),
+            "expected per-loan card with id"
+        );
+        assert!(
+            html.contains(r#"class="md:hidden"#),
+            "mobile-cards container must be md:hidden"
+        );
+
+        // Desktop table surface
+        assert!(
+            html.contains(r#"class="hidden md:block overflow-x-auto""#),
+            "desktop table wrapper must be hidden md:block"
+        );
+        assert!(
+            html.contains(r#"id="loan-row-7""#),
+            "expected per-loan row with id (desktop)"
+        );
+
+        // Same data in both: borrower name, V-code, title, days
+        assert_eq!(
+            html.matches("Mobile-Card-User").count(),
+            2,
+            "borrower name must appear in both card and row"
+        );
+        assert_eq!(
+            html.matches("V0007").count(),
+            2,
+            "volume label must appear in both surfaces"
+        );
+    }
 }

--- a/templates/pages/borrower_detail.html
+++ b/templates/pages/borrower_detail.html
@@ -48,7 +48,45 @@
         {% if active_loans.is_empty() %}
         <p class="text-sm text-stone-500 dark:text-stone-400">{{ no_active_loans_label }}</p>
         {% else %}
-        <div class="overflow-x-auto">
+        {# Story 10-3 — mobile DataTable card mode (closes #159). #}
+        <div class="md:hidden space-y-3" role="list" id="borrower-loans-cards-mobile">
+            {% for loan in active_loans %}
+            <article id="borrower-loan-card-{{ loan.id }}" role="listitem"
+                     class="rounded-md border border-stone-200 dark:border-stone-700 p-4 bg-white dark:bg-stone-800">
+                <header class="mb-2">
+                    <span class="font-mono font-semibold text-base text-stone-900 dark:text-stone-100">{{ loan.volume_label }}</span>
+                </header>
+                <dl class="text-sm grid grid-cols-2 gap-y-1 gap-x-3">
+                    <dt class="text-stone-500 dark:text-stone-400">{{ col_title }}</dt>
+                    <dd class="text-stone-900 dark:text-stone-100 text-right break-words">{{ loan.title_name }}</dd>
+                    <dt class="text-stone-500 dark:text-stone-400">{{ col_date }}</dt>
+                    <dd class="text-stone-900 dark:text-stone-100 text-right">{{ loan.loaned_at.format("%Y-%m-%d") }}</dd>
+                    <dt class="text-stone-500 dark:text-stone-400">{{ col_duration }}</dt>
+                    <dd class="text-right {% if loan.duration_days >= overdue_threshold %}text-red-600 dark:text-red-400 font-semibold{% elif loan.duration_days >= 14 %}text-amber-600 dark:text-amber-400{% else %}text-stone-900 dark:text-stone-100{% endif %}">
+                        {{ loan.duration_days }} {{ days_label }}
+                        {% if loan.duration_days >= overdue_threshold %}
+                        <span class="ml-1 inline-flex items-center rounded-full bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-300">{{ overdue_label }}</span>
+                        {% endif %}
+                    </dd>
+                </dl>
+                {% if role == "librarian" || role == "admin" %}
+                <div class="mt-3 flex justify-end">
+                    <button hx-get="/loans/{{ loan.id }}/return-modal?target=borrower-feedback"
+                            hx-target="#modal-slot"
+                            hx-swap="innerHTML"
+                            hx-disabled-elt="this"
+                            data-modal-trigger
+                            aria-haspopup="dialog"
+                            aria-expanded="false"
+                            class="px-3 py-1.5 text-sm font-medium text-white bg-indigo-600 rounded hover:bg-indigo-700 disabled:opacity-50">
+                        {{ return_label }}
+                    </button>
+                </div>
+                {% endif %}
+            </article>
+            {% endfor %}
+        </div>
+        <div class="hidden md:block overflow-x-auto">
             <table class="min-w-full text-sm">
                 <thead>
                     <tr class="border-b border-stone-200 dark:border-stone-700 text-left">

--- a/templates/pages/borrowers.html
+++ b/templates/pages/borrowers.html
@@ -62,7 +62,24 @@
         role,
     ) %}{% endcall %}
     {% else %}
-    <div class="overflow-x-auto">
+    {# Story 10-3 — mobile DataTable card mode (closes #159). #}
+    <div class="md:hidden space-y-3" role="list" id="borrowers-cards-mobile">
+        {% for b in borrowers.items %}
+        <article id="borrower-card-{{ b.id }}" role="listitem"
+                 class="rounded-md border border-stone-200 dark:border-stone-700 p-4 bg-white dark:bg-stone-800">
+            <header class="mb-2">
+                <a href="/borrower/{{ b.id }}" class="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold text-base">{{ b.name }}</a>
+            </header>
+            <dl class="text-sm grid grid-cols-[auto_1fr] gap-y-1 gap-x-3">
+                <dt class="text-stone-500 dark:text-stone-400">{{ email_label }}</dt>
+                <dd class="text-stone-900 dark:text-stone-100 text-right break-words">{{ b.email.as_deref().unwrap_or("-") }}</dd>
+                <dt class="text-stone-500 dark:text-stone-400">{{ phone_label }}</dt>
+                <dd class="text-stone-900 dark:text-stone-100 text-right">{{ b.phone.as_deref().unwrap_or("-") }}</dd>
+            </dl>
+        </article>
+        {% endfor %}
+    </div>
+    <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm">
             <thead>
                 <tr class="border-b border-stone-200 dark:border-stone-700 text-left">

--- a/templates/pages/loans.html
+++ b/templates/pages/loans.html
@@ -86,7 +86,51 @@
         role,
     ) %}{% endcall %}
     {% else %}
-    <div class="overflow-x-auto">
+    {# Story 10-3 — mobile DataTable card mode (closes #159).
+       Desktop keeps the table; mobile renders the same data as stacked
+       cards. The two surfaces are mutually exclusive via the md
+       breakpoint, share zero JS, and carry the same data so the
+       sort/page query params already on `/loans` apply identically. #}
+    <div class="md:hidden space-y-3" role="list" id="loans-cards-mobile">
+        {% for loan in loans.items %}
+        <article id="loan-card-{{ loan.id }}" role="listitem"
+                 class="rounded-md border border-stone-200 dark:border-stone-700 p-4 bg-white dark:bg-stone-800{% if highlight_loan_id.is_some() && highlight_loan_id.unwrap() == loan.id %} ring-2 ring-yellow-400 dark:ring-yellow-500{% endif %}">
+            <header class="mb-2">
+                <a href="/borrower/{{ loan.borrower_id }}" class="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold text-base">{{ loan.borrower_name }}</a>
+            </header>
+            <dl class="text-sm grid grid-cols-2 gap-y-1 gap-x-3">
+                <dt class="text-stone-500 dark:text-stone-400">{{ col_volume }}</dt>
+                <dd class="text-stone-900 dark:text-stone-100 text-right font-mono">{{ loan.volume_label }}</dd>
+                <dt class="text-stone-500 dark:text-stone-400">{{ col_title }}</dt>
+                <dd class="text-stone-900 dark:text-stone-100 text-right break-words">{{ loan.title_name }}</dd>
+                <dt class="text-stone-500 dark:text-stone-400">{{ col_date }}</dt>
+                <dd class="text-stone-900 dark:text-stone-100 text-right">{{ loan.loaned_at.format("%Y-%m-%d") }}</dd>
+                <dt class="text-stone-500 dark:text-stone-400">{{ col_duration }}</dt>
+                <dd class="text-right {% if loan.duration_days >= overdue_threshold %}text-red-600 dark:text-red-400 font-semibold{% elif loan.duration_days >= 14 %}text-amber-600 dark:text-amber-400{% else %}text-stone-900 dark:text-stone-100{% endif %}">
+                    {{ loan.duration_days }} {{ days_label }}
+                    {% if loan.duration_days >= overdue_threshold %}
+                    <span class="ml-1 inline-flex items-center rounded-full bg-red-100 dark:bg-red-900/30 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-300">{{ overdue_label }}</span>
+                    {% endif %}
+                </dd>
+            </dl>
+            {% if role == "librarian" || role == "admin" %}
+            <div class="mt-3 flex justify-end">
+                <button hx-get="/loans/{{ loan.id }}/return-modal?target=loan-feedback"
+                        hx-target="#modal-slot"
+                        hx-swap="innerHTML"
+                        hx-disabled-elt="this"
+                        data-modal-trigger
+                        aria-haspopup="dialog"
+                        aria-expanded="false"
+                        class="px-3 py-1.5 text-sm font-medium text-white bg-indigo-600 rounded hover:bg-indigo-700 disabled:opacity-50">
+                    {{ return_label }}
+                </button>
+            </div>
+            {% endif %}
+        </article>
+        {% endfor %}
+    </div>
+    <div class="hidden md:block overflow-x-auto">
         <table class="min-w-full text-sm">
             <thead>
                 <tr class="border-b border-stone-200 dark:border-stone-700 text-left">

--- a/tests/e2e/helpers/loans.ts
+++ b/tests/e2e/helpers/loans.ts
@@ -72,12 +72,14 @@ export async function createBorrower(page: Page, name: string): Promise<void> {
   await page.locator("#new-name").fill(name);
   await page.locator('main button[type="submit"]').last().click();
   // Assertion-as-wait: the borrower anchor appearing in the list confirms
-  // the server committed the INSERT. Scoped to the actual `/borrower/:id`
-  // anchor so stale DOM (form input echo, nav, breadcrumbs) cannot trip
-  // the wait before the row is visible.
+  // the server committed the INSERT. Scoped to `tbody` so the assertion
+  // works correctly across viewports — story 10-3 added a parallel
+  // mobile-card surface (`md:hidden`) that also carries the borrower
+  // anchor. The `tbody` scope picks only the desktop-table copy, which
+  // is the surface visible at default Playwright viewport (1280x720).
   const exactName = new RegExp(`^\\s*${escapeRegex(name)}\\s*$`);
   await expect(
-    page.locator('a[href^="/borrower/"]').filter({ hasText: exactName }),
+    page.locator('tbody a[href^="/borrower/"]').filter({ hasText: exactName }),
   ).toBeVisible({ timeout: 5000 });
 }
 
@@ -89,8 +91,12 @@ export async function createBorrower(page: Page, name: string): Promise<void> {
  */
 async function getBorrowerIdByName(page: Page, name: string): Promise<string> {
   await page.goto("/borrowers");
+  // Scoped to `tbody` (story 10-3): the borrowers list now renders the
+  // same row in two surfaces (desktop table + mobile card list). Counting
+  // matches across both would inflate the count by 2× and break the
+  // ambiguity-detection assertion. Only the table has a `<tbody>`.
   const link = page
-    .locator('a[href^="/borrower/"]')
+    .locator('tbody a[href^="/borrower/"]')
     .filter({ hasText: new RegExp(`^\\s*${escapeRegex(name)}\\s*$`) });
   // Fail loud on ambiguity: if two borrowers share the exact name, .first()
   // would silently pick the wrong id and the loan would be created against
@@ -226,8 +232,12 @@ export async function returnLoanFromBorrowerDetail(
   volumeLabel: string,
 ): Promise<void> {
   const activeLoans = page.locator("#active-loans-section");
+  // Story 10-3: the active-loans section now renders the Return button
+  // in both surfaces (mobile card + desktop table). Scope to `tbody` so
+  // the helper picks the visible desktop-table copy at the default
+  // Playwright viewport (1280x720).
   const returnBtn = activeLoans
-    .locator('button:has-text("Return"), button:has-text("Retourner")')
+    .locator('tbody button:has-text("Return"), tbody button:has-text("Retourner")')
     .first();
   await expect(returnBtn).toBeVisible({ timeout: 3000 });
   await returnBtn.click();

--- a/tests/e2e/specs/journeys/borrower-delete-modal.spec.ts
+++ b/tests/e2e/specs/journeys/borrower-delete-modal.spec.ts
@@ -26,9 +26,11 @@ test.describe("Borrower delete modal (Story 9-10)", () => {
 
     await createBorrower(page, NAME);
 
-    // Navigate to borrower detail.
+    // Navigate to borrower detail. Story 10-3 added a mobile-card surface
+    // that also carries the borrower link; scope to `tbody` so the
+    // desktop-table copy is the unambiguous click target.
     const link = page
-      .locator('a[href^="/borrower/"]')
+      .locator('tbody a[href^="/borrower/"]')
       .filter({ hasText: new RegExp(`^\\s*${NAME}\\s*$`) });
     await link.click();
     await expect(page.locator("h1")).toContainText(NAME, { timeout: 5000 });

--- a/tests/e2e/specs/journeys/borrower-loans.spec.ts
+++ b/tests/e2e/specs/journeys/borrower-loans.spec.ts
@@ -20,7 +20,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
     await createBorrower(page, "BL-Detail Borrower");
 
     // Navigate to borrower detail
-    await page.getByText("BL-Detail Borrower").click();
+    await page.locator("tbody").getByText("BL-Detail Borrower").click();
     await expect(page.locator("h1")).toContainText("BL-Detail Borrower", {
       timeout: 3000,
     });
@@ -44,7 +44,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
 
     // Navigate to borrower detail
     await page.goto("/borrowers");
-    await page.getByText("BL-Loan Detail Borrower").click();
+    await page.locator("tbody").getByText("BL-Loan Detail Borrower").click();
     await expect(page.locator("h1")).toContainText("BL-Loan Detail Borrower", {
       timeout: 3000,
     });
@@ -52,9 +52,10 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
     // Should show the loan with volume label and title
     await expect(page.locator("body")).toContainText("V0080", { timeout: 5000 });
 
-    // Should show Return button
+    // Should show Return button — story 10-3 scope to tbody so the
+    // desktop-table copy (visible at default viewport) is asserted.
     const returnBtn = page.locator(
-      'button:has-text("Return"), button:has-text("Retourner")',
+      'tbody button:has-text("Return"), tbody button:has-text("Retourner")',
     );
     await expect(returnBtn.first()).toBeVisible({ timeout: 3000 });
   });
@@ -67,7 +68,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
 
     // Navigate to borrower detail
     await page.goto("/borrowers");
-    await page.getByText("BL-Return Detail Borrower").click();
+    await page.locator("tbody").getByText("BL-Return Detail Borrower").click();
     await expect(page.locator("#active-loans-section")).toContainText("V0081", {
       timeout: 5000,
     });
@@ -102,7 +103,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
 
     // Navigate to borrower detail — should see loan
     await page.goto("/borrowers");
-    await page.getByText("BL-Smoke Detail Borrower").click();
+    await page.locator("tbody").getByText("BL-Smoke Detail Borrower").click();
     const activeLoans = page.locator("#active-loans-section");
     await expect(activeLoans).toContainText("V0082", { timeout: 5000 });
 

--- a/tests/e2e/specs/journeys/mobile-datatable-cards.spec.ts
+++ b/tests/e2e/specs/journeys/mobile-datatable-cards.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Story 10-3 (closes #159) — Mobile DataTable card mode.
+ *
+ * `/loans`, `/borrowers` and `/borrower/:id` now render the same row
+ * data twice: a desktop table (`hidden md:block`) and a mobile-card
+ * list (`md:hidden`). At the mobile breakpoint (< 768px) only the
+ * cards are visible; at md+ only the table is.
+ *
+ * Spec ID "MC" — never scans an ISBN in this file but the convention
+ * stands for any future addition.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import {
+  scanTitleAndVolume,
+  createBorrower,
+  createLoan,
+} from "../../helpers/loans";
+import { specIsbn } from "../../helpers/isbn";
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
+
+test.describe("Story 10-3 — mobile DataTable card mode", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page);
+  });
+
+  test("/loans renders cards on mobile, table on desktop (same loan in both)", async ({
+    page,
+  }) => {
+    // Seed: borrower + title + volume + loan.
+    const isbn = specIsbn("MC", 1);
+    const volumeLabel = "V8001";
+    const borrowerName = "MC-Loans-User-1";
+    await scanTitleAndVolume(page, isbn, volumeLabel);
+    await createBorrower(page, borrowerName);
+    await createLoan(page, volumeLabel, borrowerName);
+
+    // Mobile viewport — cards visible, table hidden.
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/loans");
+    const mobileCards = page.locator("#loans-cards-mobile");
+    await expect(mobileCards).toBeVisible();
+    await expect(
+      mobileCards.locator("article", { hasText: borrowerName }),
+    ).toBeVisible();
+    await expect(page.locator("#loans-table-body")).not.toBeVisible();
+
+    // Desktop viewport — table visible, cards hidden.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.reload();
+    await expect(page.locator("#loans-table-body")).toBeVisible();
+    await expect(page.locator("#loans-cards-mobile")).not.toBeVisible();
+  });
+
+  test("/borrowers renders mobile cards on small viewport", async ({
+    page,
+  }) => {
+    await createBorrower(page, "MC-Borrower-User-2");
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/borrowers");
+    const mobileCards = page.locator("#borrowers-cards-mobile");
+    await expect(mobileCards).toBeVisible();
+    await expect(
+      mobileCards.locator("article", { hasText: "MC-Borrower-User-2" }),
+    ).toBeVisible();
+  });
+
+  test("/borrower/:id renders the active-loans mobile cards", async ({
+    page,
+  }) => {
+    // Seed: borrower + title + volume + loan
+    const isbn = specIsbn("MC", 3);
+    const volumeLabel = "V8003";
+    const borrowerName = "MC-Borrower-Detail-User-3";
+    await scanTitleAndVolume(page, isbn, volumeLabel);
+    await createBorrower(page, borrowerName);
+    await createLoan(page, volumeLabel, borrowerName);
+
+    // Resolve the borrower's detail URL via the /borrowers list
+    await page.goto("/borrowers");
+    const link = page.locator(`a:has-text("${borrowerName}")`).first();
+    const href = await link.getAttribute("href");
+    expect(href).toMatch(/\/borrower\/\d+/);
+
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto(href!);
+
+    const mobileCards = page.locator("#borrower-loans-cards-mobile");
+    await expect(mobileCards).toBeVisible();
+    await expect(
+      mobileCards.locator("article", { hasText: volumeLabel }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #159. Story 10-3 of Epic 10 (Mobile UX & sécurité closeout).

## What ships

Three pages now render the same row data twice — desktop table (\`hidden md:block\`) AND mobile card list (\`md:hidden\`) — switched purely via the Tailwind \`md\` breakpoint:

- \`/loans\` — \`#loans-cards-mobile\` parallels \`#loans-table-body\`
- \`/borrowers\` — \`#borrowers-cards-mobile\` parallels the table
- \`/borrower/:id\` — \`#borrower-loans-cards-mobile\` parallels the active-loans table

Card layout is consistent across surfaces: primary identifier in the header (borrower name as link, V-code as mono span), then a 2-column \`<dl>\` grid of fields, then an actions row (Return modal trigger when present). Overdue/amber colour rules on the duration field are preserved.

## Spec scope adjustment

Epic 10 spec listed \`/title/:id\` volumes as the third surface. On inspection, \`TitleDetailTemplate\` exposes only a \`volume_count: u64\` — there is no volumes list/table on that page. Re-targeted to \`/borrower/:id\`'s active-loans table, which carries the same loan-row shape as \`/loans\` and is the natural sibling. The Epic 10 retrospective will note this spec-vs-reality drift.

## Tests

### Unit (lib) — 3 new

- \`routes::loans::tests::loans_template_renders_both_mobile_cards_and_desktop_table\`
- \`routes::borrowers::tests::borrowers_template_renders_both_mobile_cards_and_desktop_table\`
- \`routes::borrowers::tests::borrower_detail_active_loans_renders_both_surfaces\`

Full lib suite: **794 / 794** passing locally.

### E2E — new spec + helper fixes

\`tests/e2e/specs/journeys/mobile-datatable-cards.spec.ts\` (spec ID \`MC\`) — 3 tests:

- \`/loans\` at 375×667 → mobile cards visible, table hidden; at 1280×800 → table visible, cards hidden
- \`/borrowers\` at 375×667 → cards visible
- \`/borrower/:id\` at 375×667 → active-loans cards visible

**Helper updates** (\`tests/e2e/helpers/loans.ts\`) — scoped to \`tbody\` so dual-surface DOM doesn't trip strict-mode locators:

- \`createBorrower\` post-insert assertion
- \`getBorrowerIdByName\`
- \`returnLoanFromBorrowerDetail\` Return-button locator

\`returnLoanFromLoansPage\` was already scoped to \`#loans-table-body\` — no change needed.

**Spec updates** — 2 existing files patched (6 sites total) to scope \`getByText\`/\`<a href>\` locators to \`tbody\`:

- \`tests/e2e/specs/journeys/borrower-loans.spec.ts\` (5 sites)
- \`tests/e2e/specs/journeys/borrower-delete-modal.spec.ts\` (1 site)

Full Playwright suite: **246 / 246** passing (2 skipped, pre-existing).

### Sprint status

10-3 \`backlog → done\` transition in this PR per Foundation Rule #16.

## Test plan

- [ ] CI green on Rust + Playwright + clippy
- [ ] Manual smoke at mobile viewport (Chrome devtools → 375 width): visit /loans → cards stacked, all loan info visible without horizontal scroll
- [ ] Manual smoke at desktop: visit /loans → table layout unchanged from pre-10-3
- [ ] Manual a11y: keyboard-navigate the card stack on mobile (Tab → links → Enter → /borrower/:id navigates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)