### PR TITLE
Story 10-4: admin tabs mobile dropdown

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-29
-# last_updated: 2026-05-14 (Story 10-3 → done — mobile DataTable card mode closes #159)
+# last_updated: 2026-05-15 (Story 10-4 → done — admin tabs mobile dropdown)
 # project: mybibli
 # project_key: NOKEY
 # tracking_system: file-system
@@ -197,6 +197,6 @@ development_status:
   10-1-auth-threat-model-doc: done
   10-2-csrf-rejection-ux-and-mobile-logout: done
   10-3-mobile-datatable-card-mode: done
-  10-4-admin-tabs-mobile-dropdown: backlog
+  10-4-admin-tabs-mobile-dropdown: done
   10-5-a11y-entity-detail-coverage: backlog
   epic-10-retrospective: backlog

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -1684,4 +1684,87 @@ mod tests {
                 .is_ok()
         );
     }
+
+    // ─── Story 10-4: admin tabs mobile dropdown ─────────────
+
+    /// Build an AdminShellTemplate with all 5 tabs and the named tab
+    /// marked active, for use by the rendering tests below.
+    fn admin_shell_with_active(active: AdminTab) -> AdminShellTemplate {
+        let mk = |tab: AdminTab, label: &str, badge: i64| AdminTabItem {
+            name: tab.as_str(),
+            hx_path: tab.hx_path(),
+            label: label.to_string(),
+            aria_selected: tab == active,
+            badge_count: badge,
+            badge_aria: format!("{} {}", label, badge),
+        };
+        AdminShellTemplate {
+            tabs: vec![
+                mk(AdminTab::Health, "Health", 0),
+                mk(AdminTab::Users, "Users", 0),
+                mk(AdminTab::ReferenceData, "Reference data", 0),
+                mk(AdminTab::Trash, "Trash", 3),
+                mk(AdminTab::System, "System", 0),
+            ],
+            tabs_aria: "Admin tabs".to_string(),
+            active_tab_name: active.as_str(),
+            panel_html: "<p>panel body</p>".to_string(),
+        }
+    }
+
+    /// Story 10-4 (closes #160): admin_tabs.html must render BOTH the
+    /// mobile <select> dropdown (md:hidden) AND the desktop tablist
+    /// (hidden md:flex). Both surfaces target the same #admin-shell
+    /// endpoint so swap behaviour is identical from either path.
+    #[test]
+    fn admin_shell_renders_mobile_select_and_desktop_tablist() {
+        use askama::Template;
+        let html = admin_shell_with_active(AdminTab::Health).render().unwrap();
+        // Mobile dropdown surface
+        assert!(
+            html.contains(r#"id="admin-tab-select""#),
+            "mobile <select> must carry the well-known id"
+        );
+        assert!(
+            html.contains(r#"<div class="md:hidden mb-6""#),
+            "mobile wrapper must be md:hidden"
+        );
+        // HTMX wiring (per AC: name=tab, hx-get=/admin, change trigger,
+        // push-url so back/forward work)
+        assert!(html.contains(r#"name="tab""#));
+        assert!(html.contains(r#"hx-get="/admin""#));
+        assert!(html.contains(r#"hx-trigger="change""#));
+        assert!(html.contains(r##"hx-target="#admin-shell""##));
+        assert!(html.contains(r#"hx-push-url="true""#));
+        // Desktop tablist surface
+        assert!(
+            html.contains(r#"class="hidden md:flex"#),
+            "desktop tablist must be hidden md:flex"
+        );
+        assert!(html.contains(r#"role="tablist""#));
+    }
+
+    /// The selected tab must be reflected in BOTH the desktop tablist
+    /// (aria-selected="true") and the mobile dropdown (`<option ... selected>`).
+    #[test]
+    fn admin_shell_selected_tab_is_reflected_in_both_surfaces() {
+        use askama::Template;
+        let html = admin_shell_with_active(AdminTab::Trash).render().unwrap();
+        // Desktop: aria-selected="true" on the Trash tab anchor
+        assert!(
+            html.contains(r#"id="tab-trash""#) && html.contains(r#"aria-selected="true""#),
+            "Trash tab anchor must carry aria-selected=true on desktop"
+        );
+        // Mobile: the Trash option carries `selected`. We pin the exact
+        // string so a regression that drops the attribute fails loudly.
+        assert!(
+            html.contains(r#"<option value="trash" selected>"#),
+            "Trash option must carry the `selected` attribute in the mobile dropdown"
+        );
+        // Badge count surfaces in the option label too (Trash carries 3)
+        assert!(
+            html.contains("Trash (3)"),
+            "option label must include the badge count in parens"
+        );
+    }
 }

--- a/templates/components/admin_tabs.html
+++ b/templates/components/admin_tabs.html
@@ -1,6 +1,30 @@
 {# Admin tab bar + panel wrapper (story 8-1). Rendered Rust-side via
-   `AdminShellTemplate` and returned verbatim on HTMX swaps into #admin-shell. #}
-<div role="tablist" aria-label="{{ tabs_aria }}" class="border-b border-stone-200 dark:border-stone-700 flex flex-wrap gap-2 mb-6">
+   `AdminShellTemplate` and returned verbatim on HTMX swaps into #admin-shell.
+
+   Story 10-4 (closes #160): on narrow viewports (< md) the tablist is
+   replaced by a <select> dropdown so the tabs stay on a single visual row.
+   Both surfaces target the same #admin-shell endpoint so a swap from
+   either path lands the new shell render. #}
+<div class="md:hidden mb-6">
+    <label for="admin-tab-select" class="sr-only">{{ tabs_aria }}</label>
+    <select id="admin-tab-select"
+            name="tab"
+            hx-get="/admin"
+            hx-trigger="change"
+            hx-target="#admin-shell"
+            hx-swap="innerHTML"
+            hx-push-url="true"
+            class="w-full px-3 py-2 border border-stone-300 dark:border-stone-600 rounded-md bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 text-sm focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2">
+    {% for tab in tabs %}
+        {% if tab.aria_selected %}
+        <option value="{{ tab.name }}" selected>{{ tab.label }}{% if tab.badge_count > 0 %} ({{ tab.badge_count }}){% endif %}</option>
+        {% else %}
+        <option value="{{ tab.name }}">{{ tab.label }}{% if tab.badge_count > 0 %} ({{ tab.badge_count }}){% endif %}</option>
+        {% endif %}
+    {% endfor %}
+    </select>
+</div>
+<div role="tablist" aria-label="{{ tabs_aria }}" class="hidden md:flex border-b border-stone-200 dark:border-stone-700 flex-wrap gap-2 mb-6">
 {% for tab in tabs %}
     {% if tab.aria_selected %}
     <a role="tab"

--- a/tests/e2e/specs/journeys/admin-mobile-dropdown.spec.ts
+++ b/tests/e2e/specs/journeys/admin-mobile-dropdown.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Story 10-4 (closes #160) — Admin tabs render as a <select> on mobile.
+ *
+ * Foundation Rule #7 envelope: blank browser, real loginAs, real HTMX
+ * round-trips. The two viewports exercise both surfaces (the desktop
+ * tablist is hidden on mobile, and vice versa).
+ *
+ * Spec ID "AM" — no ISBNs generated.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
+
+test.describe("Story 10-4 — admin tabs mobile dropdown", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test("mobile viewport: <select> visible, desktop tablist hidden, Health selected by default", async ({
+    page,
+  }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/admin");
+
+    const dropdown = page.locator("#admin-tab-select");
+    await expect(dropdown).toBeVisible();
+    // Health is the default landing tab.
+    await expect(dropdown).toHaveValue("health");
+    // Desktop tablist is not visible at mobile breakpoint.
+    await expect(page.locator('[role="tablist"]')).not.toBeVisible();
+  });
+
+  test("desktop viewport: tablist visible, <select> hidden", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/admin");
+    await expect(page.locator('[role="tablist"]')).toBeVisible();
+    await expect(page.locator("#admin-tab-select")).not.toBeVisible();
+  });
+
+  test("mobile dropdown change → URL updates, panel swaps to the new tab", async ({
+    page,
+  }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/admin");
+
+    const dropdown = page.locator("#admin-tab-select");
+    await dropdown.selectOption("users");
+
+    // hx-push-url=true updates the address bar via HX-Push-Url
+    await page.waitForURL(/\/admin(\?tab=users)?/, { timeout: 5000 });
+    // Panel content reflects the new tab — Users panel has the create-user
+    // CTA somewhere; the panel-id is the most stable assertion target.
+    await expect(page.locator("#panel-users")).toBeVisible({ timeout: 5000 });
+    // The dropdown's value tracks the new selection after the swap.
+    await expect(page.locator("#admin-tab-select")).toHaveValue("users");
+  });
+});

--- a/tests/e2e/specs/journeys/borrowers.spec.ts
+++ b/tests/e2e/specs/journeys/borrowers.spec.ts
@@ -83,7 +83,7 @@ test.describe("Borrower CRUD & Search (Story 4-1)", () => {
     await expect(page).toHaveURL(/\/borrowers/, { timeout: 5000 });
 
     // Navigate to the borrower detail
-    await page.getByText("BW-Temp Borrower").click();
+    await page.locator("tbody").getByText("BW-Temp Borrower").click();
     await expect(page.locator("h1")).toContainText("BW-Temp Borrower");
 
     // Delete
@@ -131,7 +131,7 @@ test.describe("Borrower CRUD & Search (Story 4-1)", () => {
     await expect(page.locator("body")).toContainText("BW-Smoke Borrower");
 
     // Click into detail
-    await page.getByText("BW-Smoke Borrower").click();
+    await page.locator("tbody").getByText("BW-Smoke Borrower").click();
     await expect(page.locator("h1")).toContainText("BW-Smoke Borrower");
   });
 });


### PR DESCRIPTION
## Summary
- Wrap the admin tablist with `hidden md:flex` and render a parallel `<select id="admin-tab-select">` for `< md` viewports. The select drives an `hx-get="/admin"` + `hx-push-url` swap into `#admin-shell`, so deep links and the back button keep working.
- Add unit coverage in `src/routes/admin.rs` for the dual-surface render and active-tab reflection.
- Add `tests/e2e/specs/journeys/admin-mobile-dropdown.spec.ts` (3 tests: mobile shows select, desktop shows tablist, change → URL + panel swap).
- Fix two `borrowers.spec.ts` selectors that were producing strict-mode violations against the mobile card surface introduced in 10-3 (same dual-surface root cause as the six sites patched there).

## Test plan
- [x] `cargo clippy --bin mybibli --tests -- -D warnings` clean
- [x] `cargo test` — 796/796
- [x] `npx playwright test specs/journeys/admin-mobile-dropdown.spec.ts` — 3/3
- [x] `npx playwright test specs/journeys/borrowers.spec.ts` — 7/7
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)