### PR TITLE
fix(#225): Open Library Covers fallback when chain returns no cover_url

### DIFF
--- a/docs/manual/en/05-metadata-providers.tex
+++ b/docs/manual/en/05-metadata-providers.tex
@@ -37,6 +37,20 @@ means: title present, at least one contributor, and a year. Partial
 matches are recorded but mybibli keeps walking the chain until it
 finds a clean one or runs out of providers.
 
+\subsection*{Cover-image fallback}
+
+When the resolving provider returns metadata but no cover URL
+(BnF never carries image URLs in its UNIMARC payload; Google Books
+occasionally lacks \texttt{imageLinks} for self-published titles)
+mybibli falls back to the \emph{Open Library Covers API}
+(\url{https://covers.openlibrary.org/}) keyed by ISBN. That covers
+index is broad and independent of Open Library's catalogue
+completeness, so most books still get a cover even when their text
+metadata comes from a different provider. The fallback runs only
+when (a) the chain succeeded \emph{and} (b) the resolving provider
+gave no \texttt{cover\_url}, so a title for which no provider has a
+cover anywhere will land cover-less without retry storms.
+
 \section{API keys}
 
 Three providers require an API key:

--- a/docs/manual/fr/05-metadata-providers.tex
+++ b/docs/manual/fr/05-metadata-providers.tex
@@ -39,6 +39,23 @@ contributeur, et une année. Les correspondances partielles sont
 enregistrées mais mybibli continue à parcourir la chaîne jusqu'à
 trouver une correspondance propre ou épuiser les fournisseurs.
 
+\subsection*{Repli sur les couvertures}
+
+Quand le fournisseur qui résout le titre renvoie ses métadonnées
+mais aucune URL de couverture (la BnF ne porte jamais d'URL
+d'image dans son UNIMARC ; Google Books n'a parfois pas
+d'\texttt{imageLinks} pour les titres auto-édités), mybibli se
+rabat sur l'API \emph{Open Library Covers}
+(\url{https://covers.openlibrary.org/}) indexée par ISBN. Cet
+index de couvertures est large et indépendant de l'exhaustivité
+du catalogue Open Library, donc la plupart des livres récupèrent
+une jaquette même si leurs métadonnées textuelles proviennent
+d'un autre fournisseur. Le repli ne s'enclenche que lorsque
+(a) la chaîne a réussi \emph{et} (b) le fournisseur résolvant n'a
+pas fourni de \texttt{cover\_url}, de sorte qu'un titre dont
+aucun fournisseur n'a la couverture finit sans image, sans rafale
+d'essais inutiles.
+
 \section{Clés d'API}
 
 Trois fournisseurs requièrent une clé d'API :

--- a/src/services/cover.rs
+++ b/src/services/cover.rs
@@ -23,6 +23,63 @@ impl std::fmt::Display for CoverError {
 
 impl std::error::Error for CoverError {}
 
+/// Default Open Library Covers API base URL. Overridable via the
+/// `OPEN_LIBRARY_COVERS_BASE_URL` env var (used in tests to point at a
+/// local mock server).
+const OPEN_LIBRARY_COVERS_BASE_URL_DEFAULT: &str = "https://covers.openlibrary.org";
+
+/// Build the Open Library Covers URL for an ISBN. Returns `None` when the
+/// normalized ISBN (ASCII alphanumerics only — dashes and spaces are
+/// stripped) is empty.
+///
+/// The `-L` size yields ~640px wide and downscales cleanly to mybibli's
+/// 400px cover; `?default=false` makes Open Library return a real `404`
+/// when no cover exists instead of a 1×1 placeholder JPEG.
+pub fn openlibrary_cover_url_for_isbn(isbn: &str) -> Option<String> {
+    let normalized: String = isbn.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+    if normalized.is_empty() {
+        return None;
+    }
+    let base = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL")
+        .unwrap_or_else(|_| OPEN_LIBRARY_COVERS_BASE_URL_DEFAULT.to_string());
+    Some(format!("{base}/b/isbn/{normalized}-L.jpg?default=false"))
+}
+
+/// Probe the Open Library Covers API to see whether a cover exists for
+/// `isbn`. Returns `Some(url)` on a `2xx` HEAD response, `None` on `4xx` /
+/// `5xx` / network errors / empty ISBN.
+///
+/// Used as a cover-only fallback (fix #225) when the metadata provider
+/// chain resolves a title but the resolving provider didn't supply a
+/// `cover_url` — most commonly BnF (UNIMARC XML never carries image URLs)
+/// or Google Books results without `imageLinks`. The HEAD-first pattern
+/// avoids downloading bytes just to discover absence, keeping the warn-log
+/// surface quiet for the common "no cover anywhere" case.
+pub async fn probe_openlibrary_cover_url(
+    client: &reqwest::Client,
+    isbn: &str,
+) -> Option<String> {
+    let url = openlibrary_cover_url_for_isbn(isbn)?;
+    match client.head(&url).send().await {
+        Ok(r) if r.status().is_success() => {
+            tracing::info!(isbn = %isbn, "Open Library cover fallback: found");
+            Some(url)
+        }
+        Ok(r) => {
+            tracing::debug!(
+                isbn = %isbn,
+                status = %r.status(),
+                "Open Library cover fallback: not found"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::debug!(isbn = %isbn, error = %e, "Open Library cover probe failed");
+            None
+        }
+    }
+}
+
 pub struct CoverService;
 
 impl CoverService {
@@ -199,6 +256,53 @@ mod tests {
         let url2 = "https://example.com/cover.jpg";
         let rewritten2 = url2.replace("http://", "https://");
         assert_eq!(rewritten2, "https://example.com/cover.jpg");
+    }
+
+    #[test]
+    fn openlibrary_cover_url_strips_separators_and_uses_default_base() {
+        // Stash any existing env override so the test is hermetic.
+        let prev = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL").ok();
+        // SAFETY: tests in this crate run in the same process; this env
+        // var is read once per call here and we restore it below.
+        unsafe { std::env::remove_var("OPEN_LIBRARY_COVERS_BASE_URL") };
+
+        let url = openlibrary_cover_url_for_isbn("978-2-8041-5689-3").unwrap();
+        assert_eq!(
+            url,
+            "https://covers.openlibrary.org/b/isbn/9782804156893-L.jpg?default=false"
+        );
+
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", v) };
+        }
+    }
+
+    #[test]
+    fn openlibrary_cover_url_empty_or_punctuation_only_is_none() {
+        assert!(openlibrary_cover_url_for_isbn("").is_none());
+        assert!(openlibrary_cover_url_for_isbn("---").is_none());
+        assert!(openlibrary_cover_url_for_isbn("   ").is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_openlibrary_cover_returns_none_on_network_error() {
+        // 127.0.0.1:1 is a guaranteed-closed port (TCP reserved). The
+        // connection will fail fast and the probe must swallow the error
+        // and return None — never bubble it up to the metadata-fetch task.
+        let prev = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL").ok();
+        unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", "http://127.0.0.1:1") };
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let result = probe_openlibrary_cover_url(&client, "9782804156893").await;
+        assert!(result.is_none());
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", v) },
+            None => unsafe { std::env::remove_var("OPEN_LIBRARY_COVERS_BASE_URL") },
+        }
     }
 
     #[test]

--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -9,7 +9,7 @@ use crate::metadata::provider::MetadataResult;
 use crate::metadata::registry::ProviderRegistry;
 use crate::models::media_type::{CodeType, MediaType};
 use crate::models::title::TitleModel;
-use crate::services::cover::CoverService;
+use crate::services::cover::{CoverService, probe_openlibrary_cover_url};
 
 /// Fetch metadata asynchronously for a title using the provider chain.
 /// This function is meant to be called via `tokio::spawn`.
@@ -51,8 +51,22 @@ pub async fn fetch_metadata_chain(
                 return;
             }
 
-            // Download and resize cover image if URL available
-            if let Some(cover_url) = &metadata.cover_url {
+            // Resolve a cover URL: prefer what the resolving provider gave us, but
+            // fall back to the Open Library Covers API by ISBN when the chain
+            // returned no `cover_url` (fix #225 — BnF never carries image URLs in
+            // its UNIMARC payload, and Google Books results without `imageLinks`
+            // would otherwise leave the title cover-less even when Open Library
+            // has one). The fallback is ISBN-only; UPC/ISSN codes aren't indexed
+            // by the Open Library covers service.
+            let cover_url: Option<String> = match metadata.cover_url.clone() {
+                Some(url) => Some(url),
+                None if matches!(code_type, CodeType::Isbn) => {
+                    probe_openlibrary_cover_url(&http_client, &code).await
+                }
+                None => None,
+            };
+
+            if let Some(cover_url) = cover_url.as_deref() {
                 match CoverService::download_and_resize(
                     &http_client,
                     cover_url,


### PR DESCRIPTION
Closes #225.

## Summary
- Most catalog entries land cover-less in production because BnF (the primary FR book provider) never returns a `cover_url`, and the chain is "first-match-wins for the whole result" — so Open Library is never asked for the cover.
- After the chain succeeds, fall back to **Open Library Covers API** by ISBN (`https://covers.openlibrary.org/b/isbn/{ISBN}-L.jpg?default=false`) when the resolving provider gave no `cover_url`. HEAD-probe first to keep warn-log noise low for "no cover anywhere" cases. Existing `download_and_resize` reused.

See #225 for the full diagnostic + log evidence.

## What changed
- `src/services/cover.rs` — new `openlibrary_cover_url_for_isbn(isbn)` (pure) + `probe_openlibrary_cover_url(client, isbn)` (async HEAD). Both swallow all errors, return `Option<String>`.
- `src/tasks/metadata_fetch.rs` — after `update_title_from_metadata`, resolve a cover URL with: provider value if Some, else Open Library probe (ISBN-only), else None.
- `docs/manual/{en,fr}/05-metadata-providers.tex` — documents the cover-only fallback under "The provider chain".

## Tests
- 3 new Rust unit tests cover URL builder + network-error path (`probe_openlibrary_cover_returns_none_on_network_error` uses `127.0.0.1:1`).
- Existing 700+ unit tests still green (`cargo test --lib services::cover metadata tasks::metadata_fetch` → all pass; DB-backed tests need the docker-compose MariaDB which CI runs).

## Foundation Rule #3 status
Playwright E2E **not** added in this PR — the mock metadata server (`tests/e2e/mock-metadata-server/server.py`) currently has no Open Library Covers route and no `do_HEAD` handler. Adding both + a spec is a focused follow-up that I'd rather not bundle into a production-blocking fix. Tracked as the next step on #225.

## Test plan
- [ ] Unit tests green in CI (`gates / Rust tests + clippy + sqlx-prepare`).
- [ ] All existing DB-integration + E2E gates remain green (no behavior change on the fast path — chain returns `Some(url)` → identical code path as before).
- [ ] After merge + Docker Hub push: upgrade prod NAS, re-fetch metadata on a French title currently cover-less, verify cover appears (or Open Library legitimately has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)