### PR TITLE
fix(#228): Open Library Covers fallback also in Re-fetch metadata path

### DIFF
--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -19,7 +19,7 @@ use crate::models::series::{SeriesModel, TitleSeriesAssignment};
 use crate::models::title::{SimilarTitle, TitleModel, detect_edited_fields};
 use crate::models::volume::VolumeModel;
 use crate::routes::catalog::feedback_html_pub;
-use crate::services::cover::CoverService;
+use crate::services::cover::{CoverService, resolve_cover_url_with_fallback};
 use crate::services::series::SeriesService;
 use crate::services::title::{FieldConflict, TitleService};
 use crate::utils::{current_url, html_escape};
@@ -719,11 +719,24 @@ pub async fn redownload_metadata(
         }
     };
 
+    // Resolve cover URL with the Open Library fallback (fix #228) once, before
+    // either branch consumes it. Both the direct-apply path and the conflict-
+    // confirmation form share the same resolved URL.
+    let resolved_cover_url =
+        resolve_cover_url_with_fallback(&state.http_client, &metadata, &code, &code_type).await;
+
     let manually_edited = title.parsed_manually_edited_fields();
 
     if manually_edited.is_empty() {
         // No manual edits — apply all metadata directly
-        let updated = apply_metadata_to_title(pool, &state, &title, &metadata).await?;
+        let updated = apply_metadata_to_title(
+            pool,
+            &state,
+            &title,
+            &metadata,
+            resolved_cover_url.as_deref(),
+        )
+        .await?;
         let genre_name = GenreModel::find_name_by_id(pool, updated.genre_id).await?;
         let has_code = true;
         let mut html = metadata_display_html(&updated, &genre_name, &session, has_code, loc);
@@ -785,7 +798,7 @@ pub async fn redownload_metadata(
         new_age_rating: metadata.age_rating.clone().unwrap_or_default(),
         new_issue_number: metadata.issue_number.clone().unwrap_or_default(),
         new_dewey_code: metadata.dewey_code.clone().unwrap_or_default(),
-        new_cover_url: metadata.cover_url.clone().unwrap_or_default(),
+        new_cover_url: resolved_cover_url.clone().unwrap_or_default(),
         label_confirm_title: rust_i18n::t!("metadata.confirm_title", locale = loc).to_string(),
         label_current: rust_i18n::t!("metadata.current_value", locale = loc).to_string(),
         label_new: rust_i18n::t!("metadata.new_value", locale = loc).to_string(),
@@ -1188,6 +1201,7 @@ async fn apply_metadata_to_title(
     state: &AppState,
     title: &TitleModel,
     metadata: &MetadataResult,
+    cover_url: Option<&str>,
 ) -> Result<TitleModel, AppError> {
     let pub_date = metadata.publication_date.as_deref().and_then(|s| {
         chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
@@ -1247,8 +1261,10 @@ async fn apply_metadata_to_title(
     )
     .await?;
 
-    // Download cover if available (use updated version for locking)
-    if let Some(cover_url) = &metadata.cover_url {
+    // Download cover if available — caller is responsible for resolving the URL,
+    // which gives the Open Library Covers fallback a single source of truth across
+    // the background-fetch + re-fetch paths (fix #228, extends #225).
+    if let Some(cover_url) = cover_url {
         match CoverService::download_and_resize(
             &state.http_client,
             cover_url,

--- a/src/services/cover.rs
+++ b/src/services/cover.rs
@@ -3,6 +3,9 @@ use std::path::Path;
 
 use image::ImageReader;
 
+use crate::metadata::provider::MetadataResult;
+use crate::models::media_type::CodeType;
+
 /// Errors that can occur during cover image download and processing.
 #[derive(Debug)]
 pub enum CoverError {
@@ -78,6 +81,34 @@ pub async fn probe_openlibrary_cover_url(
             None
         }
     }
+}
+
+/// Resolve a cover URL combining the resolving provider's `cover_url` and
+/// the Open Library Covers fallback. Single source of truth used by every
+/// code path that downloads a cover for a resolved metadata result
+/// (fix #228 — was inlined only in the background scan path #225).
+///
+/// Order:
+/// 1. If `metadata.cover_url` is `Some`, return it as-is.
+/// 2. Else, when `code_type` is ISBN, HEAD-probe Open Library Covers and
+///    return its URL on 2xx.
+/// 3. Else, `None`.
+///
+/// Never panics, never bubbles errors — the worst outcome is a title
+/// landing cover-less.
+pub async fn resolve_cover_url_with_fallback(
+    client: &reqwest::Client,
+    metadata: &MetadataResult,
+    code: &str,
+    code_type: &CodeType,
+) -> Option<String> {
+    if let Some(url) = &metadata.cover_url {
+        return Some(url.clone());
+    }
+    if matches!(code_type, CodeType::Isbn) {
+        return probe_openlibrary_cover_url(client, code).await;
+    }
+    None
 }
 
 pub struct CoverService;
@@ -177,6 +208,13 @@ impl CoverService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serialize every test that mutates `OPEN_LIBRARY_COVERS_BASE_URL`.
+    /// `set_var` / `remove_var` are process-global and tokio tests run on a
+    /// shared thread pool — without this lock, parallel runs leak the env
+    /// var between cases and the default-base-URL assertion fails.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_cover_error_display() {
@@ -260,6 +298,7 @@ mod tests {
 
     #[test]
     fn openlibrary_cover_url_strips_separators_and_uses_default_base() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // Stash any existing env override so the test is hermetic.
         let prev = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL").ok();
         // SAFETY: tests in this crate run in the same process; this env
@@ -285,7 +324,86 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // ENV_LOCK serializes env-var access between tests; release-before-await would defeat the purpose.
+    async fn resolve_cover_url_returns_provider_value_when_present() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // When the resolving provider supplied a cover_url, the helper must
+        // return it verbatim without touching Open Library — this is the
+        // "fast path" that every popular EN book on Google Books hits.
+        let prev = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL").ok();
+        // Point at a closed port: if the helper ever calls Open Library on
+        // the happy path it'll hang or error — we want it to return early.
+        unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", "http://127.0.0.1:1") };
+
+        let client = reqwest::Client::new();
+        let metadata = MetadataResult {
+            cover_url: Some("https://example.com/cover.jpg".to_string()),
+            ..MetadataResult::default()
+        };
+        let result =
+            resolve_cover_url_with_fallback(&client, &metadata, "9782804156893", &CodeType::Isbn)
+                .await;
+        assert_eq!(result.as_deref(), Some("https://example.com/cover.jpg"));
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", v) },
+            None => unsafe { std::env::remove_var("OPEN_LIBRARY_COVERS_BASE_URL") },
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn resolve_cover_url_skips_fallback_for_non_isbn_codes() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // UPC / ISSN codes aren't indexed by Open Library Covers — the helper
+        // must short-circuit to None without making a network call.
+        let prev = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL").ok();
+        unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", "http://127.0.0.1:1") };
+
+        let client = reqwest::Client::new();
+        let metadata = MetadataResult::default();
+        let upc = resolve_cover_url_with_fallback(&client, &metadata, "012345678905", &CodeType::Upc)
+            .await;
+        let issn =
+            resolve_cover_url_with_fallback(&client, &metadata, "00280836", &CodeType::Issn).await;
+        assert!(upc.is_none());
+        assert!(issn.is_none());
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", v) },
+            None => unsafe { std::env::remove_var("OPEN_LIBRARY_COVERS_BASE_URL") },
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn resolve_cover_url_returns_none_when_provider_silent_and_fallback_unreachable() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Belt-and-braces: no provider cover_url, ISBN code, OL probe fails →
+        // None. Must never panic, must never bubble the error.
+        let prev = std::env::var("OPEN_LIBRARY_COVERS_BASE_URL").ok();
+        unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", "http://127.0.0.1:1") };
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let metadata = MetadataResult::default();
+        let result =
+            resolve_cover_url_with_fallback(&client, &metadata, "9782804156893", &CodeType::Isbn)
+                .await;
+        assert!(result.is_none());
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OPEN_LIBRARY_COVERS_BASE_URL", v) },
+            None => unsafe { std::env::remove_var("OPEN_LIBRARY_COVERS_BASE_URL") },
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn probe_openlibrary_cover_returns_none_on_network_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // 127.0.0.1:1 is a guaranteed-closed port (TCP reserved). The
         // connection will fail fast and the probe must swallow the error
         // and return None — never bubble it up to the metadata-fetch task.

--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -9,7 +9,7 @@ use crate::metadata::provider::MetadataResult;
 use crate::metadata::registry::ProviderRegistry;
 use crate::models::media_type::{CodeType, MediaType};
 use crate::models::title::TitleModel;
-use crate::services::cover::{CoverService, probe_openlibrary_cover_url};
+use crate::services::cover::{CoverService, resolve_cover_url_with_fallback};
 
 /// Fetch metadata asynchronously for a title using the provider chain.
 /// This function is meant to be called via `tokio::spawn`.
@@ -51,20 +51,9 @@ pub async fn fetch_metadata_chain(
                 return;
             }
 
-            // Resolve a cover URL: prefer what the resolving provider gave us, but
-            // fall back to the Open Library Covers API by ISBN when the chain
-            // returned no `cover_url` (fix #225 — BnF never carries image URLs in
-            // its UNIMARC payload, and Google Books results without `imageLinks`
-            // would otherwise leave the title cover-less even when Open Library
-            // has one). The fallback is ISBN-only; UPC/ISSN codes aren't indexed
-            // by the Open Library covers service.
-            let cover_url: Option<String> = match metadata.cover_url.clone() {
-                Some(url) => Some(url),
-                None if matches!(code_type, CodeType::Isbn) => {
-                    probe_openlibrary_cover_url(&http_client, &code).await
-                }
-                None => None,
-            };
+            // Resolve cover URL via the shared fallback helper (fix #225 + #228).
+            let cover_url =
+                resolve_cover_url_with_fallback(&http_client, &metadata, &code, &code_type).await;
 
             if let Some(cover_url) = cover_url.as_deref() {
                 match CoverService::download_and_resize(


### PR DESCRIPTION
Closes #228.

## Summary
- v1.1.6 fixed the cover fallback for the background scan path only; the user-triggered "Re-fetch metadata" button went through `routes/titles.rs::redownload_metadata` → `apply_metadata_to_title` which still had the original bug (silently skips when `metadata.cover_url` is `None`).
- Symptom in production: FR titles resolved by BnF stayed cover-less on re-fetch, while titles whose chain happened to resolve via Google Books / Open Library got covers (because those providers carry `cover_url` directly).
- Extracted a single helper `CoverService::resolve_cover_url_with_fallback` (DRY per Foundation Rule #1), wired into all three call sites: background fetch, direct-apply re-fetch, and the `MetadataConfirmTemplate` populated for the conflict-confirmation flow.

## What changed
- `src/services/cover.rs` — new pub helper `resolve_cover_url_with_fallback(client, metadata, code, code_type) -> Option<String>`; tests serialized via `static ENV_LOCK: Mutex<()>` to keep parallel env-var access hermetic.
- `src/tasks/metadata_fetch.rs` — inline fallback replaced by helper call.
- `src/routes/titles.rs` — `apply_metadata_to_title` signature now takes `cover_url: Option<&str>` (caller owns resolution); `redownload_metadata` resolves once and feeds both branches (direct apply + `MetadataConfirmTemplate.new_cover_url`).

## Tests
- 3 new `#[tokio::test]` covering: provider has URL → returned as-is; non-ISBN code → None (no network call); ISBN + OL unreachable → None.
- All 12 `services::cover::tests` green; clippy `-D warnings` clean.

## Foundation Rule #3 status
Same as #226 — no Playwright E2E added; mock metadata server still lacks the `/b/isbn/...` route + `do_HEAD` support that would be required to verify the round-trip end-to-end. Tracked in #228 as follow-up.

## Test plan
- [ ] CI gates green.
- [ ] After merge + Docker Hub push: upgrade prod, click "Re-fetch metadata" on a FR title that v1.1.6 left cover-less, verify cover appears (when Open Library has one for that ISBN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)