### PR TITLE
fix(#213): persist covers across container upgrades (v1.1.4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,8 +67,22 @@ APP_LANGUAGE=en
 
 # Path where downloaded cover images are written. Resolved as a regular
 # filesystem path — relative paths resolve against the app's CWD.
-# Default: `./covers`. In Docker, mount a volume here for persistence.
+# Default: `./covers`. Inside the container this is `/app/covers`.
+#
+# In Docker, `docker-compose.yml` maps the named volume `mybibli_covers`
+# onto `/app/covers` so covers persist across container upgrades (issue
+# #213). DO NOT change `COVERS_DIR` here unless you also update the mount
+# target in docker-compose.yml to match.
 COVERS_DIR=./covers
+
+# Optional bind-mount path for covers (issue #213). Used only when you
+# uncomment the bind-mount line in `docker-compose.yml`'s `volumes:` block
+# on the `mybibli` service AND comment out the `mybibli_covers` named
+# volume mount. Pick a host path that's visible in your file manager
+# (Synology DSM, rsync backup target, etc.) — the default below is a
+# subfolder of the docker-compose project so it doesn't conflict with
+# the local `./covers` dir used by `cargo run`.
+# COVERS_HOST_PATH=./covers-host
 
 # =====================================================================
 # 4. Cookie & CSP hardening

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mybibli"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Built for collectors who want more than a spreadsheet:
 
 Pre-built images are published to Docker Hub at [`gcorbaz/mybibli`](https://hub.docker.com/r/gcorbaz/mybibli) — `:latest` tracks the highest semver, individual tags pin to the exact release. Honor the **1.1.0 minimum** banner above. For development against the source tree, see **Development** below.
 
+### Persistent storage — both volumes are mandatory
+
+`docker-compose.yml` declares **two named volumes** that MUST survive container upgrades:
+
+- `mybibli_db_data` → `/var/lib/mysql` — your catalog (titles, volumes, loans, etc.)
+- `mybibli_covers` → `/app/covers` — downloaded cover JPGs (issue [#213](https://github.com/guycorbaz/mybibli/issues/213))
+
+If you deploy `docker-compose.yml` from the repo unchanged, you already have both. Back them up together — losing one without the other leaves DB references pointing at missing files (or vice versa).
+
+**Upgrading from a pre-1.1.4 install?** Pre-1.1.4 `docker-compose.yml` did not declare `mybibli_covers`, so the cover JPGs lived inside the container's writable layer and were lost on every `docker compose up -d` after a `pull`. Adding the volume now preserves covers fetched from this point forward, but does NOT restore the ones that disappeared on prior upgrades. To recover, re-trigger metadata fetch from each affected title's detail page (the "Re-fetch metadata" button). A bulk-fetch admin action is tracked at issue [#214](https://github.com/guycorbaz/mybibli/issues/214).
+
+**Synology DSM / bind-mount users:** comment out the `mybibli_covers:/app/covers` line in `docker-compose.yml` and uncomment the bind-mount line right below it, then set `COVERS_HOST_PATH` in your `.env` to the host path you want — Synology File Station / your rsync routine will see the covers directly.
+
 ## Configuration
 
 All deployment-time settings are environment variables — there is no
@@ -82,7 +95,11 @@ The variables are grouped in seven sections:
    published by Docker).
 3. **Application** — `RUST_LOG` (tracing filter; prod-safe default
    `mybibli=info`), `APP_LANGUAGE` (`en` or `fr`), `COVERS_DIR`
-   (filesystem path for downloaded cover images).
+   (filesystem path for downloaded cover images — in Docker, the
+   `/app/covers` directory is mapped to the persistent `mybibli_covers`
+   named volume; see "Persistent storage" above. `COVERS_HOST_PATH`
+   is an optional bind-mount override for users who prefer a host path
+   visible in their file manager).
 4. **Cookie & CSP hardening** — `MYBIBLI_COOKIE_SECURE` (set to `true`
    only behind HTTPS, see issue
    [#94](https://github.com/guycorbaz/mybibli/issues/94)),
@@ -311,7 +328,7 @@ Coding conventions and architecture rules for contributors are in [`CLAUDE.md`](
 | 9 | Polish UX & Accessibilité | ✅ done |
 | 10 | Mobile UX & sécurité closeout | ✅ done |
 
-mybibli has been live in production since v1.1.1 (2026-05-14) on the household NAS that drove the project. v1.0.0 shipped after Epic 9 close (2026-05-10) as the first production-ready build; v1.1.0 added the seed-gate + audit trio (mandatory install floor — see banner at the top of this file); v1.1.2 closed Epic 10 (mobile UX dual-surface pattern, CSRF rejection UX, axe-core entity-detail coverage); v1.1.3 is the first production-driven-feedback patch (home-page layout reorder so filter results land above the fold; locations tree rows clickable). The planned-feature build phase is complete — future work is GH-issue-driven polish iterations and production-driven fixes. See [`epics.md`](_bmad-output/planning-artifacts/epics.md) for the full breakdown and [`sprint-status.yaml`](_bmad-output/implementation-artifacts/sprint-status.yaml) for the story-by-story state.
+mybibli has been live in production since v1.1.1 (2026-05-14) on the household NAS that drove the project. v1.0.0 shipped after Epic 9 close (2026-05-10) as the first production-ready build; v1.1.0 added the seed-gate + audit trio (mandatory install floor — see banner at the top of this file); v1.1.2 closed Epic 10 (mobile UX dual-surface pattern, CSRF rejection UX, axe-core entity-detail coverage); v1.1.3 was the first production-driven-feedback patch (home-page layout reorder so filter results land above the fold; locations tree rows clickable); v1.1.4 fixes issue [#213](https://github.com/guycorbaz/mybibli/issues/213) — the published `docker-compose.yml` template now persists cover JPGs in the `mybibli_covers` named volume so they survive container upgrades. The planned-feature build phase is complete — future work is GH-issue-driven polish iterations and production-driven fixes. See [`epics.md`](_bmad-output/planning-artifacts/epics.md) for the full breakdown and [`sprint-status.yaml`](_bmad-output/implementation-artifacts/sprint-status.yaml) for the story-by-story state.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,22 @@
-# Full local stack: app + persistent MariaDB.
+# Full local stack: app + persistent MariaDB + persistent covers.
 #
 # All configuration values live in .env — nothing in this file needs editing.
 #
+# Persistent state lives in two named volumes (both survive `docker compose
+# down` AND `docker compose up -d` after a `pull`):
+#   - `mybibli_db_data`  — MariaDB data directory
+#   - `mybibli_covers`   — downloaded cover JPGs (issue #213)
+# Back them up together — losing one without the other will surface as
+# half-broken (DB references that point at missing covers or vice versa).
+#
 # To use an EXTERNAL database instead:
-#   1. Comment out (or delete) the `db:` service and the `volumes:` block.
-#   2. Comment out the `depends_on:` block on the `mybibli` service.
-#   3. Set MYSQL_HOST / MYSQL_PORT / MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE
+#   1. Comment out (or delete) the `db:` service.
+#   2. Remove `mybibli_db_data:` from the `volumes:` block at the bottom.
+#   3. Comment out the `depends_on:` block on the `mybibli` service.
+#   4. Set MYSQL_HOST / MYSQL_PORT / MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE
 #      in your .env to point at the external DB.
+# Keep `mybibli_covers:` even with an external DB — covers are local to
+# this app instance.
 
 services:
   mybibli:
@@ -20,6 +30,19 @@ services:
       RUST_LOG: ${RUST_LOG:-mybibli=info}
       APP_LANGUAGE: ${APP_LANGUAGE:-en}
       MYBIBLI_COOKIE_SECURE: ${MYBIBLI_COOKIE_SECURE:-false}
+    volumes:
+      # Issue #213 — cover images MUST persist across container upgrades.
+      # The Rust binary writes cover JPGs into `/app/covers` (resolved
+      # from `COVERS_DIR=./covers` against WORKDIR /app). Without this
+      # mount, every `docker compose up -d` after a `docker compose pull`
+      # destroys the writable layer holding the accumulated covers.
+      #
+      # The named volume `mybibli_covers` works zero-config — Docker
+      # manages persistence, backup via `docker volume`. If you prefer a
+      # bind mount visible in the host filesystem (Synology DSM, manual
+      # rsync backups), comment the line below and uncomment the second:
+      - mybibli_covers:/app/covers
+      # - ${COVERS_HOST_PATH:-./covers-host}:/app/covers
     depends_on:
       db:
         condition: service_healthy
@@ -48,3 +71,4 @@ services:
 
 volumes:
   mybibli_db_data:
+  mybibli_covers:

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -41,9 +41,11 @@ services:
       DATABASE_URL: mysql://mybibli:mybibli@db:3306/mybibli?charset=utf8mb4
       HOST: "0.0.0.0"
       PORT: "8080"
-      COVERS_DIR: "/data/covers"
     volumes:
-      - mybibli-covers:/data/covers
+      # Issue #213 — cover JPGs MUST persist across container upgrades.
+      # Without this mount, every `docker compose up -d` after a pull
+      # destroys the writable layer and the cataloged covers vanish.
+      - mybibli-covers:/app/covers
     depends_on:
       db:
         condition: service_healthy
@@ -84,7 +86,7 @@ All deployment-time settings are environment variables — no config file. The c
 ## Tags
 
 - `:latest` — tracks the highest semver release tag.
-- `:1.1.3` (current), `:1.1.2`, `:1.1.1`, `:1.1.0` — specific releases. Pin to a specific tag in production-style setups; track `:latest` is reasonable for homelab.
+- `:1.1.4` (current), `:1.1.3`, `:1.1.2`, `:1.1.1`, `:1.1.0` — specific releases. Pin to a specific tag in production-style setups; track `:latest` is reasonable for homelab.
 - **No `:dev`, no `:main`, no `:beta` published** — tagged releases only.
 
 ## Docs

--- a/docs/manual/en/01-installation.tex
+++ b/docs/manual/en/01-installation.tex
@@ -42,10 +42,15 @@ Before you start:
   \item Pick a host directory for the mybibli files
         (e.g.\ \texttt{/srv/mybibli} on Linux,
         \texttt{/volume1/docker/mybibli} on Synology DSM).
-  \item Pick a host directory for the cover-image
-        store\index{covers!directory}
-        (e.g.\ \texttt{/srv/mybibli/covers}). This will be mounted
-        into the container.
+  \item Decide how cover images are stored\index{covers!directory}.
+        The shipped \texttt{docker-compose.yml} declares a Docker
+        \emph{named volume} (\texttt{mybibli\_covers}) — zero
+        configuration, Docker manages persistence and backup via
+        \texttt{docker volume}. If you prefer a host-visible directory
+        (Synology DSM file browser, manual rsync backups), pick a host
+        path now (e.g.\ \texttt{/volume1/docker/mybibli/covers}) and
+        you will switch the compose file to a bind mount in step~3
+        below.
   \item Choose a strong password for the bundled MariaDB
         \texttt{root} and application users — or, for an external
         database, create a dedicated database and user up front (see
@@ -70,6 +75,31 @@ curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/docker-compos
 curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/.env.example
 cp .env.example .env
 \end{lstlisting}
+
+\subsection*{1b. (Optional) Switch covers to a bind mount}\label{sec:install-covers-bind}
+
+By default, the shipped \texttt{docker-compose.yml} stores downloaded
+cover images in the Docker-managed named volume
+\texttt{mybibli\_covers}. This works zero-config and persists across
+container upgrades (issue~\#213). Most operators should leave it
+as-is.
+
+If you want covers visible in your host file manager (Synology DSM
+File Station, manual rsync backups, etc.), edit the compose file:
+
+\begin{itemize}
+  \item In the \texttt{mybibli} service's \texttt{volumes:} block,
+        comment out the \texttt{- mybibli\_covers:/app/covers} line
+        and uncomment the
+        \texttt{- \$\{COVERS\_HOST\_PATH:-./covers-host\}:/app/covers}
+        line right below it.
+  \item In \texttt{.env}, set \texttt{COVERS\_HOST\_PATH} to the host
+        path you picked in the pre-installation checklist (e.g.\
+        \texttt{COVERS\_HOST\_PATH=/volume1/docker/mybibli/covers}).
+  \item Create the directory before starting the stack
+        (\texttt{mkdir -p}) so Docker doesn't auto-create it owned by
+        root.
+\end{itemize}
 
 \subsection*{2. Edit \texttt{.env}}
 
@@ -166,8 +196,11 @@ Edit \texttt{docker-compose.yml} and remove the bundled database:
   \item delete (or comment out) the entire \texttt{db:} service;
   \item delete (or comment out) the \texttt{depends\_on:} block on
         the \texttt{mybibli} service;
-  \item delete (or comment out) the \texttt{volumes:} block at the
-        bottom of the file.
+  \item in the bottom \texttt{volumes:} block, remove
+        \texttt{mybibli\_db\_data:} only — \textbf{keep}
+        \texttt{mybibli\_covers:}\index{covers!persistence}. Cover
+        images are local to the app and must survive container
+        upgrades regardless of where the database lives (issue~\#213).
 \end{itemize}
 
 \subsection*{3. Point \texttt{.env} at the external database}

--- a/docs/manual/en/07-backup-restore.tex
+++ b/docs/manual/en/07-backup-restore.tex
@@ -12,11 +12,15 @@ Three artifacts together form a complete mybibli backup:
   \item \textbf{The MariaDB database.}\index{backup!database} Holds
         every title, volume, location, contributor, loan, user,
         audit log and setting. Lose this and you start from zero.
-  \item \textbf{The \texttt{covers/} directory.}\index{backup!covers}
-        Cover images downloaded during cataloging. Lose this and
-        the catalog still works, but every title page shows a
-        generic placeholder until you re-fetch metadata
-        title-by-title.
+  \item \textbf{Cover images.}\index{backup!covers} Downloaded during
+        cataloging and persisted in the Docker volume
+        \texttt{mybibli\_covers} (or in your host bind-mount path if
+        you switched per
+        section~\ref{sec:install-covers-bind}). Lose this and the
+        catalog still works, but every title page shows a generic
+        placeholder until you re-fetch metadata title-by-title
+        (issue~\#213 — pre-1.1.4 installs without this volume had
+        covers disappear on every container upgrade).
   \item \textbf{The \texttt{.env} file.}\index{backup!.env} Holds
         passwords (database, API keys not yet migrated). Lose this
         and a re-deploy needs you to re-enter every credential.
@@ -60,12 +64,31 @@ restores faster than a SQL dump.
 
 \subsection*{Covers and \texttt{.env}}
 
-A plain \texttt{tar} archive is enough:
+For a host-mounted covers directory (bind-mount installs), a plain
+\texttt{tar} archive is enough:
 
 \begin{lstlisting}
 tar czf backups/mybibli-files-$(date +%Y%m%d).tar.gz \
-    .env covers/
+    .env "$COVERS_HOST_PATH"
 \end{lstlisting}
+
+For the default install (named Docker volume), back up the volume
+through Docker — the host path of a named volume varies by Docker
+version and is not stable, so don't try to \texttt{tar} it directly:
+
+\begin{lstlisting}
+docker run --rm \
+    -v mybibli_covers:/source:ro \
+    -v "$(pwd)/backups:/backup" \
+    alpine \
+    tar czf "/backup/mybibli-covers-$(date +%Y%m%d).tar.gz" -C /source .
+tar czf "backups/mybibli-env-$(date +%Y%m%d).tar.gz" .env
+\end{lstlisting}
+
+The throwaway \texttt{alpine} container mounts the named volume
+read-only, the host \texttt{backups/} directory writable, and writes
+the tarball. Same shape works for restoring — see the Restore
+section below.
 
 \section{Recommended cadence}
 
@@ -110,8 +133,24 @@ against the external server.
 
 \subsection*{Covers and \texttt{.env}}
 
+For a host-bind-mount install:
+
 \begin{lstlisting}
 tar xzf backups/mybibli-files-20260513.tar.gz
+\end{lstlisting}
+
+For the default named-volume install, restore through a throwaway
+container in the symmetric shape to the backup:
+
+\begin{lstlisting}
+docker compose stop mybibli
+docker run --rm \
+    -v mybibli_covers:/target \
+    -v "$(pwd)/backups:/backup:ro" \
+    alpine \
+    sh -c "rm -rf /target/* && tar xzf /backup/mybibli-covers-20260513.tar.gz -C /target"
+tar xzf backups/mybibli-env-20260513.tar.gz
+docker compose start mybibli
 \end{lstlisting}
 
 Restart the stack so the mybibli container picks up the restored

--- a/docs/manual/en/10-troubleshooting.tex
+++ b/docs/manual/en/10-troubleshooting.tex
@@ -197,17 +197,36 @@ limitation; planned indexes will close the gap.
 
 \section{Cover images are missing}
 
-\subsection*{Symptom: every title shows the placeholder}
+\subsection*{Symptom: every title shows the placeholder}\label{sec:troubleshoot-covers-missing}
 
-The \texttt{covers/} directory is empty or unreadable. Confirm:
+The cover directory is empty or unreadable. Confirm:
 
 \begin{itemize}
-  \item the volume mount in \texttt{docker-compose.yml} points to
-        a directory that exists and is writable by the container;
+  \item \texttt{docker-compose.yml} declares the
+        \texttt{mybibli\_covers} named volume (or a bind mount on
+        \texttt{COVERS\_HOST\_PATH}) mapped to \texttt{/app/covers}.
+        Pre-1.1.4 installs did NOT declare this volume — see the
+        next subsection;
   \item the metadata fetch actually returned a cover URL (check the
         title page — if the URL is missing, the provider did not
         supply one).
 \end{itemize}
+
+\subsection*{Symptom: covers vanished after upgrading the image}\label{sec:troubleshoot-covers-upgrade-loss}
+
+You upgraded from a pre-1.1.4 install and all previously cataloged
+covers are gone. This is issue~\#213 — the older compose template
+did not persist \texttt{/app/covers}, so the writable layer holding
+those JPGs was destroyed when the new container replaced the old
+one.
+
+Fix forward: pull the 1.1.4 \texttt{docker-compose.yml}, run
+\texttt{docker compose down \&\& docker compose up -d}. Subsequent
+covers are persisted in the \texttt{mybibli\_covers} volume.
+
+Recovery of lost covers: open each affected title's detail page and
+click \emph{Re-fetch metadata} to repopulate from the provider
+chain. A bulk action is tracked at issue~\#214.
 
 \section{Where to file bugs}
 

--- a/docs/manual/fr/01-installation.tex
+++ b/docs/manual/fr/01-installation.tex
@@ -50,10 +50,17 @@ Avant de commencer :
   \item Choisissez un répertoire hôte pour les fichiers mybibli
         (par exemple \texttt{/srv/mybibli} sur Linux,
         \texttt{/volume1/docker/mybibli} sur Synology DSM).
-  \item Choisissez un répertoire hôte pour le stockage des images de
-        couverture\index{couvertures!répertoire}
-        (par exemple \texttt{/srv/mybibli/covers}). Il sera monté
-        dans le conteneur.
+  \item Choisissez comment stocker les images de
+        couverture\index{couvertures!répertoire}. Le fichier
+        \texttt{docker-compose.yml} fourni déclare un \emph{volume
+        nommé} Docker (\texttt{mybibli\_covers}) — aucune
+        configuration, Docker gère la persistance et la sauvegarde via
+        \texttt{docker volume}. Si vous préférez un répertoire visible
+        dans votre gestionnaire de fichiers (File Station de Synology
+        DSM, sauvegardes rsync manuelles), choisissez dès maintenant
+        un chemin sur l'hôte (par exemple
+        \texttt{/volume1/docker/mybibli/covers}); vous basculerez le
+        compose vers un bind mount à l'étape~3 plus bas.
   \item Choisissez un mot de passe fort pour les utilisateurs
         \texttt{root} et applicatif de la MariaDB embarquée — ou,
         pour une base de données externe, créez à l'avance une base
@@ -80,6 +87,33 @@ curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/docker-compos
 curl -O https://raw.githubusercontent.com/guycorbaz/mybibli/v1.1.0/.env.example
 cp .env.example .env
 \end{lstlisting}
+
+\subsection*{1b. (Optionnel) Basculer les couvertures vers un bind mount}\label{sec:install-covers-bind}
+
+Par défaut, le fichier \texttt{docker-compose.yml} stocke les images
+de couverture téléchargées dans le volume nommé Docker
+\texttt{mybibli\_covers}. Cela fonctionne sans configuration et persiste
+à travers les mises à jour du conteneur (issue~\#213). La plupart des
+opérateurs peuvent laisser tel quel.
+
+Si vous souhaitez voir les couvertures dans votre gestionnaire de
+fichiers (File Station de Synology DSM, sauvegardes rsync manuelles,
+etc.), éditez le fichier compose :
+
+\begin{itemize}
+  \item Dans le bloc \texttt{volumes:} du service \texttt{mybibli},
+        commentez la ligne \texttt{- mybibli\_covers:/app/covers} et
+        décommentez la ligne
+        \texttt{- \$\{COVERS\_HOST\_PATH:-./covers-host\}:/app/covers}
+        juste en-dessous.
+  \item Dans \texttt{.env}, définissez \texttt{COVERS\_HOST\_PATH} sur
+        le chemin hôte choisi dans la liste de vérification
+        pré-installation (par exemple
+        \texttt{COVERS\_HOST\_PATH=/volume1/docker/mybibli/covers}).
+  \item Créez le répertoire avant de démarrer la pile
+        (\texttt{mkdir -p}) pour éviter que Docker ne le crée
+        automatiquement avec le propriétaire root.
+\end{itemize}
 
 \subsection*{2. Éditer \texttt{.env}}
 
@@ -178,8 +212,12 @@ Modifiez \texttt{docker-compose.yml} et retirez la base embarquée :
   \item supprimez (ou commentez) tout le service \texttt{db:} ;
   \item supprimez (ou commentez) le bloc \texttt{depends\_on:} sur le
         service \texttt{mybibli} ;
-  \item supprimez (ou commentez) le bloc \texttt{volumes:} en bas du
-        fichier.
+  \item dans le bloc \texttt{volumes:} en bas du fichier, retirez
+        \texttt{mybibli\_db\_data:} uniquement —
+        \textbf{conservez} \texttt{mybibli\_covers:}\index{couvertures!persistance}.
+        Les images de couverture sont locales à l'application et doivent
+        survivre aux mises à jour du conteneur, peu importe où réside
+        la base de données (issue~\#213).
 \end{itemize}
 
 \subsection*{3. Pointer \texttt{.env} vers la base externe}

--- a/docs/manual/fr/07-backup-restore.tex
+++ b/docs/manual/fr/07-backup-restore.tex
@@ -14,11 +14,16 @@ Trois artefacts forment ensemble une sauvegarde mybibli complète :
         chaque titre, volume, lieu, contributeur, prêt,
         utilisateur, journal d'audit et paramètre. La perdre,
         c'est repartir de zéro.
-  \item \textbf{Le répertoire \texttt{covers/}.}\index{sauvegarde!covers}
-        Les images de couverture téléchargées au catalogage. Le
-        perdre, le catalogue fonctionne toujours mais chaque page
-        de titre affiche un placeholder générique tant que vous
-        n'avez pas re-fetché les métadonnées titre par titre.
+  \item \textbf{Les images de couverture.}\index{sauvegarde!couvertures}
+        Téléchargées au catalogage et persistées dans le volume
+        Docker \texttt{mybibli\_covers} (ou dans le chemin hôte du
+        bind mount si vous avez basculé selon
+        section~\ref{sec:install-covers-bind}). Les perdre, le
+        catalogue fonctionne toujours mais chaque page de titre
+        affiche un placeholder générique tant que vous n'avez pas
+        re-fetché les métadonnées titre par titre (issue~\#213 — les
+        installs antérieures à 1.1.4 sans ce volume perdaient les
+        couvertures à chaque mise à jour du conteneur).
   \item \textbf{Le fichier \texttt{.env}.}\index{sauvegarde!.env}
         Contient les mots de passe (base, clés d'API non encore
         migrées). Le perdre, un re-déploiement vous oblige à
@@ -61,14 +66,34 @@ Les utilisateurs DSM Synology peuvent aussi planifier une tâche
 \emph{Hyper Backup} qui cible le paquet MariaDB — elle produit une
 sauvegarde binaire qui se restaure plus vite qu'un dump SQL.
 
-\subsection*{Covers et \texttt{.env}}
+\subsection*{Couvertures et \texttt{.env}}
 
-Une simple archive \texttt{tar} suffit :
+Pour un répertoire de couvertures monté en bind-mount sur l'hôte,
+une simple archive \texttt{tar} suffit :
 
 \begin{lstlisting}
 tar czf backups/mybibli-files-$(date +%Y%m%d).tar.gz \
-    .env covers/
+    .env "$COVERS_HOST_PATH"
 \end{lstlisting}
+
+Pour l'install par défaut (volume Docker nommé), sauvegardez le
+volume via Docker — le chemin hôte d'un volume nommé varie selon la
+version de Docker et n'est pas stable, donc n'essayez pas de le
+\texttt{tar} directement :
+
+\begin{lstlisting}
+docker run --rm \
+    -v mybibli_covers:/source:ro \
+    -v "$(pwd)/backups:/backup" \
+    alpine \
+    tar czf "/backup/mybibli-covers-$(date +%Y%m%d).tar.gz" -C /source .
+tar czf "backups/mybibli-env-$(date +%Y%m%d).tar.gz" .env
+\end{lstlisting}
+
+Le conteneur \texttt{alpine} jetable monte le volume nommé en
+lecture seule, le répertoire \texttt{backups/} hôte en écriture, et
+écrit l'archive tar. Même forme pour restaurer — voir la section
+Restauration plus bas.
 
 \section{Cadence recommandée}
 
@@ -113,10 +138,26 @@ docker compose start mybibli
 Pour MariaDB externe, les mêmes commandes client \texttt{mariadb}
 fonctionnent contre le serveur externe.
 
-\subsection*{Covers et \texttt{.env}}
+\subsection*{Couvertures et \texttt{.env}}
+
+Pour un install bind-mount hôte :
 
 \begin{lstlisting}
 tar xzf backups/mybibli-files-20260513.tar.gz
+\end{lstlisting}
+
+Pour l'install par défaut (volume nommé), restaurez via un
+conteneur jetable symétrique à la sauvegarde :
+
+\begin{lstlisting}
+docker compose stop mybibli
+docker run --rm \
+    -v mybibli_covers:/target \
+    -v "$(pwd)/backups:/backup:ro" \
+    alpine \
+    sh -c "rm -rf /target/* && tar xzf /backup/mybibli-covers-20260513.tar.gz -C /target"
+tar xzf backups/mybibli-env-20260513.tar.gz
+docker compose start mybibli
 \end{lstlisting}
 
 Redémarrez la pile pour que le conteneur mybibli prenne en compte

--- a/docs/manual/fr/10-troubleshooting.tex
+++ b/docs/manual/fr/10-troubleshooting.tex
@@ -204,18 +204,38 @@ combleront l'écart.
 
 \section{Images de couverture manquantes}
 
-\subsection*{Symptôme : chaque titre affiche le placeholder}
+\subsection*{Symptôme : chaque titre affiche le placeholder}\label{sec:troubleshoot-couvertures-manquantes}
 
-Le répertoire \texttt{covers/} est vide ou illisible. Confirmez :
+Le répertoire des couvertures est vide ou illisible. Confirmez :
 
 \begin{itemize}
-  \item que le volume monté dans \texttt{docker-compose.yml} pointe
-        vers un répertoire qui existe et est accessible en écriture
-        au conteneur ;
+  \item que \texttt{docker-compose.yml} déclare le volume nommé
+        \texttt{mybibli\_covers} (ou un bind mount sur
+        \texttt{COVERS\_HOST\_PATH}) mappé sur \texttt{/app/covers}.
+        Les installs antérieures à 1.1.4 ne déclaraient PAS ce
+        volume — voir la sous-section suivante ;
   \item que la récupération de métadonnées a effectivement renvoyé
         une URL de couverture (regardez la page du titre — si l'URL
         manque, le fournisseur ne l'a pas fournie).
 \end{itemize}
+
+\subsection*{Symptôme : les couvertures ont disparu après mise à jour de l'image}\label{sec:troubleshoot-couvertures-perte-mise-a-jour}
+
+Vous avez mis à jour depuis une install antérieure à 1.1.4 et toutes
+les couvertures précédemment cataloguées ont disparu. Il s'agit de
+l'issue~\#213 — l'ancien modèle compose ne persistait pas
+\texttt{/app/covers}, donc le layer en écriture portant ces JPG a
+été détruit quand le nouveau conteneur a remplacé l'ancien.
+
+Correctif : récupérez le \texttt{docker-compose.yml} de la 1.1.4,
+puis lancez \texttt{docker compose down \&\& docker compose up -d}.
+Les couvertures suivantes seront persistées dans le volume
+\texttt{mybibli\_covers}.
+
+Récupération des couvertures perdues : ouvrez la page de détail de
+chaque titre concerné et cliquez sur \emph{Re-télécharger les
+métadonnées} pour repeupler depuis la chaîne de fournisseurs. Une
+action en masse est suivie dans l'issue~\#214.
 
 \section{Où signaler un bug}
 


### PR DESCRIPTION
## Summary

- Adds named volume `mybibli_covers` to `docker-compose.yml` so cover JPGs survive `docker compose up -d` after a `pull` (issue #213)
- Documents an optional `COVERS_HOST_PATH` bind-mount override for users who want a host-visible directory (Synology DSM, rsync routines)
- Full doc sync per Foundation Rule #19: README, user manual EN/FR (install + backup + troubleshooting), Docker Hub overview
- Bumps Cargo.toml 1.1.3 → 1.1.4

Closes #213.

## Recovery for affected users

Per-title metadata re-fetch (no new code). Bulk action is tracked separately at #214.

## Test plan

- [x] `cargo check` + `cargo clippy --tests` (SQLX_OFFLINE) clean
- [x] Manual review of `docker-compose.yml` syntax (validated by docker compose config in next CI run)
- [ ] CI passes
- [ ] Smoke after merge: pull `gcorbaz/mybibli:1.1.4` against the new compose, scan a title, restart container, confirm cover JPG still served from `/covers/<id>.jpg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)