### PR TITLE
feat(v1.2): #205 — "Uncategorized" filter chip on the home page

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -80,6 +80,8 @@ home:
   scanning_announcement: "Scan detected, processing…"
   scan_failed_fallback: "Scan failed. Try again or use the catalog page."
   remove_filter_aria: "Remove filter"
+  filter:
+    uncategorized: "Uncategorized"
 catalog:
   title: Catalog
   scan_placeholder: "Scan or type: ISBN, V-code, L-code, or search..."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -80,6 +80,8 @@ home:
   scanning_announcement: "Scan détecté, traitement…"
   scan_failed_fallback: "Échec du scan. Veuillez réessayer ou utiliser la page catalogue."
   remove_filter_aria: "Retirer le filtre"
+  filter:
+    uncategorized: "Sans genre"
 catalog:
   title: Catalogue
   scan_placeholder: "Scanner ou taper : ISBN, code V, code L, ou recherche..."

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -18,6 +18,7 @@ use crate::routes::home_indicators::{
     IndicatorFilter, IndicatorTag, build_indicator_tags, parse_indicator_filter,
 };
 use crate::services::search::{SearchOutcome, SearchService};
+use crate::services::title::TitleService;
 use crate::utils::{current_url, html_escape, url_encode};
 
 #[derive(Debug, Deserialize)]
@@ -72,6 +73,9 @@ pub struct HomeTemplate {
     pub pagination_next: String,
     pub pagination_aria_label: String,
     pub remove_filter_aria: String,
+    // Fix #205: label for the dedicated "uncategorized" filter chip
+    // (titles whose genre is the default "Non classé"). Localized.
+    pub label_uncategorized: String,
     pub col_title: String,
     pub col_contributor: String,
     pub col_genre: String,
@@ -200,8 +204,19 @@ pub async fn home(
     // Parse legacy filter (genre:N / state:foo) — but skip when an
     // indicator filter is parsed (any role) so it doesn't double-fire
     // downstream.
+    //
+    // Fix #205: `?filter=uncategorized` is a marketing alias for "show
+    // only titles whose genre is the default Non-classé bucket". We
+    // resolve it to that genre id at handler time (one async lookup,
+    // also self-heals via `TitleService::find_default_genre_id` if the
+    // row was soft-deleted) and treat it like an ordinary genre filter
+    // downstream. `parse_filter` itself stays pure / non-async / DB-
+    // free so existing call sites and tests don't have to move.
     let (genre_id, volume_state) = if parsed_indicator.is_some() {
         (None, None)
+    } else if params.filter.as_deref() == Some("uncategorized") {
+        let default_genre_id = TitleService::find_default_genre_id(pool).await?;
+        (Some(default_genre_id), None)
     } else {
         parse_filter(&params.filter)
     };
@@ -572,6 +587,7 @@ pub async fn home(
         pagination_next: rust_i18n::t!("pagination.next", locale = loc).to_string(),
         pagination_aria_label: rust_i18n::t!("pagination.aria_label", locale = loc).to_string(),
         remove_filter_aria: rust_i18n::t!("home.remove_filter_aria", locale = loc).to_string(),
+        label_uncategorized: rust_i18n::t!("home.filter.uncategorized", locale = loc).to_string(),
         col_title: rust_i18n::t!("search.col.title", locale = loc).to_string(),
         col_contributor: rust_i18n::t!("search.col.contributor", locale = loc).to_string(),
         col_genre: rust_i18n::t!("search.col.genre", locale = loc).to_string(),
@@ -744,6 +760,23 @@ pub(crate) mod tests {
         assert!(s.is_none());
     }
 
+    /// Fix #205: `parse_filter` MUST stay DB-free / pure. The
+    /// `?filter=uncategorized` keyword is resolved at handler level
+    /// (one async lookup to find the default-genre id), NOT here. This
+    /// sentinel pins the contract — if someone later moves the logic
+    /// into `parse_filter`, this test catches it and forces them to
+    /// also revisit the caller in `home_search` that currently does
+    /// the short-circuit before reaching parse_filter.
+    #[test]
+    fn test_parse_filter_uncategorized_is_handled_at_handler_level() {
+        let (g, s) = parse_filter(&Some("uncategorized".to_string()));
+        assert!(
+            g.is_none(),
+            "parse_filter must not try to resolve the uncategorized keyword"
+        );
+        assert!(s.is_none(), "no volume-state should be inferred either");
+    }
+
     #[test]
     fn test_parse_filter_state() {
         let (g, s) = parse_filter(&Some("state:unshelved".to_string()));
@@ -862,6 +895,7 @@ pub(crate) mod tests {
             pagination_next: "Next".to_string(),
             pagination_aria_label: "Pagination".to_string(),
             remove_filter_aria: "Remove filter".to_string(),
+            label_uncategorized: "Uncategorized".to_string(),
             col_title: "Title".to_string(),
             col_contributor: "Contributor".to_string(),
             col_genre: "Genre".to_string(),

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -88,6 +88,34 @@
            aria-label="Filter by: {{ genre.name }}">{{ genre.name }}</a>
         {% endif %}
         {% endfor %}
+
+        {# Fix #205: dedicated "Uncategorized" chip — surfaces titles
+           whose genre is the default Non-classé bucket. Distinct from
+           the genre chips above (which list named genres only) because
+           the default genre is conceptually "no real classification yet"
+           and deserves a one-click filter. #}
+        {% if active_filter == "uncategorized" %}
+        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 text-sm" role="status" aria-label="Active filter: {{ label_uncategorized }}. Press to remove filter">
+            {{ label_uncategorized }}
+            <button type="button"
+                    hx-get="/?q={{ query_encoded }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+                    hx-target="#browse-results"
+                    hx-swap="innerHTML"
+                    hx-push-url="true"
+                    class="ml-1 text-indigo-500 hover:text-indigo-700"
+                    aria-label="{{ remove_filter_aria }}">&times;</button>
+        </span>
+        {% else %}
+        <a href="/?q={{ query_encoded }}&amp;filter=uncategorized&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+           hx-get="/?q={{ query_encoded }}&amp;filter=uncategorized&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+           hx-target="#browse-results"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           class="px-3 py-1 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 text-sm hover:bg-stone-200 dark:hover:bg-stone-700"
+           role="link"
+           aria-label="Filter by: {{ label_uncategorized }}">{{ label_uncategorized }}</a>
+        {% endif %}
+
         <input type="hidden" name="filter" id="filter-hidden" value="{{ active_filter }}">
         <input type="hidden" name="sort" value="{{ current_sort }}">
         <input type="hidden" name="dir" value="{{ current_dir }}">


### PR DESCRIPTION
Closes #205.

## Summary
- New `?filter=uncategorized` query value surfaces titles whose `genre_id` is the default "Non classé" bucket — i.e. titles where the metadata-fetch chain couldn't infer a genre and the user hasn't classified them yet.
- Rendered as a dedicated chip in the same row as the named-genre chips on the home page.
- Handler-level short-circuit resolves the alias to the default-genre id; `parse_filter` stays DB-free / pure / synchronous so existing call sites and tests don't move.

## What changed
- `src/routes/home.rs::home_search` — short-circuits on `Some("uncategorized")` and resolves `TitleService::find_default_genre_id` (self-heals the seed row if needed). Downstream search uses the resolved id like any other genre filter.
- `HomeTemplate.label_uncategorized: String` — wired to the new locale key `home.filter.uncategorized` (EN "Uncategorized", FR "Sans genre").
- `templates/pages/home.html` — chip added after the named-genre chip loop, mirroring active/inactive UX of the existing chips.

## Tests
- `test_parse_filter_uncategorized_is_handled_at_handler_level` — sentinel that `parse_filter` ignores the keyword (so a future move to inside `parse_filter` lights up here and forces a visit to the handler).
- All 4 existing `parse_filter` tests still pass.
- Clippy `-D warnings` clean.

## Release positioning
Part of the v1.2.0 bundle. **No version bump** in this PR — release commit cut once #235 and #214 are also on main, per the minor-batching policy.

## Test plan
- [ ] CI green.
- [ ] After merge + Docker Hub push: click "Uncategorized" / "Sans genre" chip on home → list filters down to no-genre titles; click × to clear; chip mirrors active/inactive state of genre chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)