### PR TITLE
feat(v1.2): quick-wins bundle — #215 spinner + #236 Dewey chip + #200 fold/unfold

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -354,6 +354,8 @@ location:
   invalid_node_type: "Invalid location type."
   volumes_count: "%{count} volumes"
   breadcrumb_label: Location path
+  tree:
+    toggle: Toggle subtree
   contents_title: Shelf contents
   empty_volumes: "No volumes at this location."
   col_title: Title

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -354,6 +354,8 @@ location:
   invalid_node_type: "Type d'emplacement invalide."
   volumes_count: "%{count} volumes"
   breadcrumb_label: Chemin de l'emplacement
+  tree:
+    toggle: Afficher / masquer la sous-arborescence
   contents_title: Contenu de l'étagère
   empty_volumes: "Aucun volume à cet emplacement."
   col_title: Titre

--- a/src/routes/locations.rs
+++ b/src/routes/locations.rs
@@ -301,9 +301,35 @@ fn render_node_at_depth(
     // at L73 + templates/pages/location_detail.html). mutation_controls
     // (edit / delete / add-child buttons, when can_edit) stay OUTSIDE
     // the anchor so they remain individually focusable + clickable.
+    //
+    // Issue #200: rows that have at least one child get a fold/unfold
+    // toggle in front of the row, and the children are wrapped in a
+    // `<div class="tree-children" id="tree-children-{id}">` container
+    // (instead of being rendered as flat siblings). Both pieces work
+    // together: `static/js/locations-tree-toggle.js` hides the container
+    // on click and persists the collapsed-node-id set in localStorage so
+    // the layout survives a reload. Indentation classes still drive the
+    // visual depth, so wrapping doesn't change the look when open.
+    let has_children = !node.children.is_empty();
+    let toggle_html = if has_children {
+        format!(
+            r#"<button type="button" class="tree-toggle p-1 text-stone-400 hover:text-stone-600 dark:hover:text-stone-200" data-tree-target="tree-children-{id}" aria-expanded="true" aria-label="{toggle_lbl}"><span class="tree-toggle-icon" aria-hidden="true">▼</span></button>"#,
+            id = node.location.id,
+            toggle_lbl = crate::utils::html_escape(
+                rust_i18n::t!("location.tree.toggle", locale = loc).as_ref()
+            ),
+        )
+    } else {
+        // Spacer keeps row labels aligned across the column whether or
+        // not a row has children. `w-6` matches the toggle button's
+        // approximate width (icon + padding).
+        r#"<span class="w-6" aria-hidden="true"></span>"#.to_string()
+    };
+
     html.push_str(&format!(
-        r#"<div role="treeitem" class="{indent_class}">
+        r#"<div role="treeitem" class="{indent_class}" data-tree-node-id="{id}">
 <div class="flex items-center gap-2 px-3 py-2 rounded-md hover:bg-stone-100 dark:hover:bg-stone-800 group">
+{toggle_html}
 <a href="/location/{id}" class="flex items-center gap-2 flex-1 min-w-0 no-underline">
 <span class="text-stone-400" aria-hidden="true">{icon}</span>
 <span class="font-medium text-stone-900 dark:text-stone-100">{name}</span>
@@ -312,24 +338,31 @@ fn render_node_at_depth(
 </a>
 {mutation_controls}
 </div>
-{child_form}
-</div>"#,
+{child_form}"#,
         id = node.location.id,
     ));
 
-    // Render children at deeper indentation
-    for child in &node.children {
-        render_node_at_depth(
-            child,
-            html,
-            node_types,
-            next_lcode,
-            depth + 1,
-            can_edit,
-            loc,
-            csrf_token,
-        );
+    if has_children {
+        html.push_str(&format!(
+            r#"<div class="tree-children" id="tree-children-{id}">"#,
+            id = node.location.id,
+        ));
+        for child in &node.children {
+            render_node_at_depth(
+                child,
+                html,
+                node_types,
+                next_lcode,
+                depth + 1,
+                can_edit,
+                loc,
+                csrf_token,
+            );
+        }
+        html.push_str("</div>");
     }
+
+    html.push_str("</div>");
 }
 
 // ─── Location tree page ──────────────────────────────────────────
@@ -790,6 +823,60 @@ mod tests {
         );
         assert!(html.contains(r#"value="a&quot;b&lt;c&gt;""#));
         assert!(!html.contains(r#"value="a"b<c>""#));
+    }
+
+    /// Fix #200: a parent node carries a `tree-toggle` button + a
+    /// `tree-children-<id>` container around its children. Leaf nodes
+    /// carry no toggle (alignment spacer instead). This pairs with
+    /// `static/js/locations-tree-toggle.js` for the fold/unfold UX.
+    #[test]
+    fn render_tree_html_emits_toggle_and_children_container_for_parents() {
+        let locations = vec![
+            LocationModel {
+                id: 1,
+                parent_id: None,
+                name: "Salon".to_string(),
+                node_type: "room".to_string(),
+                label: "L0001".to_string(),
+            },
+            LocationModel {
+                id: 2,
+                parent_id: Some(1),
+                name: "Étagère".to_string(),
+                node_type: "shelf".to_string(),
+                label: "L0002".to_string(),
+            },
+        ];
+        let tree = build_tree(&locations, &HashMap::new());
+        let html = render_tree_html(
+            &tree,
+            &[(1, "room".to_string())],
+            "L0003",
+            /* can_edit */ false,
+            "en",
+            "tok",
+        );
+
+        // Parent (id=1) has children → expect a toggle wired to the
+        // children container, and the container itself with the matching id.
+        assert!(
+            html.contains(r#"data-tree-target="tree-children-1""#),
+            "parent's toggle should target its children container"
+        );
+        assert!(
+            html.contains(r#"id="tree-children-1""#),
+            "parent should wrap its children in a tree-children container"
+        );
+
+        // The leaf (id=2) has no children → no toggle button, no container.
+        assert!(
+            !html.contains(r#"data-tree-target="tree-children-2""#),
+            "leaf node should not emit a toggle"
+        );
+        assert!(
+            !html.contains(r#"id="tree-children-2""#),
+            "leaf node should not emit a children container"
+        );
     }
 
     #[test]

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -371,27 +371,33 @@ fn metadata_display_html(
     let desc_html = title.description.as_ref()
         .map(|d| format!(r#"<div class="mt-4"><p class="text-stone-700 dark:text-stone-300 text-sm">{}</p></div>"#, html_escape(d)))
         .unwrap_or_default();
-    let dewey_html = title
+    // Fix #236: the Dewey chip now lives inside the media-type / genre
+    // row at the top of the metadata block (right after the genre),
+    // matching the full-page template's layout. The separate
+    // `<p>{label}: {value}</p>` paragraph is gone.
+    let dewey_label = rust_i18n::t!("metadata.field.dewey_code", locale = loc);
+    let dewey_chip_html = title
         .dewey_code
         .as_ref()
         .map(|d| {
             format!(
-                r#"<p class="mt-1 text-xs text-stone-400">{}: {}</p>"#,
-                rust_i18n::t!("metadata.field.dewey_code", locale = loc),
-                html_escape(d)
+                r#"<span title="{label}">{label} {value}</span>"#,
+                label = html_escape(&dewey_label),
+                value = html_escape(d),
             )
         })
         .unwrap_or_default();
 
     format!(
         r#"<h1 class="text-2xl font-bold text-stone-900 dark:text-stone-100">{title}</h1>
-        {subtitle}{publisher}{isbn}{desc}{dewey}
+        {subtitle}{publisher}{isbn}{desc}
         <div class="mt-4 flex flex-wrap gap-4 text-sm text-stone-600 dark:text-stone-400">
             <span class="inline-flex items-center gap-1">
                 <img src="/static/icons/{media_type}.svg" alt="" class="w-4 h-4" aria-hidden="true">
                 {media_type}
             </span>
             <span>{genre}</span>
+            {dewey_chip}
         </div>
         {buttons}"#,
         title = html_escape(&title.title),
@@ -399,7 +405,7 @@ fn metadata_display_html(
         publisher = publisher_html,
         isbn = isbn_html,
         desc = desc_html,
-        dewey = dewey_html,
+        dewey_chip = dewey_chip_html,
         media_type = html_escape(&title.media_type),
         genre = html_escape(genre_name),
         buttons = edit_buttons,
@@ -1343,6 +1349,101 @@ struct MetadataConfirmTemplate {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Fix #236: Dewey chip rides in the media-type / genre row at the
+    /// top of the title-detail metadata block, NOT in a separate `<p>`
+    /// further down the page. This test pins both halves: the chip is
+    /// present when `dewey_code` is `Some`, and the old standalone
+    /// `<p>{label}: {value}</p>` paragraph is gone.
+    #[test]
+    fn metadata_display_html_renders_dewey_chip_in_row() {
+        let title = TitleModel {
+            id: 1,
+            title: "Le Lotus bleu".to_string(),
+            subtitle: None,
+            description: None,
+            language: "fr".to_string(),
+            media_type: "bd".to_string(),
+            publication_date: None,
+            publisher: None,
+            isbn: None,
+            issn: None,
+            upc: None,
+            cover_image_url: None,
+            genre_id: 1,
+            dewey_code: Some("741.5".to_string()),
+            page_count: None,
+            track_count: None,
+            total_duration: None,
+            age_rating: None,
+            issue_number: None,
+            manually_edited_fields: None,
+            version: 0,
+        };
+        let session = crate::middleware::auth::Session {
+            token: None,
+            user_id: None,
+            role: crate::middleware::auth::Role::Anonymous,
+            csrf_token: String::new(),
+            preferred_language: None,
+        };
+
+        let html = metadata_display_html(&title, "BD", &session, false, "en");
+
+        // The chip itself (label + value), rendered inside a <span>.
+        assert!(
+            html.contains(r#"<span title="Dewey code">Dewey code 741.5</span>"#),
+            "Dewey chip should appear in the metadata row. Got:\n{html}"
+        );
+        // The legacy standalone paragraph must NOT be there anymore.
+        assert!(
+            !html.contains(r#"<p class="mt-1 text-xs text-stone-400">Dewey code: 741.5</p>"#),
+            "Legacy standalone Dewey paragraph should have been removed."
+        );
+    }
+
+    /// When `dewey_code` is `None`, no chip and no leftover spacing
+    /// should leak into the rendered HTML.
+    #[test]
+    fn metadata_display_html_omits_dewey_chip_when_absent() {
+        let title = TitleModel {
+            id: 1,
+            title: "Title".to_string(),
+            subtitle: None,
+            description: None,
+            language: "en".to_string(),
+            media_type: "book".to_string(),
+            publication_date: None,
+            publisher: None,
+            isbn: None,
+            issn: None,
+            upc: None,
+            cover_image_url: None,
+            genre_id: 1,
+            dewey_code: None,
+            page_count: None,
+            track_count: None,
+            total_duration: None,
+            age_rating: None,
+            issue_number: None,
+            manually_edited_fields: None,
+            version: 0,
+        };
+        let session = crate::middleware::auth::Session {
+            token: None,
+            user_id: None,
+            role: crate::middleware::auth::Role::Anonymous,
+            csrf_token: String::new(),
+            preferred_language: None,
+        };
+
+        let html = metadata_display_html(&title, "Fiction", &session, false, "en");
+
+        assert!(
+            !html.contains("Dewey code"),
+            "no Dewey code on title → no Dewey chip / label anywhere"
+        );
+    }
 
     /// Regression guard for fix #238.
     ///

--- a/static/js/locations-tree-toggle.js
+++ b/static/js/locations-tree-toggle.js
@@ -1,0 +1,126 @@
+// Fix #200 — fold / unfold support for the /locations tree.
+//
+// The Rust render (`src/routes/locations.rs::render_node_at_depth`)
+// emits, for every parent node, a `<button class="tree-toggle">` with
+// `data-tree-target="tree-children-<id>"` pointing at the wrapper
+// `<div class="tree-children" id="tree-children-<id>">` that holds the
+// node's children. This script does three things:
+//
+//   1. Click delegation: a single document-level listener flips the
+//      target's hidden state, mirrors that into `aria-expanded` on the
+//      button + flips the ▼/▶ icon, and persists the new state.
+//   2. Persistence: the collapsed-node IDs are stored as a JSON array
+//      under `mybibli-locations-collapsed`, scoped to localStorage so
+//      it survives a reload but stays per-browser. The set is bounded
+//      by the catalog's location count — no eviction logic needed.
+//   3. Restore on page load: every persisted ID gets its container
+//      hidden + button updated before the first paint after DOM ready.
+//
+// CSP-safe: pure addEventListener, no inline handlers, no eval, served
+// from /static/js/ under `script-src 'self'`.
+
+(function () {
+    "use strict";
+
+    const STORAGE_KEY = "mybibli-locations-collapsed";
+    const ICON_EXPANDED = "▼";
+    const ICON_COLLAPSED = "▶";
+
+    function readCollapsedSet() {
+        try {
+            const raw = window.localStorage.getItem(STORAGE_KEY);
+            if (!raw) return new Set();
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) return new Set();
+            return new Set(parsed.map(String));
+        } catch (_) {
+            // localStorage unavailable / parse error — fall back to a
+            // fresh empty set; toggles still work for the current page,
+            // just don't survive a reload.
+            return new Set();
+        }
+    }
+
+    function writeCollapsedSet(set) {
+        try {
+            window.localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify(Array.from(set))
+            );
+        } catch (_) {
+            // Quota or private mode — ignore. State stays correct in DOM.
+        }
+    }
+
+    function findIconSpan(toggle) {
+        return toggle.querySelector(".tree-toggle-icon");
+    }
+
+    function collapse(toggle, target) {
+        target.classList.add("hidden");
+        toggle.setAttribute("aria-expanded", "false");
+        const icon = findIconSpan(toggle);
+        if (icon) icon.textContent = ICON_COLLAPSED;
+    }
+
+    function expand(toggle, target) {
+        target.classList.remove("hidden");
+        toggle.setAttribute("aria-expanded", "true");
+        const icon = findIconSpan(toggle);
+        if (icon) icon.textContent = ICON_EXPANDED;
+    }
+
+    function nodeIdFromTargetId(targetId) {
+        // `tree-children-<id>` → `<id>`. Returns null on shape mismatch.
+        const prefix = "tree-children-";
+        if (!targetId || !targetId.startsWith(prefix)) return null;
+        return targetId.slice(prefix.length);
+    }
+
+    function applyPersistedState() {
+        const collapsed = readCollapsedSet();
+        if (collapsed.size === 0) return;
+        for (const id of collapsed) {
+            const target = document.getElementById("tree-children-" + id);
+            if (!target) continue;
+            const toggle = document.querySelector(
+                `.tree-toggle[data-tree-target="tree-children-${CSS.escape(id)}"]`
+            );
+            if (!toggle) continue;
+            collapse(toggle, target);
+        }
+    }
+
+    function handleClick(event) {
+        const toggle = event.target.closest(".tree-toggle");
+        if (!toggle) return;
+        event.preventDefault();
+        const targetId = toggle.getAttribute("data-tree-target");
+        if (!targetId) return;
+        const target = document.getElementById(targetId);
+        if (!target) return;
+
+        const nodeId = nodeIdFromTargetId(targetId);
+        const collapsed = readCollapsedSet();
+
+        if (target.classList.contains("hidden")) {
+            expand(toggle, target);
+            if (nodeId) collapsed.delete(nodeId);
+        } else {
+            collapse(toggle, target);
+            if (nodeId) collapsed.add(nodeId);
+        }
+        writeCollapsedSet(collapsed);
+    }
+
+    function init() {
+        applyPersistedState();
+        document.addEventListener("click", handleClick);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/templates/fragments/metadata_confirm.html
+++ b/templates/fragments/metadata_confirm.html
@@ -1,7 +1,8 @@
 <div class="space-y-4">
     <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-100">{{ label_confirm_title }}</h3>
 
-    <form hx-post="/title/{{ title_id }}/confirm-metadata" hx-target="#title-metadata" hx-swap="innerHTML">
+    <form hx-post="/title/{{ title_id }}/confirm-metadata" hx-target="#title-metadata" hx-swap="innerHTML"
+          hx-indicator="#apply-changes-spinner">
         <input type="hidden" name="version" value="{{ version }}">
         <!-- Pass new metadata values as hidden fields -->
         <input type="hidden" name="new_title" value="{{ new_title }}">
@@ -72,6 +73,9 @@
             <button type="submit"
                     class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700">
                 {{ label_apply }}
+                <span id="apply-changes-spinner" class="htmx-indicator ml-1">
+                    <svg class="animate-spin inline h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+                </span>
             </button>
         </div>
     </form>

--- a/templates/pages/locations.html
+++ b/templates/pages/locations.html
@@ -51,3 +51,7 @@
     {% endif %}
 </div>
 {% endblock %}
+
+{% block scripts %}
+<script src="/static/js/locations-tree-toggle.js" defer></script>
+{% endblock %}

--- a/templates/pages/title_detail.html
+++ b/templates/pages/title_detail.html
@@ -20,6 +20,9 @@
                         {{ title.media_type }}
                     </span>
                     <span>{{ genre_name }}</span>
+                    {% if let Some(dewey) = title.dewey_code %}
+                    <span title="{{ label_dewey_code }}">{{ label_dewey_code }} {{ dewey }}</span>
+                    {% endif %}
                     <span>{{ volume_count }} {{ label_vol }}</span>
                 </div>
                 {% if let Some(pub_name) = title.publisher %}
@@ -39,10 +42,6 @@
                     <p class="text-stone-700 dark:text-stone-300 text-sm">{{ desc }}</p>
                 </div>
                 {% endif %}
-                {% if let Some(dewey) = title.dewey_code %}
-                    <p class="mt-1 text-xs text-stone-500 dark:text-stone-400">{{ label_dewey_code }}: {{ dewey }}</p>
-                {% endif %}
-
                 {% if role == "librarian" || role == "admin" %}
                 <div class="mt-4 flex gap-3">
                     <button hx-get="/title/{{ title.id }}/edit" hx-target="#title-metadata" hx-swap="innerHTML"


### PR DESCRIPTION
First three CRs of the v1.2.0 "See what you own, find it faster" release bundle.

## Issues addressed

- Closes [#215](https://github.com/guycorbaz/mybibli/issues/215) — spinner on "Apply selected changes" in the metadata-confirmation form.
- Closes [#236](https://github.com/guycorbaz/mybibli/issues/236) — Dewey chip next to genre on `/title/:id`.
- Closes [#200](https://github.com/guycorbaz/mybibli/issues/200) — fold / unfold the `/locations` tree, with localStorage persistence.

## What changed

- `templates/fragments/metadata_confirm.html` — `hx-indicator` on the form + spinner SVG inside the submit button.
- `templates/pages/title_detail.html` + `src/routes/titles.rs::metadata_display_html` — Dewey chip moved into the media-type / genre row, the old standalone paragraph removed. Both surfaces (full page + HTMX swap fragment) now agree.
- `src/routes/locations.rs::render_node_at_depth` — parent rows emit a `tree-toggle` button + wrap children in `<div class="tree-children" id="tree-children-<id>">`. Leaves get a spacer to keep label alignment. Indentation strategy unchanged.
- `static/js/locations-tree-toggle.js` (NEW) — delegated click handler, localStorage persistence under `mybibli-locations-collapsed`, restore-on-DOMContentLoaded. CSP-clean.
- `locales/{en,fr}.yml` — `location.tree.toggle` key for the toggle button's `aria-label`.
- `templates/pages/locations.html` — `{% block scripts %}` override pulling in the new JS.

## Tests
- `metadata_display_html_renders_dewey_chip_in_row` + `_omits_dewey_chip_when_absent` — #236 contract.
- `render_tree_html_emits_toggle_and_children_container_for_parents` — #200 structure.
- `templates_audit::no_inline_markup_in_templates` — passes (no inline `<style>` / `style="…"` / `onclick=` added).
- Clippy `-D warnings` clean.

## Release positioning
Per [[feedback-minor-releases-batch-crs]], **no version bump in this PR**. The v1.2.0 release commit is cut once the remaining v1.2 CRs (#235 Dewey sort, #205 uncategorized filter, #214 bulk cover refresh) are also on main.

## Test plan
- [ ] CI green (Rust + clippy + sqlx + DB integration + Playwright).
- [ ] Manual after merge: open a title with a Dewey code → chip visible next to genre. Open a title without → no chip, no leftover spacing.
- [ ] Manual: trigger a metadata re-fetch on a title with manual edits → conflict form → spinner appears on click of Apply.
- [ ] Manual: collapse a few rows on `/locations`, reload → state restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)