### PR TITLE
fix(#203,#202): defensive genre fallback + Google Books docs

### DIFF
--- a/docs/manual/en/05-metadata-providers.tex
+++ b/docs/manual/en/05-metadata-providers.tex
@@ -43,17 +43,42 @@ Three providers require an API key:
 
 \subsection*{Google Books}
 
-Optional but raises the daily request budget significantly.
+Optional but raises the daily request budget significantly. Without
+a key the Google Books provider stays disabled — the chain still
+works (BnF \texttt{→} Open Library are key-less), but English-language
+trade non-fiction that BnF misses will land with empty metadata.
+
+The Google Cloud Console flow trips up many first-timers because
+the API-key creation step is buried two menus deep. Walk through
+this exactly:
 
 \begin{enumerate}
-  \item Sign in to \url{https://console.cloud.google.com/}.
-  \item Create a new project (or reuse one).
-  \item Enable the \textbf{Books API}.
-  \item Create an \textbf{API key} under \emph{APIs \& Services →
-        Credentials}.
-  \item Paste it into \texttt{/admin > System > Metadata Providers}
-        in mybibli.
+  \item Open \url{https://console.cloud.google.com/} and sign in.
+  \item Top-bar project picker (next to the
+        \emph{Google Cloud} logo) → \emph{New project} → name it
+        anything (e.g.\ \texttt{mybibli-metadata}) → \emph{Create}.
+        Wait a few seconds for the project to be selected.
+  \item Hamburger menu (≡) → \emph{APIs \& Services} →
+        \emph{Library}. Search for \textbf{Books API}, click it,
+        then \emph{Enable}.
+  \item Still under \emph{APIs \& Services}, open
+        \emph{Credentials}. Click \emph{+ Create credentials} →
+        \emph{API key}. A modal pops up with a freshly generated
+        key — copy it now.
+  \item Recommended: click \emph{Restrict key} → under
+        \emph{API restrictions} pick \emph{Restrict key} → tick
+        only \emph{Books API}. Leave \emph{Application
+        restrictions} on \emph{None} (mybibli does not send a
+        Referer header). Save.
+  \item In mybibli: \texttt{/admin > System > Metadata Providers}
+        → paste into the \textbf{Google Books API key} field →
+        \emph{Save}. The next scan picks it up — no restart needed.
 \end{enumerate}
+
+To verify the key is active, scan an English-only ISBN that BnF
+will not have (\emph{Effective Java}, 9780134685991, is a good
+canary). The metadata should populate within a few seconds. If it
+stays empty, see \emph{Troubleshooting} at the end of the chapter.
 
 \subsection*{OMDb}
 
@@ -128,3 +153,35 @@ only placeholders. If a key leaks, rotate it at the provider
 console immediately — pasting a new key into mybibli takes effect
 within seconds.
 \end{warning}
+
+\section{Troubleshooting empty metadata}
+
+If a freshly scanned ISBN ends up with empty title / author /
+description fields, walk this list before suspecting a bug:
+
+\begin{enumerate}
+  \item \textbf{Provider status in \texttt{/admin > Health}.}
+        If Google Books or Open Library show a red cross, those
+        providers will be skipped on every fetch. Re-check the
+        last-checked HTTP code — \texttt{403} or \texttt{401}
+        usually means a missing or invalid API key, not a remote
+        outage.
+  \item \textbf{Language of the title.} BnF is the primary
+        provider and is FR-leaning. For English-only books, the
+        chain falls through to Google Books — which means the
+        key (see above) is the unblocker.
+  \item \textbf{ISBN format.} mybibli normalises EAN-13 vs ISBN-10
+        internally, but some providers index only one of the two.
+        A second scan a few minutes later sometimes hits a
+        different fallback path.
+  \item \textbf{Manually edit and save.} You can always edit
+        title, genre, contributors etc.\ by hand from the title's
+        detail page — saving works even when no provider returned
+        anything. The genre \texttt{Non classé} is the default for
+        any title that came in without classification data.
+\end{enumerate}
+
+If the fields are still empty after configuring the right keys
+and waiting a few seconds, open an issue on the project repo with
+the failing ISBN — the maintainers add provider mocks for
+reproducible cases.

--- a/docs/manual/fr/05-metadata-providers.tex
+++ b/docs/manual/fr/05-metadata-providers.tex
@@ -46,17 +46,46 @@ Trois fournisseurs requièrent une clé d'API :
 \subsection*{Google Books}
 
 Optionnelle mais relève significativement le budget de requêtes
-quotidien.
+quotidien. Sans clé, le fournisseur Google Books reste désactivé —
+la chaîne fonctionne toujours (BnF \texttt{→} Open Library
+n'exigent pas de clé), mais les ouvrages anglophones grand public
+que BnF ne référence pas arriveront avec des métadonnées vides.
+
+Le parcours dans la Google Cloud Console déroute souvent les
+nouveaux venus parce que l'étape de création de la clé est nichée
+à deux menus de profondeur. Suivez exactement ces étapes :
 
 \begin{enumerate}
-  \item Connectez-vous sur \url{https://console.cloud.google.com/}.
-  \item Créez un nouveau projet (ou réutilisez-en un).
-  \item Activez l'\textbf{API Books}.
-  \item Créez une \textbf{clé d'API} sous \emph{APIs \& Services →
-        Credentials}.
-  \item Collez-la dans \texttt{/admin > System > Metadata
-        Providers} dans mybibli.
+  \item Ouvrez \url{https://console.cloud.google.com/} et
+        connectez-vous.
+  \item Sélecteur de projet en haut (à côté du logo
+        \emph{Google Cloud}) → \emph{Nouveau projet} → nommez-le
+        librement (p.\,ex.\ \texttt{mybibli-metadata}) →
+        \emph{Créer}. Attendez quelques secondes que le projet
+        soit sélectionné.
+  \item Menu hamburger (≡) → \emph{APIs \& services} →
+        \emph{Bibliothèque}. Cherchez \textbf{Books API}, cliquez
+        dessus, puis \emph{Activer}.
+  \item Toujours sous \emph{APIs \& services}, ouvrez
+        \emph{Identifiants}. Cliquez \emph{+ Créer des
+        identifiants} → \emph{Clé d'API}. Une fenêtre affiche
+        une clé fraîchement générée — copiez-la maintenant.
+  \item Recommandé : cliquez \emph{Restreindre la clé} → sous
+        \emph{Restrictions d'API} choisissez \emph{Restreindre la
+        clé} → cochez uniquement \emph{Books API}. Laissez
+        \emph{Restrictions d'application} sur \emph{Aucune}
+        (mybibli n'envoie pas d'en-tête Referer). Enregistrez.
+  \item Dans mybibli : \texttt{/admin > System > Metadata
+        Providers} → collez dans le champ \textbf{Google Books
+        API key} → \emph{Enregistrer}. Le prochain scan la prend
+        en compte — pas de redémarrage requis.
 \end{enumerate}
+
+Pour vérifier que la clé est active, scannez un ISBN anglophone
+que BnF ne connaît pas (\emph{Effective Java}, 9780134685991, est
+un bon canari). Les métadonnées doivent se peupler en quelques
+secondes. Si elles restent vides, voyez \emph{Dépannage} en fin
+de chapitre.
 
 \subsection*{OMDb}
 
@@ -136,3 +165,37 @@ fuit, faites-la tourner immédiatement sur la console du
 fournisseur — coller une nouvelle clé dans mybibli prend effet en
 quelques secondes.
 \end{warning}
+
+\section{Dépannage : métadonnées vides}
+
+Si un ISBN fraîchement scanné finit avec des champs titre /
+auteur / description vides, parcourez cette liste avant de
+suspecter un bug :
+
+\begin{enumerate}
+  \item \textbf{État des fournisseurs dans \texttt{/admin >
+        Health}.} Si Google Books ou Open Library affichent une
+        croix rouge, ces fournisseurs sont sautés à chaque
+        récupération. Vérifiez le code HTTP du dernier check —
+        \texttt{403} ou \texttt{401} signifie en général une clé
+        d'API absente ou invalide, pas une panne du fournisseur.
+  \item \textbf{Langue du titre.} BnF est le fournisseur primaire
+        et privilégie le français. Pour les livres anglophones,
+        la chaîne bascule sur Google Books — donc la clé (voir
+        plus haut) est la pièce qui débloque la situation.
+  \item \textbf{Format de l'ISBN.} mybibli normalise EAN-13 vs
+        ISBN-10 en interne, mais certains fournisseurs n'indexent
+        que l'un des deux. Un second scan quelques minutes plus
+        tard frappe parfois une route de repli différente.
+  \item \textbf{Édition manuelle.} Vous pouvez toujours saisir
+        titre, genre, contributeurs etc.\ à la main depuis la
+        page de détail du titre — la sauvegarde fonctionne même
+        si aucun fournisseur n'a répondu. Le genre \texttt{Non
+        classé} est la valeur par défaut pour un titre arrivé
+        sans données de classification.
+\end{enumerate}
+
+Si les champs restent vides après avoir configuré les bonnes
+clés et attendu quelques secondes, ouvrez une issue sur le dépôt
+du projet avec l'ISBN qui échoue — les mainteneurs ajoutent des
+mocks de fournisseurs pour les cas reproductibles.

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -545,6 +545,17 @@ pub async fn update_title(
         .await?
         .ok_or_else(|| AppError::NotFound(rust_i18n::t!("error.not_found", locale = loc).to_string()))?;
 
+    // Defensive fallback: if the submitted genre_id is 0 (missing field,
+    // empty <select>, or a corrupt row where title.genre_id pointed at a
+    // soft-deleted genre and the dropdown had no `selected` option), fall
+    // back to the seeded "Non classé" default — TitleService self-heals the
+    // row when missing, so this never errors on a clean schema.
+    let resolved_genre_id = if form.genre_id == 0 {
+        TitleService::find_default_genre_id(pool).await?
+    } else {
+        form.genre_id
+    };
+
     let trimmed_title = form.title.trim();
     let subtitle = non_empty(&form.subtitle);
     let description = non_empty(&form.description);
@@ -570,7 +581,7 @@ pub async fn update_title(
         description.as_deref(),
         publisher.as_deref(),
         &form.language,
-        form.genre_id,
+        resolved_genre_id,
         publication_date,
         dewey_code.as_deref(),
         form.page_count,
@@ -605,7 +616,7 @@ pub async fn update_title(
         description.as_deref(),
         publisher.as_deref(),
         &form.language,
-        form.genre_id,
+        resolved_genre_id,
         publication_date,
         dewey_code.as_deref(),
         form.page_count,

--- a/src/services/title.rs
+++ b/src/services/title.rs
@@ -236,18 +236,44 @@ impl TitleService {
         TitleModel::create(pool, &new_title).await
     }
 
-    async fn find_default_genre_id(pool: &DbPool) -> Result<u64, AppError> {
-        let row: Option<(u64,)> = sqlx::query_as(
+    pub async fn find_default_genre_id(pool: &DbPool) -> Result<u64, AppError> {
+        if let Some((id,)) = sqlx::query_as::<_, (u64,)>(
             "SELECT id FROM genres WHERE name = 'Non classé' AND deleted_at IS NULL LIMIT 1",
         )
         .fetch_optional(pool)
-        .await?;
+        .await?
+        {
+            return Ok(id);
+        }
 
-        row.map(|r| r.0).ok_or_else(|| {
-            AppError::Internal(
-                "Default genre 'Non classé' not found. Run seed migrations first.".to_string(),
-            )
-        })
+        // Reactivate soft-deleted row if present — the UNIQUE constraint on
+        // `genres.name` would otherwise block the INSERT below.
+        if let Some((id,)) = sqlx::query_as::<_, (u64,)>(
+            "SELECT id FROM genres WHERE name = 'Non classé' AND deleted_at IS NOT NULL LIMIT 1",
+        )
+        .fetch_optional(pool)
+        .await?
+        {
+            sqlx::query("UPDATE genres SET deleted_at = NULL WHERE id = ?")
+                .bind(id)
+                .execute(pool)
+                .await?;
+            tracing::warn!(
+                genre_id = id,
+                "Reactivated soft-deleted 'Non classé' default genre"
+            );
+            return Ok(id);
+        }
+
+        let result = sqlx::query("INSERT INTO genres (name) VALUES ('Non classé')")
+            .execute(pool)
+            .await?;
+        let id = result.last_insert_id();
+        tracing::warn!(
+            genre_id = id,
+            "Default genre 'Non classé' was missing — re-seeded"
+        );
+        Ok(id)
     }
 
     async fn insert_pending_metadata(

--- a/tests/e2e/mock-metadata-server/server.py
+++ b/tests/e2e/mock-metadata-server/server.py
@@ -182,8 +182,10 @@ class MockMetadataHandler(http.server.BaseHTTPRequestHandler):
 
         # Blocklist: ISBNs that must return "not found" from BnF
         # - 9780000000002: used by provider-chain to test "all providers fail"
+        # - 9780000000019: used by title-edit-no-metadata (#203) — title is created
+        #   with empty metadata, exercising the edit-then-save flow
         # - Google Books known ISBNs: must NOT resolve via BnF so the chain falls through to Google Books
-        NO_METADATA_ISBNS = {"9780000000002", "9780134685991", "9780201633610"}
+        NO_METADATA_ISBNS = {"9780000000002", "9780000000019", "9780134685991", "9780201633610"}
 
         if isbn and isbn in BNF_KNOWN_ISBNS:
             body = make_sru_response(BNF_KNOWN_ISBNS[isbn])

--- a/tests/e2e/specs/journeys/title-edit-no-metadata.spec.ts
+++ b/tests/e2e/specs/journeys/title-edit-no-metadata.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+// Sentinel ISBN: the mock metadata server returns NO metadata from any
+// provider for this code (see NO_METADATA_ISBNS in mock-metadata-server/server.py).
+// Used to reproduce the user-reported scenario in issue #203: scan a code
+// that the provider chain cannot resolve, then save edits manually.
+const NO_METADATA_ISBN = "9780000000019";
+
+test.describe("Title edit after no metadata (#203)", () => {
+  // The scan response shape (skeleton vs. info) depends on whether the title
+  // already exists. Retries would land on the info-variant path and the
+  // skeleton id regex would not match — disable retries so the first attempt
+  // is the source of truth.
+  test.describe.configure({ retries: 0 });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page);
+  });
+
+  // Direct API for both scan and save instead of the HTMX form. Submitting
+  // through the form proved sensitive to DB state across retries and to the
+  // intermediate HTMX retarget/swap pipeline. Mirrors the createLoan helper.
+  test("scan no-metadata ISBN, edit title, save with picked genre", async ({
+    page,
+  }) => {
+    await page.goto("/catalog");
+    const csrfToken = await page.evaluate(() =>
+      document.querySelector('meta[name="csrf-token"]')?.getAttribute("content")
+    );
+    expect(csrfToken, "csrf token meta tag must be present").toBeTruthy();
+
+    const scanResp = await page.request.post("/catalog/scan", {
+      form: { code: NO_METADATA_ISBN, _csrf_token: csrfToken ?? "" },
+      headers: { "HX-Request": "true", "X-CSRF-Token": csrfToken ?? "" },
+    });
+    expect(scanResp.ok(), `scan failed: ${scanResp.status()}`).toBe(true);
+    const scanHtml = await scanResp.text();
+    const idMatch = scanHtml.match(/id="feedback-entry-(\d+)"/);
+    expect(
+      idMatch,
+      `no skeleton id in scan response. Response was:\n${scanHtml.slice(0, 500)}`
+    ).toBeTruthy();
+    const titleId = idMatch![1];
+
+    // Read the list of active genres from the edit form so we pick a real
+    // (non-default) id without hardcoding it.
+    const editFormResp = await page.request.get(`/title/${titleId}/edit`);
+    expect(editFormResp.ok()).toBe(true);
+    const editFormHtml = await editFormResp.text();
+    const versionMatch = editFormHtml.match(
+      /name="version" value="(\d+)"/
+    );
+    expect(versionMatch).toBeTruthy();
+    const version = versionMatch![1];
+
+    const romanMatch = editFormHtml.match(/<option value="(\d+)"[^>]*>Roman</);
+    expect(romanMatch, "Roman genre must exist in the edit form").toBeTruthy();
+    const romanId = romanMatch![1];
+
+    // Save: emulate the form's POST. Use a real genre + a real title so the
+    // assertion below distinguishes success from "form unchanged".
+    const saveResp = await page.request.post(`/title/${titleId}`, {
+      form: {
+        version,
+        title: "Test no-metadata book",
+        language: "fr",
+        genre_id: romanId,
+        _csrf_token: csrfToken ?? "",
+      },
+      headers: { "HX-Request": "true", "X-CSRF-Token": csrfToken ?? "" },
+    });
+    expect(saveResp.ok(), `save failed: ${saveResp.status()}`).toBe(true);
+    const saveHtml = await saveResp.text();
+    expect(saveHtml).toContain("Test no-metadata book");
+    expect(saveHtml).toContain("Roman");
+
+    // And the persisted state is reflected on a fresh navigation, ruling out
+    // a transient response that wasn't actually written.
+    await page.goto(`/title/${titleId}`);
+    await expect(page.locator("#title-metadata")).toContainText(
+      "Test no-metadata book"
+    );
+    await expect(page.locator("#title-metadata")).toContainText("Roman");
+  });
+
+  // Defensive-fallback contract: even if the form submits with no genre_id
+  // (sentinel #[serde(default)] = 0 — empty <select>, corrupt row, or
+  // missing field), the save resolves to the "Non classé" default rather
+  // than failing with an FK violation. This is what #203's fix added.
+  test("save with missing genre_id falls back to Non classé", async ({
+    page,
+  }) => {
+    await page.goto("/catalog");
+    const csrfToken = await page.evaluate(() =>
+      document.querySelector('meta[name="csrf-token"]')?.getAttribute("content")
+    );
+    expect(csrfToken).toBeTruthy();
+
+    // Use a different ISBN so this case has its own row, independent of the
+    // first test's title.
+    const ISBN = "9780000000026"; // Valid checksum (computed by hand)
+
+    const scanResp = await page.request.post("/catalog/scan", {
+      form: { code: ISBN, _csrf_token: csrfToken ?? "" },
+      headers: { "HX-Request": "true", "X-CSRF-Token": csrfToken ?? "" },
+    });
+    expect(scanResp.ok()).toBe(true);
+    const scanHtml = await scanResp.text();
+    const idMatch = scanHtml.match(/id="feedback-entry-(\d+)"/);
+    expect(idMatch).toBeTruthy();
+    const titleId = idMatch![1];
+
+    const editFormResp = await page.request.get(`/title/${titleId}/edit`);
+    const versionMatch = (await editFormResp.text()).match(
+      /name="version" value="(\d+)"/
+    );
+    const version = versionMatch![1];
+
+    // genre_id intentionally omitted from the form — `#[serde(default)] u64`
+    // makes it 0 server-side, exercising the fallback.
+    const saveResp = await page.request.post(`/title/${titleId}`, {
+      form: {
+        version,
+        title: "Missing-genre fallback",
+        language: "fr",
+        _csrf_token: csrfToken ?? "",
+      },
+      headers: { "HX-Request": "true", "X-CSRF-Token": csrfToken ?? "" },
+    });
+    expect(
+      saveResp.ok(),
+      `save with missing genre_id failed: ${saveResp.status()}`
+    ).toBe(true);
+    const saveHtml = await saveResp.text();
+    expect(saveHtml).toContain("Non classé");
+  });
+});

--- a/tests/title_default_genre.rs
+++ b/tests/title_default_genre.rs
@@ -1,0 +1,79 @@
+//! Integration tests for `TitleService::find_default_genre_id` — issue #203.
+//!
+//! Regression coverage for the "save title fails when no metadata" bug:
+//! the helper must return a valid `Non classé` row even after admin deletes
+//! it, so the update-title handler's fallback path never hits an FK violation.
+//!
+//! To run locally:
+//!
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test title_default_genre
+
+use mybibli::services::title::TitleService;
+use sqlx::MySqlPool;
+
+#[sqlx::test(migrations = "./migrations")]
+async fn returns_seeded_non_classe_when_present(pool: MySqlPool) {
+    let id = TitleService::find_default_genre_id(&pool)
+        .await
+        .expect("default genre lookup");
+    let (name,): (String,) = sqlx::query_as("SELECT name FROM genres WHERE id = ?")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("genre row");
+    assert_eq!(name, "Non classé");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn reactivates_soft_deleted_non_classe(pool: MySqlPool) {
+    // Soft-delete the seeded "Non classé" row.
+    let (seeded_id,): (u64,) = sqlx::query_as(
+        "SELECT id FROM genres WHERE name = 'Non classé' AND deleted_at IS NULL LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("seeded id");
+    sqlx::query("UPDATE genres SET deleted_at = NOW() WHERE id = ?")
+        .bind(seeded_id)
+        .execute(&pool)
+        .await
+        .expect("soft delete");
+
+    let resolved = TitleService::find_default_genre_id(&pool)
+        .await
+        .expect("self-heal lookup");
+    assert_eq!(resolved, seeded_id, "should reactivate same row, not insert new");
+
+    let (deleted_at,): (Option<chrono::NaiveDateTime>,) =
+        sqlx::query_as("SELECT deleted_at FROM genres WHERE id = ?")
+            .bind(seeded_id)
+            .fetch_one(&pool)
+            .await
+            .expect("row after self-heal");
+    assert!(deleted_at.is_none(), "row should be reactivated");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn reseeds_when_missing_entirely(pool: MySqlPool) {
+    // Hard-delete the seeded row. We must first repoint any titles that
+    // reference it (none in a fresh test DB, but be explicit) and then
+    // DELETE — there's a FK from titles.genre_id, so any orphan title
+    // would block this DELETE. In a freshly migrated DB there are no
+    // titles, so this is safe.
+    sqlx::query("DELETE FROM genres WHERE name = 'Non classé'")
+        .execute(&pool)
+        .await
+        .expect("hard delete");
+
+    let id = TitleService::find_default_genre_id(&pool)
+        .await
+        .expect("self-heal insert");
+    let (name,): (String,) = sqlx::query_as("SELECT name FROM genres WHERE id = ?")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("row after re-seed");
+    assert_eq!(name, "Non classé");
+}


### PR DESCRIPTION
## Summary

Bundle PR addressing two related issues surfaced by the same production user on 2026-05-15:

- **#203** (bug, severity:medium) — Save-title flow now self-heals when the submitted `genre_id` is 0 (missing field, empty `<select>`, or a stale row pointing at a soft-deleted genre): the handler falls back to the seeded "Non classé" default rather than hitting the FK constraint.
- **#202** (change-request) — Expanded the Google Books configuration walk-through in the user manual (en + fr), plus added a Troubleshooting section so operators have a checklist when a scan returns no metadata. No code changes for #202 — the broader ideas in the issue (badge per metadata source, per-provider retry, structured error surfacing) remain open for future stories.

## What changed

- `src/services/title.rs::find_default_genre_id` promoted to `pub` and made self-healing:
  - returns the active "Non classé" id when present,
  - reactivates a soft-deleted row when found (UNIQUE on `genres.name` would otherwise block an INSERT),
  - inserts a fresh row when neither exists.
- `src/routes/titles.rs::update_title` substitutes `form.genre_id == 0` with `TitleService::find_default_genre_id(pool)` before passing the value to `update_metadata` and `detect_edited_fields`.
- `docs/manual/{en,fr}/05-metadata-providers.tex`:
  - Google Books subsection now describes the Google Cloud Console flow step by step (project picker → enable Books API → Credentials → API restrictions → paste into `/admin > System > Metadata Providers`).
  - New `Troubleshooting empty metadata` section points operators at `/admin > Health`, language considerations, ISBN format normalisation, and the manual edit fallback.
- `tests/e2e/mock-metadata-server/server.py` — added `9780000000019` to the `NO_METADATA_ISBNS` blocklist (sentinel ISBN used by the new E2E spec).

## Tests

- 3 new `#[sqlx::test]` cases in `tests/title_default_genre.rs` covering the self-heal contract (present / soft-deleted / hard-deleted).
- New `tests/e2e/specs/journeys/title-edit-no-metadata.spec.ts` covering:
  - Happy path: scan no-metadata ISBN → edit → save with picked genre → persisted state visible on fresh navigation.
  - Defensive contract: POST `/title/{id}` with no `genre_id` field → save resolves to "Non classé" rather than 4xx/5xx.

## Test plan

- [x] `SQLX_OFFLINE=true cargo check`
- [x] `cargo clippy -- -D warnings` (zero warnings)
- [x] `cargo test --lib` — 805 passed
- [x] `cargo test --test title_default_genre` — 3 passed against rust-test DB at port 3307
- [x] `cargo sqlx prepare --check --workspace -- --all-targets` — cache in sync
- [x] `./scripts/e2e-reset.sh` — stack rebuilds + starts
- [x] `CI=true npx playwright test journeys/{catalog-title,metadata-editing,catalog-metadata,title-edit-no-metadata} --workers=2` — 23 passed, 1 flaky pre-existing (catalog-title:149 — unrelated)
- [x] Flake gate: no `waitForTimeout` in new spec
- [ ] CI green on this PR

## Closes

Closes #203
Refs #202 (docs slice — broader UX work tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)