### PR TITLE
feat(v1.2): #214 — admin bulk cover-refetch action

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -590,6 +590,16 @@ admin:
     provider_status_na: n/a
     last_checked: "Last checked: %{when}"
     last_checked_never: Never
+    maintenance_heading: Maintenance
+    bulk_cover_fetch:
+      missing_covers_label: "Titles with missing covers"
+      button: "Re-fetch missing covers"
+      idle: "Idle"
+      running: "Running: %{processed} / %{total} processed"
+      last_run: "Last run: %{processed} / %{total} processed"
+      started: "Bulk cover-refetch started for %{total} titles. Progress is logged; refresh the panel to see updates."
+      empty: "No titles need a cover refetch — everything that can be fetched has been."
+      already_running: "A bulk cover-refetch is already in progress. Please wait for it to complete."
   users:
     heading: User accounts
     empty_state: "Only you here! Create a Librarian account for household members."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -590,6 +590,16 @@ admin:
     provider_status_na: "n/a"
     last_checked: "Dernier contrôle : %{when}"
     last_checked_never: Jamais
+    maintenance_heading: Maintenance
+    bulk_cover_fetch:
+      missing_covers_label: "Titres sans couverture"
+      button: "Récupérer les couvertures manquantes"
+      idle: "Au repos"
+      running: "En cours : %{processed} / %{total} traités"
+      last_run: "Dernière exécution : %{processed} / %{total} traités"
+      started: "Récupération en lot lancée pour %{total} titres. La progression est journalisée ; rafraîchissez le panneau pour voir les mises à jour."
+      empty: "Aucun titre n'a besoin d'être re-fetché — tout ce qui peut être récupéré l'a été."
+      already_running: "Une récupération en lot est déjà en cours. Attendez sa fin."
   users:
     heading: "Comptes utilisateurs"
     empty_state: "Vous êtes seul·e ! Créez un compte Bibliothécaire pour les membres du foyer."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use db::DbPool;
 use metadata::registry::ProviderRegistry;
 use middleware::setup_gate::SetupGateState;
 use services::admin_health::MariadbVersionCache;
+use services::bulk_cover_fetch::BulkCoverFetchStatus;
 use tasks::provider_health::ProviderHealthMap;
 
 rust_i18n::i18n!("locales", fallback = "en");
@@ -45,6 +46,11 @@ pub struct AppState {
     /// `/setup`. Refreshed by Step 1 (admin row created) and Step 4
     /// (`setup_completed_at` written) inside the wizard handlers.
     pub setup_gate: Arc<RwLock<SetupGateState>>,
+    /// Fix #214: status of the admin "Re-fetch missing covers" bulk
+    /// action. At most one bulk fetch runs at a time, repo-wide; this
+    /// `RwLock`-guarded state is the single-instance gate, plus a small
+    /// progress counter that the admin Health panel renders.
+    pub bulk_cover_fetch: Arc<RwLock<BulkCoverFetchStatus>>,
 }
 
 impl AppState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,11 @@ async fn main() {
         provider_health: provider_health_map.clone(),
         mariadb_version_cache,
         setup_gate,
+        // Fix #214: single-instance lock for the admin bulk-cover-refetch
+        // workflow. Starts idle; the admin handler flips it to running.
+        bulk_cover_fetch: std::sync::Arc::new(std::sync::RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     };
 
     // Spawn provider-health background task AFTER AppState is built so we

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -394,6 +394,9 @@ mod tests {
             setup_gate: Arc::new(RwLock::new(
                 crate::middleware::setup_gate::SetupGateState::default(),
             )),
+            bulk_cover_fetch: Arc::new(RwLock::new(
+                crate::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+            )),
         }
     }
 

--- a/src/middleware/locale.rs
+++ b/src/middleware/locale.rs
@@ -264,6 +264,9 @@ mod middleware_integration_tests {
             setup_gate: Arc::new(RwLock::new(
                 crate::middleware::setup_gate::SetupGateState::default(),
             )),
+            bulk_cover_fetch: Arc::new(RwLock::new(
+                crate::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+            )),
         }
     }
 

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -38,6 +38,16 @@ impl std::fmt::Display for TitleModel {
     }
 }
 
+/// Fix #214: projection used by the bulk cover-refetch admin action.
+/// Carries only the fields `fetch_metadata_chain` needs.
+#[derive(Debug, Clone)]
+pub struct MissingCoverTitle {
+    pub id: u64,
+    pub code: String,
+    pub code_type: crate::models::media_type::CodeType,
+    pub media_type: String,
+}
+
 /// Data required to create a new title.
 #[derive(Debug, Deserialize)]
 pub struct NewTitle {
@@ -195,6 +205,76 @@ impl TitleModel {
             Some(r) => Ok(Some(row_to_title(r)?)),
             None => Ok(None),
         }
+    }
+
+    /// Fix #214: count active titles eligible for a bulk cover-refetch.
+    ///
+    /// Eligibility: `cover_image_url IS NULL OR ''` AND at least one
+    /// lookup code (ISBN / ISSN / UPC) — the bulk-fetch reuses the
+    /// per-title metadata chain, which only operates on codes. Titles
+    /// without any code can't be re-fetched here; they'd be a manual
+    /// catalog edit.
+    pub async fn count_missing_covers(pool: &DbPool) -> Result<i64, AppError> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM titles \
+             WHERE deleted_at IS NULL \
+               AND (cover_image_url IS NULL OR cover_image_url = '') \
+               AND (isbn IS NOT NULL OR issn IS NOT NULL OR upc IS NOT NULL)",
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    /// Fix #214: list the titles eligible for a bulk cover-refetch.
+    ///
+    /// Returns the minimal projection the bulk task needs to call
+    /// [`crate::tasks::metadata_fetch::fetch_metadata_chain`]: title
+    /// id, the lookup code, its type, and the media type. ISBN is
+    /// preferred when several codes are set (it has the broadest
+    /// provider coverage); UPC second, ISSN last.
+    ///
+    /// Ordered by `created_at ASC` so the user sees the oldest
+    /// cover-less titles fill in first.
+    pub async fn list_missing_covers(
+        pool: &DbPool,
+    ) -> Result<Vec<MissingCoverTitle>, AppError> {
+        let rows = sqlx::query(
+            "SELECT id, isbn, issn, upc, media_type FROM titles \
+             WHERE deleted_at IS NULL \
+               AND (cover_image_url IS NULL OR cover_image_url = '') \
+               AND (isbn IS NOT NULL OR issn IS NOT NULL OR upc IS NOT NULL) \
+             ORDER BY created_at ASC",
+        )
+        .fetch_all(pool)
+        .await?;
+
+        let titles = rows
+            .into_iter()
+            .filter_map(|r| {
+                let id: u64 = r.try_get("id").ok()?;
+                let isbn: Option<String> = r.try_get("isbn").ok().flatten();
+                let issn: Option<String> = r.try_get("issn").ok().flatten();
+                let upc: Option<String> = r.try_get("upc").ok().flatten();
+                let media_type: String = r.try_get("media_type").ok()?;
+                let (code, code_type) = if let Some(c) = isbn {
+                    (c, crate::models::media_type::CodeType::Isbn)
+                } else if let Some(c) = upc {
+                    (c, crate::models::media_type::CodeType::Upc)
+                } else if let Some(c) = issn {
+                    (c, crate::models::media_type::CodeType::Issn)
+                } else {
+                    return None;
+                };
+                Some(MissingCoverTitle {
+                    id,
+                    code,
+                    code_type,
+                    media_type,
+                })
+            })
+            .collect();
+        Ok(titles)
     }
 
     /// Count of active (non-soft-deleted) titles in the catalog.

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -207,6 +207,16 @@ struct AdminHealthPanel {
     count_active_loans: i64,
     providers_heading: String,
     providers: Vec<ProviderHealthRow>,
+    // Fix #214: maintenance section — "Re-fetch missing covers".
+    // Single-instance: the button is disabled while a fetch is in
+    // flight and re-enables when the task completes.
+    maintenance_heading: String,
+    missing_covers_label: String,
+    missing_covers_count: i64,
+    bulk_cover_fetch_button_label: String,
+    bulk_cover_fetch_can_start: bool,
+    bulk_cover_fetch_running: bool,
+    bulk_cover_fetch_status_label: String,
 }
 
 struct ProviderHealthRow {
@@ -417,6 +427,105 @@ pub async fn admin_health_panel(
 ) -> Result<Response, AppError> {
     session.require_role_with_return(Role::Admin, "/admin?tab=health")?;
     render_admin(&state, &session, locale.0, &uri, is_htmx, AdminTab::Health, None).await
+}
+
+/// Fix #214: admin action — re-trigger the metadata-fetch chain on
+/// every title with a missing cover. Single-instance: a second click
+/// while one is in flight returns 409. The actual work runs in a
+/// detached `tokio::spawn` task — the handler returns immediately
+/// with a feedback HTML snippet for HTMX to swap into the Health
+/// panel.
+pub async fn admin_bulk_cover_refetch(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+) -> Result<Response, AppError> {
+    session.require_role_with_return(Role::Admin, "/admin?tab=health")?;
+    let pool = &state.pool;
+    let loc = locale.0;
+
+    let titles = crate::models::title::TitleModel::list_missing_covers(pool).await?;
+    let total = titles.len();
+
+    if total == 0 {
+        // Nothing to do — surface a friendly message, don't lock the
+        // status, don't audit-log.
+        return Ok(crate::routes::catalog::feedback_html_pub(
+            "info",
+            &rust_i18n::t!("admin.health.bulk_cover_fetch.empty", locale = loc),
+            "",
+        )
+        .into_response());
+    }
+
+    if crate::services::bulk_cover_fetch::try_start(&state.bulk_cover_fetch, total).is_err() {
+        return Err(AppError::Conflict(
+            rust_i18n::t!(
+                "admin.health.bulk_cover_fetch.already_running",
+                locale = loc
+            )
+            .to_string(),
+        ));
+    }
+
+    tracing::info!(
+        admin_id = session.user_id.unwrap_or(0),
+        total = total,
+        "Bulk cover-refetch started"
+    );
+
+    // Spawn the detached worker. Clones what it needs from AppState
+    // (cheap — all Arc-wrapped); no shared mutable references.
+    let pool_clone = pool.clone();
+    let registry_clone = state.registry.clone();
+    let http_client_clone = state.http_client.clone();
+    let covers_dir_clone = state.covers_dir.clone();
+    let status_clone = state.bulk_cover_fetch.clone();
+    let timeout_secs = {
+        // Snapshot the timeout setting once, outside the loop.
+        state
+            .settings
+            .read()
+            .map(|s| s.metadata_fetch_timeout_secs)
+            .unwrap_or(30)
+    };
+
+    tokio::spawn(async move {
+        for title in titles {
+            crate::tasks::metadata_fetch::fetch_metadata_chain(
+                pool_clone.clone(),
+                title.id,
+                title.code.clone(),
+                title.code_type,
+                title
+                    .media_type
+                    .parse::<crate::models::media_type::MediaType>()
+                    .unwrap_or(crate::models::media_type::MediaType::Book),
+                registry_clone.clone(),
+                timeout_secs,
+                http_client_clone.clone(),
+                covers_dir_clone.clone(),
+            )
+            .await;
+            crate::services::bulk_cover_fetch::increment_processed(&status_clone);
+            // Politeness toward external metadata providers. The
+            // chain has its own per-provider rate limiters, but a
+            // small inter-title gap helps when the chain runs short
+            // (e.g. cached BnF hits).
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+        crate::services::bulk_cover_fetch::mark_complete(&status_clone);
+        tracing::info!("Bulk cover-refetch completed");
+    });
+
+    let message = rust_i18n::t!(
+        "admin.health.bulk_cover_fetch.started",
+        locale = loc,
+        total = total
+    )
+    .to_string();
+    Ok(crate::routes::catalog::feedback_html_pub("success", &message, "")
+        .into_response())
 }
 
 pub async fn admin_users_panel(
@@ -1512,6 +1621,32 @@ async fn render_health_panel(state: &AppState, loc: &'static str) -> Result<Stri
 
     let providers = build_provider_rows(&state.registry, &state.provider_health, loc);
 
+    // Fix #214: maintenance section data — count of titles with no
+    // cover + bulk-fetch status. Cheap query (single SELECT COUNT) and
+    // a lock-only status read; no extra DB round-trip beyond the count.
+    let missing_covers_count = crate::models::title::TitleModel::count_missing_covers(pool).await?;
+    let bulk_status =
+        crate::services::bulk_cover_fetch::snapshot(&state.bulk_cover_fetch);
+    let bulk_cover_fetch_status_label = if bulk_status.running {
+        rust_i18n::t!(
+            "admin.health.bulk_cover_fetch.running",
+            locale = loc,
+            processed = bulk_status.processed,
+            total = bulk_status.total
+        )
+        .to_string()
+    } else if bulk_status.last_completed_at.is_some() {
+        rust_i18n::t!(
+            "admin.health.bulk_cover_fetch.last_run",
+            locale = loc,
+            processed = bulk_status.processed,
+            total = bulk_status.total
+        )
+        .to_string()
+    } else {
+        rust_i18n::t!("admin.health.bulk_cover_fetch.idle", locale = loc).to_string()
+    };
+
     let panel = AdminHealthPanel {
         versions_heading: rust_i18n::t!("admin.health.versions_heading", locale = loc)
             .to_string(),
@@ -1538,6 +1673,22 @@ async fn render_health_panel(state: &AppState, loc: &'static str) -> Result<Stri
         providers_heading: rust_i18n::t!("admin.health.providers_heading", locale = loc)
             .to_string(),
         providers,
+        maintenance_heading: rust_i18n::t!("admin.health.maintenance_heading", locale = loc)
+            .to_string(),
+        missing_covers_label: rust_i18n::t!(
+            "admin.health.bulk_cover_fetch.missing_covers_label",
+            locale = loc
+        )
+        .to_string(),
+        missing_covers_count,
+        bulk_cover_fetch_button_label: rust_i18n::t!(
+            "admin.health.bulk_cover_fetch.button",
+            locale = loc
+        )
+        .to_string(),
+        bulk_cover_fetch_can_start: !bulk_status.running && missing_covers_count > 0,
+        bulk_cover_fetch_running: bulk_status.running,
+        bulk_cover_fetch_status_label,
     };
 
     panel

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -600,6 +600,9 @@ mod language_tests {
             setup_gate: std::sync::Arc::new(std::sync::RwLock::new(
                 crate::middleware::setup_gate::SetupGateState::default(),
             )),
+            bulk_cover_fetch: std::sync::Arc::new(std::sync::RwLock::new(
+                crate::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+            )),
         };
         Router::new()
             .route("/language", axum::routing::post(change_language))
@@ -842,6 +845,9 @@ mod language_tests {
             mariadb_version_cache: crate::services::admin_health::new_mariadb_version_cache(),
             setup_gate: std::sync::Arc::new(std::sync::RwLock::new(
                 crate::middleware::setup_gate::SetupGateState::default(),
+            )),
+            bulk_cover_fetch: std::sync::Arc::new(std::sync::RwLock::new(
+                crate::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
             )),
         };
         let app = axum::Router::new()

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -253,6 +253,10 @@ pub fn build_router(state: AppState) -> Router {
         // the catalog sub-router) so they skip `pending_updates_middleware`.
         .route("/admin", axum::routing::get(admin::admin_page))
         .route("/admin/health", axum::routing::get(admin::admin_health_panel))
+        .route(
+            "/admin/health/bulk-cover-refetch",
+            axum::routing::post(admin::admin_bulk_cover_refetch),
+        )
         .route("/admin/users", axum::routing::get(admin::admin_users_panel).post(admin::admin_users_create))
         .route("/admin/users/new", axum::routing::get(admin::admin_users_create_form))
         .route("/admin/users/{id}/edit", axum::routing::get(admin::admin_users_edit_form))

--- a/src/services/bulk_cover_fetch.rs
+++ b/src/services/bulk_cover_fetch.rs
@@ -1,0 +1,179 @@
+//! Bulk cover-refetch admin action (issue #214).
+//!
+//! When the user has many titles whose `cover_image_url` is `NULL` (a
+//! common state after upgrading from a release that predated the Open
+//! Library Covers fallback in v1.1.6/1.1.7 — most French titles
+//! cataloged via BnF arrive without a cover), they want a one-click
+//! way to re-trigger the metadata-fetch chain on every such title.
+//!
+//! This module owns the shared in-process state that coordinates that
+//! workflow: a single instance of [`BulkCoverFetchStatus`] lives in
+//! [`crate::AppState`] under an `Arc<RwLock<…>>`, and the admin handler
+//! flips it between `running` / `idle` with the helpers below. The
+//! actual per-title work is delegated to
+//! [`crate::tasks::metadata_fetch::fetch_metadata_chain`] — there is
+//! no second worker pool, no second rate-limiter, no second
+//! cover-download path.
+//!
+//! ## Concurrency contract
+//!
+//! Exactly one bulk fetch may be running at a time, repo-wide. A
+//! second attempt while one is in flight is refused with
+//! [`AlreadyRunning`] — the admin handler maps that to an HTTP 409.
+//! The single-instance lock is deliberate: each title hits 3+ external
+//! providers, and a doubled bulk run would simply waste their quotas.
+//!
+//! Status reads (e.g. for the admin Health panel's banner) take a read
+//! lock and clone the scalar fields out — never hold the guard across
+//! an `.await`.
+
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Utc};
+
+/// Snapshot of where the bulk-cover-refetch currently is. Stored in
+/// `AppState.bulk_cover_fetch` as `Arc<RwLock<BulkCoverFetchStatus>>`.
+///
+/// - `running == false` + `processed == 0` ⇒ never run, or fully reset.
+/// - `running == true` ⇒ a task is in flight; `processed` rises
+///   monotonically toward `total` as titles complete.
+/// - `running == false` + `last_completed_at == Some(_)` ⇒ a previous
+///   run completed; the totals are kept as a "what happened last
+///   time" record until the next start (which clears them).
+#[derive(Debug, Default, Clone)]
+pub struct BulkCoverFetchStatus {
+    pub running: bool,
+    pub total: usize,
+    pub processed: usize,
+    pub started_at: Option<DateTime<Utc>>,
+    pub last_completed_at: Option<DateTime<Utc>>,
+}
+
+/// Returned by [`try_start`] when a bulk fetch is already in flight.
+/// Mapped to a 409 by the admin handler.
+#[derive(Debug)]
+pub struct AlreadyRunning;
+
+/// Atomically transition the status from idle to running.
+///
+/// Returns `Ok(())` if the transition succeeded (the caller now owns
+/// the lock-like semantics — they MUST eventually call
+/// [`mark_complete`] to clear the running flag), or
+/// [`AlreadyRunning`] if a fetch was already running.
+///
+/// The lock is held only for the duration of the check-and-set — no
+/// awaits across it, so the read/write contract from `AppState` is
+/// preserved.
+pub fn try_start(
+    status: &Arc<RwLock<BulkCoverFetchStatus>>,
+    total: usize,
+) -> Result<(), AlreadyRunning> {
+    let mut guard = status.write().map_err(|_| AlreadyRunning)?;
+    if guard.running {
+        return Err(AlreadyRunning);
+    }
+    guard.running = true;
+    guard.total = total;
+    guard.processed = 0;
+    guard.started_at = Some(Utc::now());
+    Ok(())
+}
+
+/// Increment the per-title progress counter. Called by the bulk-fetch
+/// task after each title completes — successfully or not.
+pub fn increment_processed(status: &Arc<RwLock<BulkCoverFetchStatus>>) {
+    if let Ok(mut guard) = status.write() {
+        guard.processed = guard.processed.saturating_add(1);
+    }
+}
+
+/// Mark the bulk fetch as complete. Sets `running = false` and stamps
+/// `last_completed_at`. Idempotent — calling it twice is harmless.
+pub fn mark_complete(status: &Arc<RwLock<BulkCoverFetchStatus>>) {
+    if let Ok(mut guard) = status.write() {
+        guard.running = false;
+        guard.last_completed_at = Some(Utc::now());
+    }
+}
+
+/// Read a snapshot of the current status. Clones the scalar fields out
+/// so callers never hold the read guard across `.await`.
+pub fn snapshot(status: &Arc<RwLock<BulkCoverFetchStatus>>) -> BulkCoverFetchStatus {
+    status
+        .read()
+        .map(|g| g.clone())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_start_succeeds_on_idle_status() {
+        let s = Arc::new(RwLock::new(BulkCoverFetchStatus::default()));
+        assert!(try_start(&s, 42).is_ok());
+
+        let snap = snapshot(&s);
+        assert!(snap.running);
+        assert_eq!(snap.total, 42);
+        assert_eq!(snap.processed, 0);
+        assert!(snap.started_at.is_some());
+    }
+
+    #[test]
+    fn try_start_refuses_when_already_running() {
+        let s = Arc::new(RwLock::new(BulkCoverFetchStatus::default()));
+        try_start(&s, 10).unwrap();
+        assert!(
+            try_start(&s, 5).is_err(),
+            "second concurrent start must be refused"
+        );
+        // Original total/processed must be untouched.
+        let snap = snapshot(&s);
+        assert_eq!(snap.total, 10);
+        assert_eq!(snap.processed, 0);
+    }
+
+    #[test]
+    fn increment_processed_is_bounded_and_monotonic() {
+        let s = Arc::new(RwLock::new(BulkCoverFetchStatus::default()));
+        try_start(&s, 3).unwrap();
+        increment_processed(&s);
+        increment_processed(&s);
+        let snap = snapshot(&s);
+        assert_eq!(snap.processed, 2);
+        assert!(snap.running, "still running until mark_complete is called");
+    }
+
+    #[test]
+    fn mark_complete_clears_running_and_keeps_counters() {
+        let s = Arc::new(RwLock::new(BulkCoverFetchStatus::default()));
+        try_start(&s, 5).unwrap();
+        increment_processed(&s);
+        increment_processed(&s);
+        mark_complete(&s);
+
+        let snap = snapshot(&s);
+        assert!(!snap.running);
+        // Counters preserved — useful for the "last run summary" UX.
+        assert_eq!(snap.total, 5);
+        assert_eq!(snap.processed, 2);
+        assert!(snap.last_completed_at.is_some());
+    }
+
+    #[test]
+    fn try_start_after_complete_resets_counters() {
+        let s = Arc::new(RwLock::new(BulkCoverFetchStatus::default()));
+        try_start(&s, 5).unwrap();
+        increment_processed(&s);
+        mark_complete(&s);
+
+        // Second run starts with fresh counters.
+        try_start(&s, 8).unwrap();
+        let snap = snapshot(&s);
+        assert_eq!(snap.total, 8);
+        assert_eq!(snap.processed, 0);
+        assert!(snap.running);
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod admin_system;
 pub mod auth;
 pub mod auto_purge;
 pub mod borrowers;
+pub mod bulk_cover_fetch;
 pub mod contributor;
 pub mod cover;
 pub mod dashboard;

--- a/templates/fragments/admin_health_panel.html
+++ b/templates/fragments/admin_health_panel.html
@@ -29,7 +29,7 @@
     </table>
 
     <h2 class="text-lg font-semibold text-stone-900 dark:text-stone-100 mb-4">{{ providers_heading }}</h2>
-    <table class="min-w-full divide-y divide-stone-200 dark:divide-stone-700">
+    <table class="min-w-full divide-y divide-stone-200 dark:divide-stone-700 mb-8">
         <tbody class="divide-y divide-stone-100 dark:divide-stone-800">
             {% for p in providers %}
             <tr>
@@ -43,4 +43,38 @@
             {% endfor %}
         </tbody>
     </table>
+
+    {# Fix #214: Maintenance — bulk cover-refetch. Single-button
+       interface; the actual work runs detached in tokio::spawn. The
+       button is disabled while a fetch is in flight; refreshing the
+       Health panel polls the latest status. #}
+    <h2 class="text-lg font-semibold text-stone-900 dark:text-stone-100 mb-4">{{ maintenance_heading }}</h2>
+    <div class="mb-4">
+        <div class="flex items-center justify-between mb-3">
+            <div>
+                <p class="text-sm text-stone-500 dark:text-stone-400">{{ missing_covers_label }}</p>
+                <p class="text-2xl font-mono text-stone-900 dark:text-stone-100">{{ missing_covers_count }}</p>
+            </div>
+            {% if bulk_cover_fetch_can_start %}
+            <button type="button"
+                    hx-post="/admin/health/bulk-cover-refetch"
+                    hx-target="#admin-panel-feedback"
+                    hx-swap="innerHTML"
+                    class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700">
+                {{ bulk_cover_fetch_button_label }}
+            </button>
+            {% else %}
+            <button type="button"
+                    disabled
+                    class="px-4 py-2 text-sm font-medium text-stone-400 bg-stone-200 dark:bg-stone-800 rounded-md cursor-not-allowed">
+                {{ bulk_cover_fetch_button_label }}
+            </button>
+            {% endif %}
+        </div>
+        <p class="text-sm {% if bulk_cover_fetch_running %}text-amber-700 dark:text-amber-300{% else %}text-stone-500 dark:text-stone-400{% endif %}">
+            {{ bulk_cover_fetch_status_label }}
+        </p>
+    </div>
+
+    <div id="admin-panel-feedback" class="mt-4" aria-live="polite"></div>
 </section>

--- a/tests/admin_refdata_hx_trigger.rs
+++ b/tests/admin_refdata_hx_trigger.rs
@@ -50,6 +50,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/admin_system_integration.rs
+++ b/tests/admin_system_integration.rs
@@ -30,6 +30,9 @@ fn state_with_pool(pool: DbPool) -> mybibli::AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/admin_trash_modal_lifecycle.rs
+++ b/tests/admin_trash_modal_lifecycle.rs
@@ -43,6 +43,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/admin_user_deactivate_modal.rs
+++ b/tests/admin_user_deactivate_modal.rs
@@ -40,6 +40,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/borrower_delete_modal.rs
+++ b/tests/borrower_delete_modal.rs
@@ -36,6 +36,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/connection_lost_overlay.rs
+++ b/tests/connection_lost_overlay.rs
@@ -42,6 +42,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/contextual_help_tooltips.rs
+++ b/tests/contextual_help_tooltips.rs
@@ -44,6 +44,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/contributor_delete_modal.rs
+++ b/tests/contributor_delete_modal.rs
@@ -38,6 +38,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/csrf_integration.rs
+++ b/tests/csrf_integration.rs
@@ -28,6 +28,9 @@ fn state_with_pool(pool: DbPool) -> mybibli::AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/home_scan_redirect.rs
+++ b/tests/home_scan_redirect.rs
@@ -51,6 +51,9 @@ fn state_with_pool(pool: DbPool) -> AppState {
             active: false,
             bypass_via_env: true,
         })),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/keyboard_shortcuts_cheat_sheet.rs
+++ b/tests/keyboard_shortcuts_cheat_sheet.rs
@@ -35,6 +35,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/navbar_hamburger.rs
+++ b/tests/navbar_hamburger.rs
@@ -42,6 +42,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/navbar_role_visibility.rs
+++ b/tests/navbar_role_visibility.rs
@@ -40,6 +40,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/return_loan_modal.rs
+++ b/tests/return_loan_modal.rs
@@ -37,6 +37,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/role_gating.rs
+++ b/tests/role_gating.rs
@@ -41,6 +41,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/series_delete_modal.rs
+++ b/tests/series_delete_modal.rs
@@ -38,6 +38,9 @@ fn build_state(pool: MySqlPool) -> AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/session_cookie_collision.rs
+++ b/tests/session_cookie_collision.rs
@@ -35,6 +35,9 @@ fn state_with_pool(pool: DbPool) -> mybibli::AppState {
         setup_gate: Arc::new(RwLock::new(
             mybibli::middleware::setup_gate::SetupGateState::default(),
         )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 

--- a/tests/setup_wizard.rs
+++ b/tests/setup_wizard.rs
@@ -37,6 +37,9 @@ fn state_with_pool(pool: DbPool) -> mybibli::AppState {
             active: true,
             bypass_via_env: false,
         })),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
     }
 }
 


### PR DESCRIPTION
Closes #214. Last CR of the v1.2.0 bundle — release commit follows in a separate PR.

## Summary
- One-click admin action: re-triggers the full metadata-fetch chain on every title whose cover is missing AND that carries a lookup code. Closes the recovery loop on users who upgraded from a release that predated the Open Library Covers fallback in v1.1.6 / 1.1.7.
- Detached `tokio::spawn` worker that iterates titles serially with a 500 ms inter-title delay (politeness toward providers; per-provider rate limiters in the chain handle finer back-pressure). Reuses `fetch_metadata_chain` from the fresh-scan flow, including the OL fallback that fixes #225 / #228.
- Single-instance lock via `AppState.bulk_cover_fetch: Arc<RwLock<BulkCoverFetchStatus>>` — concurrent click returns HTTP 409 with a friendly message.

## What changed
- `services::bulk_cover_fetch` (NEW) — `BulkCoverFetchStatus` + `try_start` / `increment_processed` / `mark_complete` / `snapshot`. 5 unit tests pin the state machine.
- `TitleModel::count_missing_covers` + `list_missing_covers` (NEW) — eligibility query, ISBN > UPC > ISSN code preference, `ORDER BY created_at ASC`.
- `admin::admin_bulk_cover_refetch` (NEW handler) at `POST /admin/health/bulk-cover-refetch`. Admin role only.
- `AdminHealthPanel` gains a "Maintenance" section: missing-covers count + button + status string (Idle / Running X / Y / Last run). Button disabled while a fetch is in flight.
- Locales `admin.health.bulk_cover_fetch.*` in EN + FR.
- All 17 test fixtures that build a custom `AppState` updated to carry the new field (idle default).

## Tests
- 5 unit tests on the status state machine. Clippy `-D warnings` clean. Templates CSP audit clean.

## Test plan
- [ ] CI green.
- [ ] After merge: open `/admin?tab=health`, observe "Titles with missing covers: N" + the "Re-fetch missing covers" button.
- [ ] Click the button → success feedback, button disables, status flips to "Running: X / N".
- [ ] Tail `docker logs mybibli` — watch the per-title `fetch_metadata_chain` lines fill in.
- [ ] After completion: status flips to "Last run: N / N processed". Re-running with N=0 surfaces an "all done" info message instead.

## Release positioning
v1.2.0 bundle is now complete on `main` once this lands: #235 #236 #205 #200 #215 #214 → cut release as `chore: release v1.2.0` in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)