### PR TITLE
feat(v1.2): #235 — Dewey sort on the series detail page

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -242,6 +242,10 @@ series:
   missing_volume: "Missing volume #"
   ongoing: "ongoing, last known: #%{position}"
   no_assignments: "Not assigned to any series."
+  sort:
+    position: Position
+    dewey_code: Dewey code
+    title: Title
   delete_has_titles: "Cannot delete %{name}: %{count} title(s) assigned. Remove all title assignments first."
   delete_modal_title: "Delete series %{name}?"
   delete_modal_body: "Assigned titles must be re-attached or detached first."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -242,6 +242,10 @@ series:
   missing_volume: "Volume manquant #"
   ongoing: "en cours, dernier connu : #%{position}"
   no_assignments: "Non assigné à aucune série."
+  sort:
+    position: Position
+    dewey_code: Code Dewey
+    title: Titre
   delete_has_titles: "Impossible de supprimer %{name} : %{count} titre(s) assigné(s). Retirez d'abord toutes les assignations."
   delete_modal_title: "Supprimer la série %{name} ?"
   delete_modal_body: "Les titres associés doivent être détachés ou réaffectés au préalable."

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -340,6 +340,9 @@ pub struct TitleSeriesRow {
     pub is_omnibus: bool,
     pub title_name: String,
     pub media_type: String,
+    /// Fix #235: surfaced so the series-detail page can sort positions
+    /// by Dewey, alongside the existing default sort by position number.
+    pub dewey_code: Option<String>,
 }
 
 /// A series assignment as seen from a title (for title detail page).
@@ -434,7 +437,7 @@ impl TitleSeriesModel {
     ) -> Result<Vec<TitleSeriesRow>, AppError> {
         let rows = sqlx::query(
             "SELECT ts.id, ts.title_id, ts.series_id, ts.position_number, ts.is_omnibus, \
-             t.title AS title_name, t.media_type \
+             t.title AS title_name, t.media_type, t.dewey_code \
              FROM title_series ts \
              JOIN titles t ON ts.title_id = t.id \
              WHERE ts.series_id = ? AND ts.deleted_at IS NULL AND t.deleted_at IS NULL \
@@ -454,6 +457,7 @@ impl TitleSeriesModel {
                     is_omnibus: r.try_get("is_omnibus")?,
                     title_name: r.try_get("title_name")?,
                     media_type: r.try_get("media_type")?,
+                    dewey_code: r.try_get("dewey_code")?,
                 })
             })
             .collect::<Result<Vec<_>, sqlx::Error>>()

--- a/src/routes/series.rs
+++ b/src/routes/series.rs
@@ -195,6 +195,24 @@ pub struct SeriesDetailTemplate {
     pub no_assignments_label: String,
     pub current_url: String,
     pub lang_toggle_aria: String,
+    // Fix #235: surfaced for the sort UI (which key is currently
+    // selected, which direction). Stable identifiers — see
+    // `SeriesSortKey::as_str` / `SortDir::as_str` for the canonical
+    // string forms emitted into `?sort=…&dir=…`.
+    pub current_sort: &'static str,
+    pub current_dir: &'static str,
+    pub label_sort_by: String,
+    pub label_sort_position: String,
+    pub label_sort_dewey: String,
+    pub label_sort_title: String,
+}
+
+#[derive(serde::Deserialize, Default)]
+pub struct SeriesDetailQuery {
+    #[serde(default)]
+    pub sort: Option<String>,
+    #[serde(default)]
+    pub dir: Option<String>,
 }
 
 pub async fn series_detail_page(
@@ -203,6 +221,7 @@ pub async fn series_detail_page(
     Extension(locale): Extension<Locale>,
     OriginalUri(uri): OriginalUri,
     Path(id): Path<u64>,
+    axum::extract::Query(params): axum::extract::Query<SeriesDetailQuery>,
 ) -> Result<impl IntoResponse, AppError> {
     // No auth required — anonymous read per FR95
     let pool = &state.pool;
@@ -212,10 +231,18 @@ pub async fn series_detail_page(
         .await?
         .ok_or_else(|| AppError::NotFound(rust_i18n::t!("error.not_found", locale = loc).to_string()))?;
 
-    let positions = SeriesService::get_series_positions(pool, &series).await?;
+    let mut positions = SeriesService::get_series_positions(pool, &series).await?;
     let owned = positions.iter().filter(|p| p.title_id.is_some()).count() as u64;
     let gap = compute_gap(&series, owned);
     let series_name_for_grid = series.name.clone();
+
+    // Fix #235: sort the position grid by the requested key / dir.
+    // The owned / gap counters are computed BEFORE the sort because
+    // they are scope-invariant — the values must match the underlying
+    // catalog state, not whatever order the user is browsing in.
+    let sort_key = crate::services::series::SeriesSortKey::from_param(params.sort.as_deref());
+    let sort_dir = crate::services::series::SortDir::from_param(params.dir.as_deref());
+    crate::services::series::sort_positions(&mut positions, sort_key, sort_dir);
 
     let template = SeriesDetailTemplate {
         lang: loc.to_string(),
@@ -257,6 +284,12 @@ pub async fn series_detail_page(
         no_assignments_label: rust_i18n::t!("series.no_assignments", locale = loc).to_string(),
         current_url: current_url(&uri),
         lang_toggle_aria: rust_i18n::t!("nav.language_toggle_aria", locale = loc).to_string(),
+        current_sort: sort_key.as_str(),
+        current_dir: sort_dir.as_str(),
+        label_sort_by: rust_i18n::t!("browse.sort_by", locale = loc).to_string(),
+        label_sort_position: rust_i18n::t!("series.sort.position", locale = loc).to_string(),
+        label_sort_dewey: rust_i18n::t!("series.sort.dewey_code", locale = loc).to_string(),
+        label_sort_title: rust_i18n::t!("series.sort.title", locale = loc).to_string(),
     };
 
     match template.render() {

--- a/src/services/series.rs
+++ b/src/services/series.rs
@@ -9,6 +9,10 @@ pub struct SeriesPositionInfo {
     pub title_id: Option<u64>,
     pub title_name: Option<String>,
     pub is_omnibus: bool,
+    /// Fix #235: the assigned title's Dewey code (when set), or `None`
+    /// for unassigned grid gaps. Used by `sort_positions` to support
+    /// `?sort=dewey_code` on the series-detail page.
+    pub dewey_code: Option<String>,
 }
 
 pub struct SeriesService;
@@ -256,6 +260,7 @@ impl SeriesService {
                     title_id: Some(a.title_id),
                     title_name: Some(a.title_name),
                     is_omnibus: a.is_omnibus,
+                    dewey_code: a.dewey_code,
                 })
                 .collect());
         }
@@ -279,14 +284,253 @@ fn build_position_grid(
             title_id: assignment.map(|a| a.title_id),
             title_name: assignment.map(|a| a.title_name.clone()),
             is_omnibus: assignment.is_some_and(|a| a.is_omnibus),
+            dewey_code: assignment.and_then(|a| a.dewey_code.clone()),
         });
     }
     Ok(positions)
 }
 
+/// Sort keys accepted by `sort_positions` (fix #235). The default is
+/// `Position`, which is the natural order the grid was built in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeriesSortKey {
+    Position,
+    DeweyCode,
+    Title,
+}
+
+impl SeriesSortKey {
+    /// Parse a sort key from the `?sort=` query param. Unknown / missing
+    /// values fall back to `Position` — keep this `match` and the values
+    /// in sync with the dropdown in `templates/pages/series_detail.html`.
+    pub fn from_param(s: Option<&str>) -> Self {
+        match s {
+            Some("dewey_code") => Self::DeweyCode,
+            Some("title") => Self::Title,
+            _ => Self::Position,
+        }
+    }
+
+    /// Stable identifier used in URLs and templates.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Position => "position",
+            Self::DeweyCode => "dewey_code",
+            Self::Title => "title",
+        }
+    }
+}
+
+/// Direction accepted by `sort_positions`. `Asc` is the project-wide
+/// default and matches the direction handling on the location pages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortDir {
+    Asc,
+    Desc,
+}
+
+impl SortDir {
+    pub fn from_param(s: Option<&str>) -> Self {
+        match s {
+            Some("desc") => Self::Desc,
+            _ => Self::Asc,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+}
+
+/// Sort an existing position list in place by the chosen key and
+/// direction (fix #235).
+///
+/// Contract:
+/// - **Position**: the input order is preserved (the grid is already
+///   built in position order). `Desc` reverses.
+/// - **DeweyCode**: assigned titles WITH a Dewey code come first
+///   (ascending or descending lexicographic on the code string),
+///   then assigned titles WITHOUT a code, then gaps. The trailing
+///   buckets keep their original position-order so a user looking at
+///   "everything without Dewey" still reads naturally.
+/// - **Title**: assigned titles in alphabetical title order
+///   (case-insensitive), then gaps. Empty / `None` titles sort last
+///   within the assigned bucket; gaps sort last overall.
+///
+/// The function never panics and never re-allocates beyond the in-
+/// place sort. Stable sort is used so the secondary tiebreaker is
+/// always the position order.
+pub fn sort_positions(positions: &mut [SeriesPositionInfo], key: SeriesSortKey, dir: SortDir) {
+    match key {
+        SeriesSortKey::Position => {
+            if dir == SortDir::Desc {
+                positions.reverse();
+            }
+            // Asc: input is already in position order — no-op.
+        }
+        SeriesSortKey::DeweyCode => {
+            positions.sort_by(|a, b| {
+                use std::cmp::Ordering;
+                // Compute a 3-class bucket: 0 = assigned + Dewey set,
+                // 1 = assigned + no Dewey, 2 = gap. Lower buckets sort
+                // first regardless of direction so gaps never lead.
+                let bucket = |p: &SeriesPositionInfo| -> u8 {
+                    match (p.title_id, p.dewey_code.as_deref()) {
+                        (Some(_), Some(code)) if !code.is_empty() => 0,
+                        (Some(_), _) => 1,
+                        (None, _) => 2,
+                    }
+                };
+                match bucket(a).cmp(&bucket(b)) {
+                    Ordering::Equal => {
+                        // Within the same bucket, ordered comparison
+                        // uses the Dewey code (or position for the
+                        // no-Dewey buckets, by stable-sort fallthrough).
+                        let cmp = a
+                            .dewey_code
+                            .as_deref()
+                            .cmp(&b.dewey_code.as_deref());
+                        if dir == SortDir::Desc {
+                            cmp.reverse()
+                        } else {
+                            cmp
+                        }
+                    }
+                    other => other,
+                }
+            });
+        }
+        SeriesSortKey::Title => {
+            positions.sort_by(|a, b| {
+                use std::cmp::Ordering;
+                let bucket = |p: &SeriesPositionInfo| -> u8 {
+                    match p.title_id {
+                        Some(_) => 0,
+                        None => 1,
+                    }
+                };
+                match bucket(a).cmp(&bucket(b)) {
+                    Ordering::Equal => {
+                        let an = a
+                            .title_name
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase();
+                        let bn = b
+                            .title_name
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase();
+                        let cmp = an.cmp(&bn);
+                        if dir == SortDir::Desc {
+                            cmp.reverse()
+                        } else {
+                            cmp
+                        }
+                    }
+                    other => other,
+                }
+            });
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pos(position: i32, title_id: Option<u64>, name: Option<&str>, dewey: Option<&str>) -> SeriesPositionInfo {
+        SeriesPositionInfo {
+            position,
+            title_id,
+            title_name: name.map(String::from),
+            is_omnibus: false,
+            dewey_code: dewey.map(String::from),
+        }
+    }
+
+    #[test]
+    fn series_sort_key_from_param_defaults_to_position() {
+        assert_eq!(SeriesSortKey::from_param(None), SeriesSortKey::Position);
+        assert_eq!(
+            SeriesSortKey::from_param(Some("garbage")),
+            SeriesSortKey::Position
+        );
+        assert_eq!(
+            SeriesSortKey::from_param(Some("dewey_code")),
+            SeriesSortKey::DeweyCode
+        );
+        assert_eq!(SeriesSortKey::from_param(Some("title")), SeriesSortKey::Title);
+    }
+
+    #[test]
+    fn sort_positions_position_asc_is_noop() {
+        let mut v = vec![pos(1, Some(1), Some("A"), None), pos(2, Some(2), Some("B"), None)];
+        sort_positions(&mut v, SeriesSortKey::Position, SortDir::Asc);
+        assert_eq!(v[0].position, 1);
+        assert_eq!(v[1].position, 2);
+    }
+
+    #[test]
+    fn sort_positions_position_desc_reverses() {
+        let mut v = vec![pos(1, Some(1), Some("A"), None), pos(2, Some(2), Some("B"), None)];
+        sort_positions(&mut v, SeriesSortKey::Position, SortDir::Desc);
+        assert_eq!(v[0].position, 2);
+        assert_eq!(v[1].position, 1);
+    }
+
+    #[test]
+    fn sort_positions_dewey_groups_buckets() {
+        // Bucket 0: assigned + dewey set
+        // Bucket 1: assigned + no dewey
+        // Bucket 2: gap
+        let mut v = vec![
+            pos(1, None, None, None),                       // gap
+            pos(2, Some(2), Some("B"), Some("700")),         // dewey
+            pos(3, Some(3), Some("C"), None),                // no-dewey
+            pos(4, Some(4), Some("D"), Some("500")),         // dewey
+        ];
+        sort_positions(&mut v, SeriesSortKey::DeweyCode, SortDir::Asc);
+        // Bucket 0 first: 500 then 700
+        assert_eq!(v[0].dewey_code.as_deref(), Some("500"));
+        assert_eq!(v[1].dewey_code.as_deref(), Some("700"));
+        // Bucket 1 next: no dewey, assigned
+        assert!(v[2].title_id.is_some() && v[2].dewey_code.is_none());
+        // Bucket 2 last: gap
+        assert!(v[3].title_id.is_none());
+    }
+
+    #[test]
+    fn sort_positions_dewey_desc_within_bucket_only() {
+        // Even in desc, gaps stay at the end — only within-bucket order
+        // flips. This pins the "buckets are sort-direction-invariant"
+        // half of the contract documented on `sort_positions`.
+        let mut v = vec![
+            pos(1, None, None, None),
+            pos(2, Some(2), Some("B"), Some("700")),
+            pos(3, Some(3), Some("C"), Some("500")),
+        ];
+        sort_positions(&mut v, SeriesSortKey::DeweyCode, SortDir::Desc);
+        assert_eq!(v[0].dewey_code.as_deref(), Some("700"));
+        assert_eq!(v[1].dewey_code.as_deref(), Some("500"));
+        assert!(v[2].title_id.is_none(), "gap must stay last in desc too");
+    }
+
+    #[test]
+    fn sort_positions_title_case_insensitive() {
+        let mut v = vec![
+            pos(1, Some(1), Some("banana"), None),
+            pos(2, Some(2), Some("Apple"), None),
+            pos(3, None, None, None),
+        ];
+        sort_positions(&mut v, SeriesSortKey::Title, SortDir::Asc);
+        assert_eq!(v[0].title_name.as_deref(), Some("Apple"));
+        assert_eq!(v[1].title_name.as_deref(), Some("banana"));
+        assert!(v[2].title_id.is_none());
+    }
 
     #[test]
     fn test_empty_name_validation() {
@@ -346,6 +590,7 @@ mod tests {
             is_omnibus: false,
             title_name: name.to_string(),
             media_type: "book".to_string(),
+            dewey_code: None,
         }
     }
 
@@ -358,6 +603,7 @@ mod tests {
             is_omnibus: true,
             title_name: name.to_string(),
             media_type: "book".to_string(),
+            dewey_code: None,
         }
     }
 

--- a/templates/pages/series_detail.html
+++ b/templates/pages/series_detail.html
@@ -44,6 +44,25 @@
     <div id="series-feedback" class="mt-4" aria-live="polite"></div>
 
     {% if !positions.is_empty() %}
+    {# Fix #235: sort dropdown above the position grid. The three keys
+       (position / dewey_code / title) match `SeriesSortKey::as_str` on
+       the Rust side. Direction toggles via the dir=… link below. #}
+    <div class="mt-4 flex flex-wrap items-center gap-3 text-sm">
+        <span class="text-stone-600 dark:text-stone-400">{{ label_sort_by }}</span>
+        <a href="/series/{{ series.id }}?sort=position&amp;dir={% if current_sort == "position" && current_dir == "asc" %}desc{% else %}asc{% endif %}"
+           class="px-2 py-1 rounded-md {% if current_sort == "position" %}bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300{% else %}text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800{% endif %}">
+            {{ label_sort_position }}{% if current_sort == "position" %} {% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+        </a>
+        <a href="/series/{{ series.id }}?sort=dewey_code&amp;dir={% if current_sort == "dewey_code" && current_dir == "asc" %}desc{% else %}asc{% endif %}"
+           class="px-2 py-1 rounded-md {% if current_sort == "dewey_code" %}bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300{% else %}text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800{% endif %}">
+            {{ label_sort_dewey }}{% if current_sort == "dewey_code" %} {% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+        </a>
+        <a href="/series/{{ series.id }}?sort=title&amp;dir={% if current_sort == "title" && current_dir == "asc" %}desc{% else %}asc{% endif %}"
+           class="px-2 py-1 rounded-md {% if current_sort == "title" %}bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300{% else %}text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800{% endif %}">
+            {{ label_sort_title }}{% if current_sort == "title" %} {% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+        </a>
+    </div>
+
     {% include "components/series_gap_grid.html" %}
     {% endif %}
 


### PR DESCRIPTION
Closes #235.

## Summary
- Adds `?sort=position|dewey_code|title` (+ `?dir=asc|desc`) to `/series/:id` with a sort-link row above the gap grid.
- **The `/locations/:id` half of #235 is already in production** (sort whitelist has `"dewey_code"`, template already exposes the column header). This PR finishes the series half.

## What changed
- `models::series::TitleSeriesRow` + `services::series::SeriesPositionInfo` gain `dewey_code: Option<String>`; SQL pulls `t.dewey_code` from the join.
- New `SeriesSortKey` + `SortDir` enums + pure in-place `sort_positions` function with documented bucket semantics: assigned-with-Dewey first, assigned-no-Dewey middle, gaps last — direction-invariant bucket order, in-bucket direction respected.
- `series_detail_page` accepts the new query, sorts before rendering; owned/gap counts computed BEFORE sort (catalog-scoped, not view-scoped).
- `SeriesDetailTemplate` + locale keys + sort-link row UI in `templates/pages/series_detail.html`.

## Tests
- 5 new unit tests on `sort_positions` covering default-key, position direction, Dewey buckets, Dewey desc semantics, and case-insensitive title sort.
- Existing 13 series-service tests still pass (test-helper builders updated to carry the new `dewey_code: None` field).
- Clippy `-D warnings` clean. Templates CSP audit clean.

## Release positioning
Part of v1.2.0. **No version bump** in this PR — release commit cut once #214 (bulk cover-fetch) also lands on main.

## Test plan
- [ ] CI green.
- [ ] After merge: open a series of mine on prod, click the "Dewey code" sort link → grid reorders, assigned titles with Dewey first, gaps last; click again → desc within the Dewey bucket; "Position" link returns to the canonical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)