### PR TITLE
fix(#232): stop tracking genre_id in manually_edited_fields

### DIFF
--- a/migrations/20260517170000_strip_genre_id_from_manually_edited.sql
+++ b/migrations/20260517170000_strip_genre_id_from_manually_edited.sql
@@ -1,0 +1,33 @@
+-- Fix #232: strip the spurious "genre_id" entry from
+-- titles.manually_edited_fields. The Rust code at
+-- src/models/title.rs::detect_edited_fields used to push "genre_id"
+-- on every title-edit form submit, which forced every subsequent
+-- re-fetch through the conflict-confirmation flow and silently
+-- swallowed the Open Library cover fallback (issues #225 / #228).
+--
+-- The change is purely cosmetic at the data layer: `titles.genre_id`
+-- (the actual foreign-key column) is untouched. Only the audit-flag
+-- array is cleaned up.
+
+-- 1. Remove the "genre_id" element wherever it appears in the JSON
+-- array. JSON_SEARCH returns the path to the first match (or NULL),
+-- JSON_REMOVE then drops that path. We restrict the UPDATE to rows
+-- that actually contain "genre_id" so we don't rewrite rows for
+-- nothing.
+UPDATE titles
+SET manually_edited_fields = JSON_REMOVE(
+        manually_edited_fields,
+        JSON_UNQUOTE(JSON_SEARCH(manually_edited_fields, 'one', 'genre_id'))
+    )
+WHERE manually_edited_fields IS NOT NULL
+  AND JSON_SEARCH(manually_edited_fields, 'one', 'genre_id') IS NOT NULL;
+
+-- 2. If stripping "genre_id" left an empty array, collapse to NULL so
+-- the re-fetch flow correctly takes the direct-apply branch on next
+-- run. We compare via JSON_LENGTH rather than string equality because
+-- MariaDB may normalize the JSON storage and the literal '[]' check
+-- can miss in some configurations.
+UPDATE titles
+SET manually_edited_fields = NULL
+WHERE manually_edited_fields IS NOT NULL
+  AND JSON_LENGTH(manually_edited_fields) = 0;

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -659,7 +659,6 @@ pub fn detect_edited_fields(
     new_description: Option<&str>,
     new_publisher: Option<&str>,
     new_language: &str,
-    new_genre_id: u64,
     new_publication_date: Option<chrono::NaiveDate>,
     new_dewey_code: Option<&str>,
     new_page_count: Option<i32>,
@@ -685,9 +684,12 @@ pub fn detect_edited_fields(
     if old.language != new_language {
         changed.push("language".to_string());
     }
-    if old.genre_id != new_genre_id {
-        changed.push("genre_id".to_string());
-    }
+    // NOTE: `genre_id` is intentionally NOT tracked here. It is a
+    // mybibli-only classification, no provider in the metadata chain
+    // ever returns it, so the conflict-confirm flow has nothing to
+    // protect. Tracking it used to send every re-fetch through the
+    // confirmation form and silently swallow the Open Library cover
+    // fallback (fix #232).
     if old.publication_date != new_publication_date {
         changed.push("publication_date".to_string());
     }
@@ -1197,7 +1199,6 @@ mod tests {
             None,
             Some("Gallimard"),
             "fr",
-            1,
             None,
             None,
             Some(186),
@@ -1219,7 +1220,6 @@ mod tests {
             None,
             Some("Flammarion"),
             "fr",
-            1,
             None,
             None,
             Some(186),
@@ -1241,7 +1241,6 @@ mod tests {
             Some("A description"),
             Some("Gallimard"),
             "en",
-            1,
             None,
             None,
             Some(186),
@@ -1254,6 +1253,44 @@ mod tests {
         assert!(changed.contains(&"description".to_string()));
         assert!(changed.contains(&"language".to_string()));
         assert_eq!(changed.len(), 3);
+    }
+
+    /// Regression guard for fix #232.
+    ///
+    /// The signature deliberately omits `new_genre_id` so a future
+    /// refactor cannot quietly reintroduce `"genre_id"` tracking. If
+    /// someone ever puts `new_genre_id: u64` back into the parameter
+    /// list and pushes it onto `changed`, this test stops compiling
+    /// because the call won't match the signature any more. Belt-and-
+    /// braces against the conflict-confirm-flow regression that
+    /// silently swallowed Open Library cover fallbacks for every title
+    /// whose genre had ever been edited.
+    #[test]
+    fn test_detect_edited_fields_does_not_track_genre() {
+        let old = make_test_title();
+        let changed = detect_edited_fields(
+            &old,
+            "Original Title",
+            Some("Original Sub"),
+            None,
+            Some("Gallimard"),
+            "fr",
+            None,
+            None,
+            Some(186),
+            None,
+            None,
+            None,
+            None,
+        );
+        // The model never produces "genre_id" in the changed list — the
+        // function doesn't even take a genre input. The empty result
+        // here is the explicit assertion that nothing genre-related
+        // leaks through.
+        assert!(
+            !changed.iter().any(|f| f == "genre_id"),
+            "genre_id must never appear in manually_edited_fields"
+        );
     }
 
     #[test]

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -573,7 +573,10 @@ pub async fn update_title(
             .ok()
     });
 
-    // Detect which fields changed
+    // Detect which fields changed. NOTE: `resolved_genre_id` is
+    // deliberately not passed — genre is a mybibli-only classification
+    // and the metadata-fetch chain never returns it, so it must not be
+    // tracked in `manually_edited_fields` (fix #232).
     let changed = detect_edited_fields(
         &old_title,
         trimmed_title,
@@ -581,7 +584,6 @@ pub async fn update_title(
         description.as_deref(),
         publisher.as_deref(),
         &form.language,
-        resolved_genre_id,
         publication_date,
         dewey_code.as_deref(),
         form.page_count,


### PR DESCRIPTION
Closes #232.

## Summary
- `genre_id` was being pushed into `titles.manually_edited_fields` on every title edit, even though no provider in the metadata chain ever returns it. That permanently forced re-fetches into the conflict-confirmation flow, where the cover download is gated on an unchecked `accept_cover` checkbox — explaining why FR titles still didn't get covers on re-fetch in v1.1.7 despite the Open Library fallback working.
- Drop `genre_id` from `detect_edited_fields` (signature + body). Migration strips the spurious entries from existing data and collapses now-empty arrays back to NULL, so affected titles take the direct-apply branch on next re-fetch.

See #232 for the full diagnostic + production log evidence.

## What changed
- `src/models/title.rs::detect_edited_fields` — `new_genre_id` removed from signature + body; new sentinel test `test_detect_edited_fields_does_not_track_genre` locks the contract.
- `src/routes/titles.rs::update_title` — matching argument removed at the only caller; comment explains why.
- `migrations/20260517170000_strip_genre_id_from_manually_edited.sql` — one-shot data cleanup (JSON_REMOVE of `"genre_id"` from every `manually_edited_fields` array, then `NULL` when `JSON_LENGTH = 0`).

## Tests
- 4 unit tests in `models::title::tests` for `detect_edited_fields` (3 existing updated for the new signature, 1 new regression guard) — all pass.
- DB integration tests (CI lane) will exercise the migration against a fresh schema.
- Existing CSRF / locale / dashboard tests unaffected.

## User-facing effect on re-fetch
- Titles where only the genre was customized → `manually_edited_fields` goes back to NULL → re-fetch takes the direct-apply path, refreshes metadata + downloads cover (via OL fallback) silently. No confirmation form to click through.
- Titles where other fields were also customized → still go through the conflict-confirmation flow with checkboxes (unchanged), but the spurious `"genre_id"` entry no longer pollutes that flow.

## Test plan
- [ ] CI green (Rust + clippy + sqlx + DB integration + Playwright).
- [ ] After merge + Docker Hub push: re-fetch a FR title that stayed cover-less under v1.1.7. Expect direct-apply path → cover downloads silently when OL has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)