### PR TITLE
chore: release v1.1.2 — version bump + doc sync (Foundation Rule #19)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Built for collectors who want more than a spreadsheet:
 - **Storage-location tracking.** Configurable hierarchy (room → shelf → row → …), barcode-on-shelf workflow.
 - **Loan management.** Borrower CRUD, loan registration with automatic location restoration on return, overdue threshold (admin-configurable), per-borrower history.
 - **Multi-role auth.** Anonymous (read-only), Librarian (catalog + loans), Admin (everything). Session inactivity timeout with keep-alive toast. FR/EN language toggle with per-user preference.
-- **Hardened by construction.** Strict Content Security Policy (no `unsafe-inline`/`unsafe-eval`), CSRF synchronizer-token middleware on every state-changing request, scanner-guard against burst-keyboard input leaking into modals.
+- **Hardened by construction.** Strict Content Security Policy (no `unsafe-inline`/`unsafe-eval`), CSRF synchronizer-token middleware on every state-changing request (with a server-rendered "session expired" feedback when the token drifts — see [`docs/auth-threat-model.md`](docs/auth-threat-model.md)), scanner-guard against burst-keyboard input leaking into modals.
 - **Admin panel.** Health dashboard (entity counts, MariaDB version, disk usage, provider reachability), user management with last-active-admin guard, editable reference data (genres, volume states, contributor roles, location node types), system settings (overdue threshold, provider API keys, default language), trash view + restore + permanent delete, configurable auto-purge after 30 days.
 - **First-launch setup wizard.** Fresh installs walk through Admin → Providers → Preferences → Done; the gate middleware redirects every route to `/setup` until completion. Idempotent — interruptions resume at the right step server-side.
+- **Mobile-aware + WCAG 2.2 AA accessible.** Dual-surface mobile UX on data-dense pages (desktop tables collapse into mobile cards, admin tabs collapse into a `<select>` dropdown), full keyboard navigation with shortcuts cheat-sheet (`?`), contextual help-icon tooltips, and an axe-core CI gate that covers every reachable surface including entity-detail routes and the first-launch wizard.
 
 ## Tech stack
 
@@ -303,8 +304,9 @@ Coding conventions and architecture rules for contributors are in [`CLAUDE.md`](
 | 7 | Accès multi-rôle & Sécurité | ✅ done |
 | 8 | Administration & Configuration | ✅ done |
 | 9 | Polish UX & Accessibilité | ✅ done |
+| 10 | Mobile UX & sécurité closeout | ✅ done |
 
-v1.0.0 shipped after Epic 9 close (2026-05-10). See [`epics.md`](_bmad-output/planning-artifacts/epics.md) for the full breakdown and [`sprint-status.yaml`](_bmad-output/implementation-artifacts/sprint-status.yaml) for the story-by-story state.
+mybibli has been live in production since v1.1.1 (2026-05-14) on the household NAS that drove the project. v1.0.0 shipped after Epic 9 close (2026-05-10) as the first production-ready build; v1.1.0 added the seed-gate + audit trio (mandatory install floor — see banner at the top of this file); v1.1.2 closed Epic 10 (mobile UX dual-surface pattern, CSRF rejection UX, axe-core entity-detail coverage). The planned-feature build phase is complete — future work is GH-issue-driven polish iterations and production-driven fixes. See [`epics.md`](_bmad-output/planning-artifacts/epics.md) for the full breakdown and [`sprint-status.yaml`](_bmad-output/implementation-artifacts/sprint-status.yaml) for the story-by-story state.
 
 ## License
 

--- a/docs/manual/en/08-upgrade-migration.tex
+++ b/docs/manual/en/08-upgrade-migration.tex
@@ -104,6 +104,48 @@ Every mybibli release publishes a GitHub Release page with:
 Read the notes before upgrading. Breaking changes are tagged with a
 prominent \emph{Breaking} label.
 
+\section{What's new in 1.1.2}\label{sec:whats-new-1.1.2}
+
+Version 1.1.2 closes Epic 10 — mobile UX and security closeout.
+There are no schema migrations and no breaking changes. The
+upgrade is a routine \texttt{docker compose pull \&\& docker
+compose up -d}. The user-visible improvements are:
+
+\begin{itemize}
+  \item \textbf{Mobile data tables become cards.} The catalog,
+        loans, borrowers, and series tables now collapse into a
+        compact card list on narrow viewports (anything below the
+        \texttt{md} Tailwind breakpoint). The desktop table layout
+        is unchanged. The same rows are rendered in both shapes —
+        the responsive switch is pure CSS, no JavaScript involved.
+  \item \textbf{The admin tabs become a dropdown on mobile.} On
+        narrow viewports, the five-tab admin nav (Health, Users,
+        Reference data, Trash, System) renders as a \texttt{<select>}
+        dropdown instead of overflowing horizontally. Deep links
+        to \texttt{/admin?tab=...} keep working.
+  \item \textbf{``Session expired'' feedback is now explicit.} When
+        the per-session CSRF token drifts (e.g.\ because the
+        browser was idle past the inactivity timeout and the
+        session rotated), the next state-changing action returns a
+        clear server-rendered banner instead of a silent
+        failure. The same flow handles session-timeout 403s.
+  \item \textbf{Full accessibility coverage extended to entity
+        pages.} The WCAG~2.2~AA gate in CI now covers every
+        \texttt{/title/:id}, \texttt{/borrower/:id},
+        \texttt{/contributor/:id}, \texttt{/series/:id}, and the
+        first-launch \texttt{/setup} wizard, not just the top-level
+        navigation routes. Two contrast violations on the title
+        detail page and the home recent-additions block were
+        fixed inline.
+  \item \textbf{Auth posture documented end-to-end.}
+        \texttt{docs/auth-threat-model.md} now formalises the
+        single-tenant LAN/NAS deployment shape: what CSRF protects,
+        what session cookies do, why specific design choices were
+        made, and what would need revisiting if multi-tenancy
+        became a goal. Referenced from \texttt{README.md} and
+        \texttt{CLAUDE.md}.
+\end{itemize}
+
 \section{Rollback}
 
 Rollback is \emph{not} a first-class flow. Schema migrations move

--- a/docs/manual/en/main.tex
+++ b/docs/manual/en/main.tex
@@ -94,7 +94,7 @@
 % ---- Document metadata ----------------------------------------------
 \title{\Huge\bfseries mybibli\\[6pt]\Large User Manual}
 \author{The mybibli authors\\\small \texttt{https://github.com/guycorbaz/mybibli}}
-\date{Version 1.1.0 — \today}
+\date{Version 1.1.2 — \today}
 
 % =====================================================================
 \begin{document}
@@ -105,7 +105,7 @@
 \vspace*{2cm}
 \small
 Licensed under AGPL-3.0-or-later.\\
-This manual covers mybibli version 1.1.0 and later.
+This manual covers mybibli version 1.1.2 and later (the v1.1.0 floor is still enforced for fresh installs — see the Installation chapter for the seed-gate background).
 \end{center}
 
 \tableofcontents

--- a/docs/manual/fr/08-upgrade-migration.tex
+++ b/docs/manual/fr/08-upgrade-migration.tex
@@ -110,6 +110,53 @@ Chaque release mybibli publie une page GitHub Release avec :
 Lisez les notes avant de mettre à jour. Les breaking changes
 portent une étiquette \emph{Breaking} bien visible.
 
+\section{Nouveautés de la 1.1.2}\label{sec:whats-new-1.1.2}
+
+La version 1.1.2 clôt l'Epic~10 — polish UX mobile et closeout
+sécurité. Aucune migration de schéma, aucun breaking change.
+La mise à jour est un simple \texttt{docker compose pull \&\&
+docker compose up -d} de routine. Les améliorations visibles
+côté utilisateur :
+
+\begin{itemize}
+  \item \textbf{Les tableaux deviennent des cartes sur mobile.}
+        Catalogue, prêts, emprunteurs et séries s'affichent sous
+        forme de cartes compactes sur les viewports étroits
+        (en-dessous du breakpoint Tailwind \texttt{md}). La mise
+        en page tableau desktop reste inchangée. Les deux formats
+        rendent les mêmes lignes — le basculement est purement CSS,
+        sans JavaScript.
+  \item \textbf{Les onglets admin deviennent une liste déroulante
+        sur mobile.} Sur les écrans étroits, les cinq onglets de
+        l'admin (Santé, Utilisateurs, Données de référence, Corbeille,
+        Système) se replient en \texttt{<select>} au lieu de
+        déborder horizontalement. Les liens profonds
+        \texttt{/admin?tab=...} continuent de fonctionner.
+  \item \textbf{Le message «~Session expirée~» est désormais
+        explicite.} Quand le jeton CSRF de session dérive (par
+        exemple parce que le navigateur est resté inactif au-delà
+        du timeout et que la session a tourné), l'action suivante
+        affiche maintenant une bannière serveur claire au lieu
+        d'échouer silencieusement. Le même flux gère les 403 de
+        timeout de session.
+  \item \textbf{Couverture accessibilité étendue aux pages
+        d'entité.} Le gate WCAG~2.2~AA en CI couvre désormais
+        chaque \texttt{/title/:id}, \texttt{/borrower/:id},
+        \texttt{/contributor/:id}, \texttt{/series/:id} et
+        l'assistant de première installation \texttt{/setup}, pas
+        seulement les routes de navigation principales. Deux
+        violations de contraste sur la page détail titre et sur le
+        bloc «~ajouts récents~» de la page d'accueil ont été
+        corrigées au passage.
+  \item \textbf{Posture d'authentification documentée bout en bout.}
+        \texttt{docs/auth-threat-model.md} formalise désormais la
+        forme de déploiement single-tenant LAN/NAS : ce que CSRF
+        protège, ce que font les cookies de session, le pourquoi
+        des choix de conception et ce qu'il faudrait revisiter si
+        le multi-tenant devenait un objectif. Référencé depuis
+        \texttt{README.md} et \texttt{CLAUDE.md}.
+\end{itemize}
+
 \section{Rollback}
 
 Le rollback \emph{n'est pas} un flux de première classe. Les

--- a/docs/manual/fr/main.tex
+++ b/docs/manual/fr/main.tex
@@ -94,7 +94,7 @@
 % ---- Métadonnées du document ---------------------------------------
 \title{\Huge\bfseries mybibli\\[6pt]\Large Manuel utilisateur}
 \author{Les auteurs de mybibli\\\small \texttt{https://github.com/guycorbaz/mybibli}}
-\date{Version 1.1.0 — \today}
+\date{Version 1.1.2 — \today}
 
 % =====================================================================
 \begin{document}
@@ -105,7 +105,7 @@
 \vspace*{2cm}
 \small
 Distribué sous licence AGPL-3.0-or-later.\\
-Ce manuel couvre mybibli version 1.1.0 et ultérieures.
+Ce manuel couvre mybibli version 1.1.2 et ultérieures (le plancher v1.1.0 reste obligatoire pour les nouvelles installations — voir le chapitre Installation pour le contexte du seed-gate).
 \end{center}
 
 \tableofcontents

--- a/website/about.html
+++ b/website/about.html
@@ -28,7 +28,7 @@
       <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
         <span aria-hidden="true" class="text-xl">📚</span>
         <span>mybibli</span>
-        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.0.0</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.1.2</span>
       </a>
       <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
         <a href="./index.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Home</a>

--- a/website/index.html
+++ b/website/index.html
@@ -47,7 +47,7 @@
       <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
         <span aria-hidden="true" class="text-xl">📚</span>
         <span>mybibli</span>
-        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.0.0</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.1.2</span>
       </a>
 
       <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
@@ -94,7 +94,7 @@
         <div class="max-w-3xl">
           <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
             <span class="w-1.5 h-1.5 rounded-full bg-indigo-500 dark:bg-indigo-400"></span>
-            v1.0.0 · first public release
+            v1.1.2 · in production
           </span>
           <h1 class="mt-5 text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
             Your home library,<br class="hidden sm:block" />
@@ -328,9 +328,9 @@
         <div class="reveal relative overflow-hidden rounded-2xl p-10 sm:p-14 bg-gradient-to-br from-indigo-600 via-indigo-700 to-pink-600 text-white shadow-xl">
           <div class="absolute inset-0 grid-pattern opacity-20" aria-hidden="true"></div>
           <div class="relative">
-            <h2 class="text-2xl sm:text-3xl font-bold">v1.0.0 is here.</h2>
+            <h2 class="text-2xl sm:text-3xl font-bold">v1.1.2 is live.</h2>
             <p class="mt-3 text-indigo-100 max-w-2xl">
-              All nine epics shipped. Pre-built Docker images on Docker Hub. Watch the repo to be notified of future releases, or jump into the issues to shape v2.
+              All ten epics shipped. mybibli is in production on the household NAS that drove the project. Pre-built Docker images on Docker Hub. Watch the repo for polish iterations and production-driven fixes, or jump into the issues.
             </p>
             <div class="mt-6 flex flex-wrap gap-3">
               <a href="https://github.com/guycorbaz/mybibli" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-white text-indigo-700 font-medium hover:bg-indigo-50">

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Roadmap — mybibli</title>
-  <meta name="description" content="Development roadmap for mybibli — v1.0.0 shipped, all nine epics done, post-v1 directions tracked openly as GitHub issues." />
+  <meta name="description" content="Development roadmap for mybibli — v1.1.2 in production, all ten epics done, post-v1 directions tracked openly as GitHub issues." />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📚%3C/text%3E%3C/svg%3E" />
   <script>
     (function () {
@@ -28,7 +28,7 @@
       <a href="./index.html" class="flex items-center gap-2 font-semibold text-stone-900 dark:text-stone-100">
         <span aria-hidden="true" class="text-xl">📚</span>
         <span>mybibli</span>
-        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.0.0</span>
+        <span class="hidden sm:inline-block ml-2 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 ring-1 ring-emerald-200/60 dark:ring-emerald-800/50">v1.1.2</span>
       </a>
       <nav aria-label="Primary" class="hidden md:flex items-center gap-1 text-sm">
         <a href="./index.html" class="px-3 py-1.5 rounded-md text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white hover:bg-stone-200/60 dark:hover:bg-stone-800/60">Home</a>
@@ -71,9 +71,9 @@
         <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-600/10 dark:bg-indigo-400/10 ring-1 ring-indigo-600/20 dark:ring-indigo-400/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium">
           Roadmap
         </span>
-        <h1 class="mt-5 text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50">All nine epics shipped.</h1>
+        <h1 class="mt-5 text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50">All ten epics shipped.</h1>
         <p class="mt-5 text-lg text-stone-600 dark:text-stone-300 leading-relaxed">
-          Development was organized into nine epics. <strong class="text-stone-900 dark:text-stone-100">v1.0.0 shipped at Epic 9's close</strong> — pre-built Docker images now live on Docker Hub. Post-v1 directions are tracked openly as GitHub issues.
+          Development was organized into ten epics. <strong class="text-stone-900 dark:text-stone-100">mybibli is in production</strong> on the household NAS that drove the project — v1.0.0 shipped at Epic 9's close, v1.1.0 added the seed-gate + audit trio (mandatory install floor), and v1.1.2 closed Epic 10 with the mobile UX dual-surface pattern, CSRF rejection UX, and full axe-core entity-detail coverage. Pre-built Docker images are on Docker Hub. The planned-feature build phase is complete — future work is tracked openly as GitHub issues.
         </p>
 
         <!-- Progress bar -->
@@ -94,7 +94,7 @@
     <section class="py-12 sm:py-16">
       <div class="max-w-4xl mx-auto px-4 sm:px-6">
         <div class="reveal mb-10">
-          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">The nine epics</h2>
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">The ten epics</h2>
           <p class="mt-3 text-stone-600 dark:text-stone-300">Each one ships behind a draft PR per story, gated by green CI. Each one ends with a retrospective.</p>
         </div>
 
@@ -199,17 +199,28 @@
             <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Dashboard indicators, modal-based confirmations replacing <code class="font-mono text-xs">hx-confirm</code>, status messages and empty states, connection-lost overlay, navbar polish, contextual help tooltips, keyboard shortcuts, responsive layouts, and a final WCAG 2.2 AA audit.</p>
           </li>
 
-          <!-- v1 milestone (shipped) -->
+          <!-- Epic 10 (done) -->
+          <li class="reveal pl-6 sm:pl-8 relative">
+            <span class="absolute -left-[9px] top-1.5 w-4 h-4 rounded-full bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950" aria-hidden="true"></span>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span class="text-xs uppercase tracking-wide font-semibold text-stone-500 dark:text-stone-400">Epic 10</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">Mobile UX &amp; sécurité closeout</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
+            </div>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Auth threat model documented end-to-end, CSRF rejection UX (server-rendered &quot;session expired&quot; feedback), mobile DataTable card mode + admin tabs <code class="font-mono text-xs">&lt;select&gt;</code> dropdown (dual-surface pattern), axe-core extended to every entity-detail route. Closeout epic — every story grounded in a GitHub issue from the post-Epic-9 review pass, no new feature surface.</p>
+          </li>
+
+          <!-- v1 milestone (shipped, in production) -->
           <li class="reveal pl-6 sm:pl-8 relative">
             <span class="absolute -left-[11px] top-1 w-5 h-5 rounded-md bg-emerald-500 ring-4 ring-stone-50 dark:ring-stone-950 flex items-center justify-center" aria-hidden="true">
               <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
             </span>
             <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
               <span class="text-xs uppercase tracking-wide font-semibold text-emerald-600 dark:text-emerald-400">Milestone</span>
-              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">v1.0.0 release</h3>
-              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Shipped</span>
+              <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">v1.1.2 — in production</h3>
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Live</span>
             </div>
-            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">First public release. Pre-built Docker images on Docker Hub at <a href="https://hub.docker.com/r/gcorbaz/mybibli" class="underline decoration-stone-400 hover:decoration-indigo-500">gcorbaz/mybibli</a> (<code class="font-mono text-xs">:1.0.0</code> + <code class="font-mono text-xs">:latest</code>).</p>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">mybibli has been live on the household NAS that drove the project since v1.1.1 (2026-05-14). v1.1.2 (post-Epic-10) is the current release. Pre-built Docker images on Docker Hub at <a href="https://hub.docker.com/r/gcorbaz/mybibli" class="underline decoration-stone-400 hover:decoration-indigo-500">gcorbaz/mybibli</a> — <code class="font-mono text-xs">:1.1.2</code> + <code class="font-mono text-xs">:latest</code>. Honor the <strong>1.1.0 minimum</strong> install floor (seed-gate + audit trio); earlier tags are removed.</p>
           </li>
         </ol>
       </div>


### PR DESCRIPTION
## Summary

First release exercising Foundation Rule #19 (Release Doc Sync, introduced by story 10-5). Bundles v1.1.1 → v1.1.2 patch bump with the doc surfaces brought in sync.

**Version bump:** patch (1.1.1 → 1.1.2). Epic 10 is officially closeout, no new feature surface (epic spec line 1627). Reserves 1.2.0 for an actual feature cycle.

**Surfaces in sync:**
- `Cargo.toml` 1.1.1 → 1.1.2
- `README.md` — Features bullet on mobile + a11y, Roadmap table gets Epic 10, version timeline rewrites stale "v1.0.0 shipped" sentence
- `docs/manual/{en,fr}/main.tex` — cover-page version 1.1.0 → 1.1.2 (floor sentence keeps 1.1.0 for fresh-install context)
- `docs/manual/{en,fr}/08-upgrade-migration.tex` — new "What's new in 1.1.2" section with the five user-visible Epic 10 improvements
- `website/{index,about,roadmap}.html` — header chips v1.0.0 → v1.1.2, hero CTA rewritten, roadmap timeline gets Epic 10 + new "v1.1.2 — in production" milestone card replacing the old "v1.0.0 release" card

**Out of scope (deliberately):** The two manual PDFs (`docs/manual/mybibli-manual-{en,fr}.pdf`) are NOT committed — per the manual's own "Reading the release notes" section, PDFs ship as GitHub Release attachments, not as tracked artifacts. They will be uploaded at `gh release create` time.

## Test plan
- [x] `SQLX_OFFLINE=true cargo check` clean against the bumped Cargo.toml
- [x] `docs/manual/build.sh` rebuilds both PDFs successfully with the new section
- [ ] CI green on push (no code changes; doc + Cargo.toml only)
- [ ] After merge: `git tag v1.1.2 && git push --tags` triggers `release.yml` which verifies tag matches Cargo.toml, runs gates, builds and pushes `gcorbaz/mybibli:1.1.2` + updates `:latest`
- [ ] Final: `gh release create v1.1.2 --notes-file ...` with both PDFs attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)