### PR TITLE
fix: 1.2.1 bundle — #139 + #154 + #133 + #219

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -19,7 +19,9 @@ pub enum AppError {
     /// Use for GET redirects only — pointless for failed mutations.
     UnauthorizedWithReturn(String),
     /// Authenticated user with insufficient role. Returns 403 with a FeedbackEntry body.
-    Forbidden,
+    /// Carries the request locale (one of `"en"` / `"fr"`) so the body is rendered in
+    /// the user's language — issue #219.
+    Forbidden(&'static str),
     Database(sqlx::Error),
 }
 
@@ -32,7 +34,7 @@ impl std::fmt::Display for AppError {
             AppError::Conflict(msg) => write!(f, "Conflict: {msg}"),
             AppError::Unauthorized => write!(f, "Unauthorized"),
             AppError::UnauthorizedWithReturn(next) => write!(f, "Unauthorized (next={next})"),
-            AppError::Forbidden => write!(f, "Forbidden"),
+            AppError::Forbidden(loc) => write!(f, "Forbidden (locale={loc})"),
             AppError::Database(err) => write!(f, "Database error: {err}"),
         }
     }
@@ -110,9 +112,9 @@ impl IntoResponse for AppError {
                 )
                     .into_response();
             }
-            AppError::Forbidden => {
-                let title = rust_i18n::t!("error.forbidden.title").to_string();
-                let body = rust_i18n::t!("error.forbidden.body").to_string();
+            AppError::Forbidden(loc) => {
+                let title = rust_i18n::t!("error.forbidden.title", locale = loc).to_string();
+                let body = rust_i18n::t!("error.forbidden.body", locale = loc).to_string();
                 let html = crate::routes::catalog::feedback_html_pub("error", &title, &body);
                 // polish-1 AC4.e: retarget to `#feedback-list`. The previous
                 // target `#feedback-container` was a latent dead-retarget bug
@@ -174,7 +176,7 @@ impl IntoResponse for AppError {
             ),
             AppError::Unauthorized
             | AppError::UnauthorizedWithReturn(_)
-            | AppError::Forbidden
+            | AppError::Forbidden(_)
             | AppError::Conflict(_) => {
                 unreachable!()
             }
@@ -250,6 +252,34 @@ mod tests {
         let err = AppError::Internal("crash".to_string());
         let response = err.into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // ─── #219: Forbidden body honours the carried locale ───────
+
+    #[tokio::test]
+    async fn test_forbidden_body_renders_in_french_locale() {
+        let err = AppError::Forbidden("fr");
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body_bytes = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+        assert!(
+            body.contains("Accès refusé") || body.contains("Action non autorisée"),
+            "FR locale should render French body, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forbidden_body_renders_in_english_locale() {
+        let err = AppError::Forbidden("en");
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body_bytes = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+        assert!(
+            body.contains("Access denied") || body.contains("permission"),
+            "EN locale should render English body, got: {body}"
+        );
     }
 
     #[test]

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -65,31 +65,36 @@ impl Session {
         }
     }
 
-    pub fn require_role(&self, min_role: Role) -> Result<(), AppError> {
+    /// `loc` is the request locale (one of `"en"` / `"fr"`, pulled from
+    /// `Extension(Locale)` at the handler) and is carried in
+    /// `AppError::Forbidden` so the 403 body renders in the user's language
+    /// — see issue #219.
+    pub fn require_role(&self, min_role: Role, loc: &'static str) -> Result<(), AppError> {
         if self.role >= min_role {
             Ok(())
         } else if self.role == Role::Anonymous {
             Err(AppError::Unauthorized)
         } else {
-            Err(AppError::Forbidden)
+            Err(AppError::Forbidden(loc))
         }
     }
 
     /// Like `require_role`, but for GET handlers — if the user is Anonymous, the error
     /// preserves `return_path` so `/login` can bounce them back after sign-in.
     /// Authenticated-but-insufficient still produces `Forbidden` (no point returning to
-    /// a page the user can't access anyway).
+    /// a page the user can't access anyway). `loc` is the request locale — see #219.
     pub fn require_role_with_return(
         &self,
         min_role: Role,
         return_path: &str,
+        loc: &'static str,
     ) -> Result<(), AppError> {
         if self.role >= min_role {
             Ok(())
         } else if self.role == Role::Anonymous {
             Err(AppError::UnauthorizedWithReturn(return_path.to_string()))
         } else {
-            Err(AppError::Forbidden)
+            Err(AppError::Forbidden(loc))
         }
     }
 }
@@ -410,13 +415,13 @@ mod tests {
             csrf_token: String::new(),
             preferred_language: None,
         };
-        assert!(session.require_role(Role::Librarian).is_ok());
+        assert!(session.require_role(Role::Librarian, "fr").is_ok());
     }
 
     #[test]
     fn test_require_role_anonymous_returns_unauthorized() {
         let session = anon();
-        match session.require_role(Role::Librarian) {
+        match session.require_role(Role::Librarian, "fr") {
             Err(AppError::Unauthorized) => {}
             other => panic!("expected Unauthorized, got {other:?}"),
         }
@@ -431,8 +436,8 @@ mod tests {
             csrf_token: String::new(),
             preferred_language: None,
         };
-        match session.require_role(Role::Admin) {
-            Err(AppError::Forbidden) => {}
+        match session.require_role(Role::Admin, "en") {
+            Err(AppError::Forbidden(loc)) => assert_eq!(loc, "en"),
             other => panic!("expected Forbidden, got {other:?}"),
         }
     }
@@ -440,7 +445,7 @@ mod tests {
     #[test]
     fn test_require_role_with_return_anonymous_preserves_path() {
         let session = anon();
-        match session.require_role_with_return(Role::Librarian, "/loans") {
+        match session.require_role_with_return(Role::Librarian, "/loans", "fr") {
             Err(AppError::UnauthorizedWithReturn(next)) => {
                 assert_eq!(next, "/loans");
             }
@@ -457,8 +462,8 @@ mod tests {
             csrf_token: String::new(),
             preferred_language: None,
         };
-        match session.require_role_with_return(Role::Admin, "/admin") {
-            Err(AppError::Forbidden) => {}
+        match session.require_role_with_return(Role::Admin, "/admin", "fr") {
+            Err(AppError::Forbidden(loc)) => assert_eq!(loc, "fr"),
             other => panic!("expected Forbidden, got {other:?}"),
         }
     }
@@ -482,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_role_gating_matrix_anonymous_vs_librarian_min() {
-        match make_session(Role::Anonymous).require_role(Role::Librarian) {
+        match make_session(Role::Anonymous).require_role(Role::Librarian, "fr") {
             Err(AppError::Unauthorized) => {}
             other => panic!("Anonymous/Librarian expected Unauthorized, got {other:?}"),
         }
@@ -490,7 +495,7 @@ mod tests {
 
     #[test]
     fn test_role_gating_matrix_anonymous_vs_admin_min() {
-        match make_session(Role::Anonymous).require_role(Role::Admin) {
+        match make_session(Role::Anonymous).require_role(Role::Admin, "fr") {
             Err(AppError::Unauthorized) => {}
             other => panic!("Anonymous/Admin expected Unauthorized, got {other:?}"),
         }
@@ -500,15 +505,15 @@ mod tests {
     fn test_role_gating_matrix_librarian_vs_librarian_min() {
         assert!(
             make_session(Role::Librarian)
-                .require_role(Role::Librarian)
+                .require_role(Role::Librarian, "fr")
                 .is_ok()
         );
     }
 
     #[test]
     fn test_role_gating_matrix_librarian_vs_admin_min() {
-        match make_session(Role::Librarian).require_role(Role::Admin) {
-            Err(AppError::Forbidden) => {}
+        match make_session(Role::Librarian).require_role(Role::Admin, "fr") {
+            Err(AppError::Forbidden(_)) => {}
             other => panic!("Librarian/Admin expected Forbidden, got {other:?}"),
         }
     }
@@ -517,14 +522,14 @@ mod tests {
     fn test_role_gating_matrix_admin_vs_librarian_min() {
         assert!(
             make_session(Role::Admin)
-                .require_role(Role::Librarian)
+                .require_role(Role::Librarian, "fr")
                 .is_ok()
         );
     }
 
     #[test]
     fn test_role_gating_matrix_admin_vs_admin_min() {
-        assert!(make_session(Role::Admin).require_role(Role::Admin).is_ok());
+        assert!(make_session(Role::Admin).require_role(Role::Admin, "fr").is_ok());
     }
 
     // ─── Timeout boundary contract (AC 10 / Task 6) ─────────────
@@ -587,7 +592,7 @@ mod tests {
             csrf_token: String::new(),
             preferred_language: None,
         };
-        assert!(session.require_role(Role::Librarian).is_ok());
+        assert!(session.require_role(Role::Librarian, "fr").is_ok());
     }
 
     #[test]

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -412,7 +412,7 @@ pub async fn admin_page(
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
         .unwrap_or_else(|| "/admin".to_string());
-    session.require_role_with_return(Role::Admin, &return_path)?;
+    session.require_role_with_return(Role::Admin, &return_path, locale.0)?;
 
     let tab = AdminTab::from_query_str(params.tab.as_deref());
     render_admin(&state, &session, locale.0, &uri, is_htmx, tab, None).await
@@ -425,7 +425,7 @@ pub async fn admin_health_panel(
     OriginalUri(uri): OriginalUri,
     HxRequest(is_htmx): HxRequest,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=health")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=health", locale.0)?;
     render_admin(&state, &session, locale.0, &uri, is_htmx, AdminTab::Health, None).await
 }
 
@@ -440,7 +440,7 @@ pub async fn admin_bulk_cover_refetch(
     session: Session,
     Extension(locale): Extension<Locale>,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=health")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=health", locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -540,7 +540,7 @@ pub async fn admin_users_panel(
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
         .unwrap_or_else(|| "/admin?tab=users".to_string());
-    session.require_role_with_return(Role::Admin, &return_path)?;
+    session.require_role_with_return(Role::Admin, &return_path, locale.0)?;
 
     let tab = AdminTab::Users;
     let filters = UsersFilters {
@@ -564,7 +564,7 @@ pub async fn admin_users_create_form(
     session: Session,
     Extension(locale): Extension<Locale>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
     let form = AdminUsersFormCreate {
@@ -592,7 +592,7 @@ pub async fn admin_users_create(
     Extension(locale): Extension<Locale>,
     Form(form): Form<CreateUserForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
     // Validate username (trim whitespace, check not empty)
@@ -648,7 +648,7 @@ pub async fn admin_users_edit_form(
     Extension(locale): Extension<Locale>,
     axum::extract::Path(id): axum::extract::Path<u64>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
     // Fetch user
@@ -680,7 +680,7 @@ pub async fn admin_users_row_view(
     Extension(locale): Extension<Locale>,
     axum::extract::Path(id): axum::extract::Path<u64>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
     // Fetch user
@@ -715,7 +715,7 @@ pub async fn admin_users_deactivate_modal(
     // Admin-only feature (mirror of the trigger's enclosing template gate).
     // _with_return ensures an anonymous direct-URL hitter lands back on
     // /admin?tab=users after login.
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -782,7 +782,7 @@ pub async fn admin_users_update(
     axum::extract::Path(id): axum::extract::Path<u64>,
     Form(form): Form<UpdateUserForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
     // Validate username (trim whitespace, check not empty)
@@ -882,7 +882,7 @@ pub async fn admin_users_deactivate(
     axum::extract::Path(id): axum::extract::Path<u64>,
     Form(form): Form<DeactivateForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
     let acting_admin_id = session.user_id.ok_or_else(|| {
         AppError::Internal("admin session missing user_id".to_string())
@@ -918,7 +918,7 @@ pub async fn admin_users_reactivate(
     axum::extract::Path(id): axum::extract::Path<u64>,
     Form(form): Form<ReactivateForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
     // Reactivate the user
@@ -961,7 +961,7 @@ pub async fn admin_trash_permanent_delete_confirm(
     axum::extract::Path((table, id)): axum::extract::Path<(String, u64)>,
     Query(params): Query<PermanentDeleteConfirmQuery>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=trash")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=trash", locale.0)?;
     let loc = locale.0;
 
     let version = params
@@ -1054,7 +1054,7 @@ pub async fn admin_trash_permanent_delete(
     Query(filters): Query<TrashQuery>,
     Form(form): Form<PermanentDeleteForm>,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=trash")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=trash", locale.0)?;
     let loc = locale.0;
 
     // Patch P20: consolidate user_id resolution. The handler is admin-gated
@@ -1189,7 +1189,7 @@ pub async fn admin_trash_panel(
     headers: axum::http::HeaderMap,
     Query(query): Query<TrashQuery>,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=trash")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=trash", locale.0)?;
 
     // The same /admin/trash URL serves two HTMX swap targets:
     //   * `#admin-shell` — emitted by the admin tab bar when the user
@@ -1859,15 +1859,15 @@ mod tests {
 
     #[test]
     fn test_admin_handler_requires_admin_role_for_librarian() {
-        match make_session(Role::Librarian).require_role_with_return(Role::Admin, "/admin") {
-            Err(AppError::Forbidden) => {}
+        match make_session(Role::Librarian).require_role_with_return(Role::Admin, "/admin", "fr") {
+            Err(AppError::Forbidden(_)) => {}
             other => panic!("librarian on /admin: expected Forbidden, got {other:?}"),
         }
     }
 
     #[test]
     fn test_admin_handler_anonymous_returns_unauthorized_with_return() {
-        match make_session(Role::Anonymous).require_role_with_return(Role::Admin, "/admin") {
+        match make_session(Role::Anonymous).require_role_with_return(Role::Admin, "/admin", "fr") {
             Err(AppError::UnauthorizedWithReturn(next)) => {
                 assert_eq!(next, "/admin");
             }
@@ -1879,7 +1879,7 @@ mod tests {
     fn test_admin_handler_admin_role_passes() {
         assert!(
             make_session(Role::Admin)
-                .require_role_with_return(Role::Admin, "/admin")
+                .require_role_with_return(Role::Admin, "/admin", "fr")
                 .is_ok()
         );
     }

--- a/src/routes/admin_reference_data.rs
+++ b/src/routes/admin_reference_data.rs
@@ -7,7 +7,7 @@
 //! Lives in its own module because Foundation Rule #12 caps source files
 //! at 2000 lines and `routes/admin.rs` is already at 1500+. Every POST
 //! handler here is automatically CSRF-protected (8-2 middleware) and
-//! every handler's first line is `session.require_role_with_return(Role::Admin, …)?`.
+//! every handler's first line is `session.require_role_with_return(Role::Admin, …, locale.0)?`.
 
 use askama::Template;
 use axum::Extension;
@@ -544,7 +544,7 @@ pub async fn admin_reference_data_panel(
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
         .unwrap_or_else(|| "/admin?tab=reference_data".to_string());
-    session.require_role_with_return(Role::Admin, &return_path)?;
+    session.require_role_with_return(Role::Admin, &return_path, locale.0)?;
 
     // The /admin/reference-data URL is hit by the admin tab bar (HTMX swap
     // into #admin-shell) and direct page navigation. Sub-section forms POST
@@ -578,7 +578,7 @@ pub async fn genres_section(
     session: Session,
     Extension(locale): Extension<Locale>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let entries = build_genre_rows(&state.pool, loc).await?;
     let html = render_genres_list(entries, loc)?;
@@ -591,7 +591,7 @@ pub async fn genres_create(
     Extension(locale): Extension<Locale>,
     Form(form): Form<CreateRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     let outcome = GenreModel::create(&state.pool, &name)
@@ -621,7 +621,7 @@ pub async fn genres_rename(
     Path(id): Path<u64>,
     Form(form): Form<RenameRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     GenreModel::rename(&state.pool, id, form.version, &name)
@@ -652,7 +652,7 @@ pub async fn genres_delete_modal(
     Path(id): Path<u64>,
     Query(q): Query<VersionQuery>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     require_valid_version(q.version, loc)?;
     let row = GenreModel::find_by_id(&state.pool, id)
@@ -676,7 +676,7 @@ pub async fn genres_delete(
     Path(id): Path<u64>,
     Form(form): Form<DeleteRefForm>,
 ) -> Result<axum::response::Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let row = GenreModel::find_by_id(&state.pool, id)
         .await?
@@ -720,7 +720,7 @@ pub async fn volume_states_section(
     session: Session,
     Extension(locale): Extension<Locale>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let entries = build_volume_state_rows(&state.pool, loc).await?;
     let html = render_volume_states_list(entries, &session.csrf_token, loc)?;
@@ -733,7 +733,7 @@ pub async fn volume_states_create(
     Extension(locale): Extension<Locale>,
     Form(form): Form<CreateVolumeStateForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     let is_loanable = checkbox_to_bool(&form.is_loanable);
@@ -764,7 +764,7 @@ pub async fn volume_states_rename(
     Path(id): Path<u64>,
     Form(form): Form<RenameRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     VolumeStateModel::rename(&state.pool, id, form.version, &name)
@@ -798,7 +798,7 @@ pub async fn volume_states_delete_modal(
     Path(id): Path<u64>,
     Query(q): Query<VersionQuery>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     require_valid_version(q.version, loc)?;
     let row = VolumeStateModel::find_by_id(&state.pool, id)
@@ -822,7 +822,7 @@ pub async fn volume_states_delete(
     Path(id): Path<u64>,
     Form(form): Form<DeleteRefForm>,
 ) -> Result<axum::response::Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let row = VolumeStateModel::find_by_id(&state.pool, id)
         .await?
@@ -861,7 +861,7 @@ pub async fn volume_states_loanable_toggle(
     Path(id): Path<u64>,
     Form(form): Form<LoanableToggleForm>,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let new_loanable = checkbox_to_bool(&form.is_loanable);
     // Story 8-4 P33 (D2-b): the `force` field on the toggle form is intentionally
@@ -927,7 +927,7 @@ pub async fn volume_states_loanable_confirm(
     Path(id): Path<u64>,
     Form(form): Form<LoanableToggleForm>,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let new_loanable = checkbox_to_bool(&form.is_loanable);
 
@@ -1018,7 +1018,7 @@ pub async fn volume_states_row_view(
     Extension(locale): Extension<Locale>,
     Path(id): Path<u64>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let row = VolumeStateModel::find_by_id(&state.pool, id)
         .await?
@@ -1041,7 +1041,7 @@ pub async fn roles_section(
     session: Session,
     Extension(locale): Extension<Locale>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let entries = build_role_rows(&state.pool, loc).await?;
     let html = render_roles_list(entries, loc)?;
@@ -1054,7 +1054,7 @@ pub async fn roles_create(
     Extension(locale): Extension<Locale>,
     Form(form): Form<CreateRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     let outcome = ContributorRoleModel::create(&state.pool, &name)
@@ -1084,7 +1084,7 @@ pub async fn roles_rename(
     Path(id): Path<u64>,
     Form(form): Form<RenameRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     ContributorRoleModel::rename(&state.pool, id, form.version, &name)
@@ -1115,7 +1115,7 @@ pub async fn roles_delete_modal(
     Path(id): Path<u64>,
     Query(q): Query<VersionQuery>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     require_valid_version(q.version, loc)?;
     let row = ContributorRoleModel::get(&state.pool, id)
@@ -1139,7 +1139,7 @@ pub async fn roles_delete(
     Path(id): Path<u64>,
     Form(form): Form<DeleteRefForm>,
 ) -> Result<axum::response::Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let row = ContributorRoleModel::get(&state.pool, id)
         .await?
@@ -1178,7 +1178,7 @@ pub async fn node_types_section(
     session: Session,
     Extension(locale): Extension<Locale>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let entries = build_node_type_rows(&state.pool, loc).await?;
     let html = render_node_types_list(entries, loc)?;
@@ -1191,7 +1191,7 @@ pub async fn node_types_create(
     Extension(locale): Extension<Locale>,
     Form(form): Form<CreateRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     let outcome = LocationNodeTypeModel::create(&state.pool, &name)
@@ -1221,7 +1221,7 @@ pub async fn node_types_rename(
     Path(id): Path<u64>,
     Form(form): Form<RenameRefForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let name = validate_name(&form.name, loc)?;
     // Story 8-4 P3: storage_locations.node_type is VARCHAR(50). Reject
@@ -1294,7 +1294,7 @@ pub async fn node_types_delete_modal(
     Path(id): Path<u64>,
     Query(q): Query<VersionQuery>,
 ) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     require_valid_version(q.version, loc)?;
     let row = LocationNodeTypeModel::find_by_id(&state.pool, id)
@@ -1318,7 +1318,7 @@ pub async fn node_types_delete(
     Path(id): Path<u64>,
     Form(form): Form<DeleteRefForm>,
 ) -> Result<axum::response::Response, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=reference_data", locale.0)?;
     let loc = locale.0;
     let row = LocationNodeTypeModel::find_by_id(&state.pool, id)
         .await?

--- a/src/routes/admin_system.rs
+++ b/src/routes/admin_system.rs
@@ -6,7 +6,7 @@
 //! different settings do not collide.
 //!
 //! The handlers all follow the same shape:
-//!   1. `session.require_role_with_return(Role::Admin, &return_path)?`
+//!   1. `session.require_role_with_return(Role::Admin, &return_path, locale.0)?`
 //!   2. Validate the form fields
 //!   3. UPDATE the row(s) with optimistic-lock check via `save_setting`
 //!   4. Reload the `Arc<RwLock<AppSettings>>` cache via `reload_settings_cache`
@@ -358,7 +358,7 @@ pub async fn admin_system_panel(
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
         .unwrap_or_else(|| "/admin?tab=system".to_string());
-    session.require_role_with_return(Role::Admin, &return_path)?;
+    session.require_role_with_return(Role::Admin, &return_path, locale.0)?;
 
     // Tab click swaps #admin-shell — needs the full shell. There's no
     // panel-only swap on this URL (the three section forms target their
@@ -387,7 +387,7 @@ pub async fn save_loans_settings(
     Extension(locale): Extension<Locale>,
     Form(form): Form<LoansSettingsForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=system")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=system", locale.0)?;
     let loc = locale.0;
     validate_overdue_threshold(form.overdue_threshold_days, loc)?;
     save_setting(
@@ -426,7 +426,7 @@ pub async fn save_provider_keys(
     Extension(locale): Extension<Locale>,
     Form(form): Form<ProviderKeysForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=system")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=system", locale.0)?;
     let loc = locale.0;
 
     let mut tx = state.pool.begin().await?;
@@ -506,7 +506,7 @@ pub async fn save_language_settings(
     Extension(locale): Extension<Locale>,
     Form(form): Form<LanguageSettingsForm>,
 ) -> Result<HtmxResponse, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=system")?;
+    session.require_role_with_return(Role::Admin, "/admin?tab=system", locale.0)?;
     let loc = locale.0;
     validate_default_language(&form.default_language, loc)?;
     save_setting(

--- a/src/routes/borrowers.rs
+++ b/src/routes/borrowers.rs
@@ -76,7 +76,7 @@ pub async fn borrowers_page(
     HxRequest(_is_htmx): HxRequest,
     axum::extract::Query(params): axum::extract::Query<BorrowerListQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -151,9 +151,10 @@ pub struct CreateBorrowerForm {
 pub async fn create_borrower(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     axum::Form(form): axum::Form<CreateBorrowerForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     let borrower =
@@ -216,7 +217,7 @@ pub async fn borrower_detail(
     HxRequest(_is_htmx): HxRequest,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -322,7 +323,7 @@ pub async fn edit_borrower_page(
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
     // Story 7-1 decision 2a: Admin → Librarian.
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -393,11 +394,12 @@ pub struct UpdateBorrowerForm {
 pub async fn update_borrower(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     Path(id): Path<u64>,
     axum::Form(form): axum::Form<UpdateBorrowerForm>,
 ) -> Result<impl IntoResponse, AppError> {
     // Story 7-1 decision 2a: Admin → Librarian.
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     BorrowerService::update_borrower(
@@ -442,7 +444,7 @@ pub async fn delete_modal(
     // Preserve the borrower-detail return path so an anonymous user who
     // hits this URL directly (or whose session expired) lands back on the
     // borrower page after login, not on /home.
-    session.require_role_with_return(Role::Admin, &format!("/borrower/{id}"))?;
+    session.require_role_with_return(Role::Admin, &format!("/borrower/{id}"), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -503,10 +505,11 @@ pub async fn delete_modal(
 pub async fn delete_borrower(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     HxRequest(is_htmx): HxRequest,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Admin)?;
+    session.require_role(Role::Admin, locale.0)?;
     let pool = &state.pool;
 
     BorrowerService::delete_borrower(pool, id).await?;
@@ -537,10 +540,11 @@ pub struct BorrowerSearchQuery {
 pub async fn borrower_search(
     session: Session,
     State(state): State<AppState>,
+    Extension(locale): Extension<Locale>,
     uri: axum::http::Uri,
     axum::extract::Query(query): axum::extract::Query<BorrowerSearchQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let q = query.q.trim();
     if q.len() < 2 || q.len() > 255 {

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -1,4 +1,5 @@
 use askama::Template;
+use axum::Extension;
 use axum::extract::State;
 use axum::response::{Html, IntoResponse, Redirect};
 use axum_extra::extract::cookie::{Cookie, CookieJar};
@@ -8,6 +9,7 @@ use crate::AppState;
 use crate::error::AppError;
 use crate::middleware::auth::{Role, Session};
 use crate::middleware::htmx::{HtmxResponse, HxRequest, OobUpdate};
+use crate::middleware::locale::Locale;
 use crate::models::contributor::{ContributorModel, ContributorRoleModel, TitleContributorModel};
 use crate::models::session::SessionModel;
 use crate::models::volume::VolumeModel;
@@ -314,7 +316,7 @@ async fn compute_guide_message(pool: &crate::db::DbPool, session: &Session, loc:
 
 pub async fn catalog_page(
     session: Session,
-    axum::Extension(locale): axum::Extension<crate::middleware::locale::Locale>,
+    Extension(locale): Extension<Locale>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, AppError> {
@@ -422,14 +424,14 @@ pub(crate) fn detect_code_type(code: &str) -> CodeDetection {
 
 pub async fn handle_scan(
     session: Session,
-    axum::Extension(locale): axum::Extension<crate::middleware::locale::Locale>,
+    Extension(locale): Extension<Locale>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     HxRequest(is_htmx): HxRequest,
     jar: CookieJar,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<ScanForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let loc = locale.0;
 
     let code = form.code.trim().to_string();
@@ -1119,12 +1121,13 @@ pub struct ScanWithTypeForm {
 
 pub async fn handle_scan_with_type(
     session: Session,
+    Extension(locale): Extension<Locale>,
     HxRequest(_is_htmx): HxRequest,
     jar: CookieJar,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<ScanWithTypeForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     use crate::models::media_type::{CodeType, MediaType};
 
@@ -1279,7 +1282,7 @@ struct TitleFormTemplate {
 
 pub async fn title_form_page(
     session: Session,
-    axum::Extension(locale): axum::Extension<crate::middleware::locale::Locale>,
+    Extension(locale): Extension<Locale>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     HxRequest(is_htmx): HxRequest,
     State(state): State<AppState>,
@@ -1287,7 +1290,7 @@ pub async fn title_form_page(
     // Use the pre-nest original URI for BOTH the role-gate return path and
     // the toggle's `current_url` so the two stay aligned under any future
     // router nesting.
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let loc = locale.0;
 
     let pool = &state.pool;
@@ -1348,12 +1351,12 @@ pub async fn title_form_page(
 
 pub async fn create_title(
     session: Session,
-    axum::Extension(locale): axum::Extension<crate::middleware::locale::Locale>,
+    Extension(locale): Extension<Locale>,
     HxRequest(is_htmx): HxRequest,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<TitleForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let loc = locale.0;
 
     let pool = &state.pool;
@@ -1422,10 +1425,11 @@ struct TypeSpecificFieldsTemplate {
 
 pub async fn type_specific_fields(
     session: Session,
+    Extension(locale): Extension<Locale>,
     uri: axum::http::Uri,
     axum::extract::Path(media_type): axum::extract::Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let template = TypeSpecificFieldsTemplate {
         show_page_count: matches!(media_type.as_str(), "book" | "bd" | "magazine" | "report"),
@@ -1472,11 +1476,12 @@ pub struct ContributorSearchQuery {
 
 pub async fn contributor_search(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     uri: axum::http::Uri,
     axum::extract::Query(query): axum::extract::Query<ContributorSearchQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let q = query.q.trim();
     if q.len() < 2 || q.len() > 255 {
@@ -1503,11 +1508,12 @@ pub struct AddContributorForm {
 
 pub async fn add_contributor(
     session: Session,
+    Extension(locale): Extension<Locale>,
     HxRequest(_is_htmx): HxRequest,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<AddContributorForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     let pool = &state.pool;
 
@@ -1583,11 +1589,12 @@ pub struct RemoveContributorForm {
 
 pub async fn remove_contributor(
     session: Session,
+    Extension(locale): Extension<Locale>,
     HxRequest(_is_htmx): HxRequest,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<RemoveContributorForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     let pool = &state.pool;
     ContributorService::remove_from_title(pool, form.junction_id).await?;
@@ -1636,10 +1643,11 @@ pub struct UpdateContributorForm {
 
 pub async fn update_contributor(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<UpdateContributorForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     let pool = &state.pool;
     let bio = form.biography.as_deref();
@@ -1685,11 +1693,12 @@ pub async fn update_contributor(
 /// `feedback_html` on FR54 Conflict.
 pub async fn delete_contributor(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     HxRequest(is_htmx): HxRequest,
     axum::extract::Path(id): axum::extract::Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     let pool = &state.pool;
 
@@ -1733,10 +1742,11 @@ struct ContributorFormTemplate {
 
 pub async fn contributor_form_page(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     uri: axum::http::Uri,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let pool = &state.pool;
 
@@ -1832,10 +1842,11 @@ fn contributor_list_html(contributors: &[TitleContributorModel]) -> String {
 
 pub async fn delete_title(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     let pool = &state.pool;
 
@@ -1854,10 +1865,11 @@ pub async fn delete_title(
 
 pub async fn delete_volume(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     // Guard: block deletion if volume is currently on loan
@@ -1929,7 +1941,7 @@ pub struct VolumeDetailTemplate {
 
 pub async fn volume_detail(
     session: Session,
-    axum::Extension(locale): axum::Extension<crate::middleware::locale::Locale>,
+    Extension(locale): Extension<Locale>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     HxRequest(_is_htmx): HxRequest,
     State(state): State<AppState>,
@@ -2095,12 +2107,12 @@ pub struct VolumeEditTemplate {
 
 pub async fn volume_edit_page(
     session: Session,
-    axum::Extension(locale): axum::Extension<crate::middleware::locale::Locale>,
+    Extension(locale): Extension<Locale>,
     axum::extract::OriginalUri(uri): axum::extract::OriginalUri,
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -2162,11 +2174,12 @@ pub struct VolumeEditForm {
 
 pub async fn update_volume(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<u64>,
     axum::Form(form): axum::Form<VolumeEditForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     VolumeModel::update_details(
         &state.pool,
@@ -2204,6 +2217,7 @@ pub struct SessionTimeoutOverride {
 
 pub async fn debug_set_session_timeout(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<SessionTimeoutOverride>,
 ) -> Result<impl IntoResponse, AppError> {
@@ -2215,7 +2229,7 @@ pub async fn debug_set_session_timeout(
     if std::env::var("TEST_MODE").as_deref() != Ok("1") {
         return Err(AppError::NotFound("disabled".to_string()));
     }
-    session.require_role(Role::Admin)?;
+    session.require_role(Role::Admin, locale.0)?;
     if form.secs == 0 {
         return Err(AppError::BadRequest("secs must be >= 1".to_string()));
     }

--- a/src/routes/contributors.rs
+++ b/src/routes/contributors.rs
@@ -165,7 +165,7 @@ pub async fn delete_modal(
     // Preserve the contributor-detail return path so an anonymous user who
     // hits this URL directly (or whose session expired) lands back on the
     // contributor page after login, not on /home.
-    session.require_role_with_return(Role::Librarian, &format!("/contributor/{id}"))?;
+    session.require_role_with_return(Role::Librarian, &format!("/contributor/{id}"), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 

--- a/src/routes/loans.rs
+++ b/src/routes/loans.rs
@@ -272,6 +272,22 @@ pub async fn return_loan_handler(
 
 // ─── Return loan — confirmation modal (story 9-11) ──────
 
+/// Parse `HX-Current-URL` (the document's full URL the modal trigger
+/// came from) and extract a same-origin path-and-query suitable for use
+/// as a post-login `next=` return target. Returns `None` when the URL
+/// can't be parsed or fails the [`crate::error::is_safe_next`] guard
+/// (defends against open-redirect when the header is attacker-controlled).
+fn extract_safe_path(current_url: &str) -> Option<String> {
+    use axum::http::Uri;
+    let uri: Uri = current_url.parse().ok()?;
+    let p = uri.path_and_query()?.as_str().to_string();
+    if crate::error::is_safe_next(&p) {
+        Some(p)
+    } else {
+        None
+    }
+}
+
 /// Closed allowlist of feedback-target IDs the modal is allowed to render
 /// into. Three surfaces today: the `/loans` table feedback area, the
 /// `/borrower/:id` active-loans feedback area, and the loans-page V-code
@@ -308,10 +324,20 @@ pub async fn return_modal_handler(
     session: Session,
     Extension(locale): Extension<Locale>,
     HxRequest(is_htmx): HxRequest,
+    headers: axum::http::HeaderMap,
     Path(loan_id): Path<u64>,
     Query(query): Query<ReturnModalQuery>,
 ) -> Result<Response, AppError> {
-    session.require_role_with_return(Role::Librarian, "/loans")?;
+    // Fix #133: derive the post-login return path from HX-Current-URL when
+    // available so anonymous users sent through /login bounce back to the
+    // surface they were on (/borrower/:id, /loans, etc.) instead of being
+    // hard-coded to /loans. Falls back to /loans on missing/invalid header.
+    let return_path = headers
+        .get("hx-current-url")
+        .and_then(|v| v.to_str().ok())
+        .and_then(extract_safe_path)
+        .unwrap_or_else(|| "/loans".to_string());
+    session.require_role_with_return(Role::Librarian, &return_path)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -494,6 +520,45 @@ mod tests {
     #[test]
     fn test_default_page() {
         assert_eq!(default_page(), 1);
+    }
+
+    // ─── #133: extract_safe_path coverage ───────────────
+
+    #[test]
+    fn extract_safe_path_accepts_absolute_url() {
+        assert_eq!(
+            extract_safe_path("http://example.com/borrower/42"),
+            Some("/borrower/42".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_safe_path_preserves_query() {
+        assert_eq!(
+            extract_safe_path("https://example.com/loans?page=2&sort=title"),
+            Some("/loans?page=2&sort=title".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_safe_path_accepts_bare_path() {
+        // HTMX always sends an absolute URL today, but accept a bare path
+        // defensively so we don't regress on clients that emit one.
+        assert_eq!(
+            extract_safe_path("/borrower/7"),
+            Some("/borrower/7".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_safe_path_rejects_protocol_relative() {
+        assert_eq!(extract_safe_path("//evil.example.com/path"), None);
+    }
+
+    #[test]
+    fn extract_safe_path_rejects_unparseable() {
+        assert_eq!(extract_safe_path(""), None);
+        assert_eq!(extract_safe_path("not a url"), None);
     }
 
     #[test]

--- a/src/routes/loans.rs
+++ b/src/routes/loans.rs
@@ -89,7 +89,7 @@ pub async fn loans_page(
     axum::extract::Query(params): axum::extract::Query<LoanListQuery>,
 ) -> Result<impl IntoResponse, AppError> {
     // AC #2: preserve `next` so post-login lands back on /loans.
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -169,7 +169,7 @@ pub async fn create_loan(
     HxRequest(is_htmx): HxRequest,
     axum::Form(form): axum::Form<CreateLoanForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -243,7 +243,7 @@ pub async fn return_loan_handler(
     HxRequest(is_htmx): HxRequest,
     Path(loan_id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -337,7 +337,7 @@ pub async fn return_modal_handler(
         .and_then(|v| v.to_str().ok())
         .and_then(extract_safe_path)
         .unwrap_or_else(|| "/loans".to_string());
-    session.require_role_with_return(Role::Librarian, &return_path)?;
+    session.require_role_with_return(Role::Librarian, &return_path, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -405,7 +405,7 @@ pub async fn scan_on_loans(
 ) -> Result<impl IntoResponse, AppError> {
     // Strip query string from `next` — no point replaying a failed scan after login,
     // and the user-supplied `?code=` shouldn't be reflected into the login form.
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
     let code = params.code.trim().to_uppercase();

--- a/src/routes/locations.rs
+++ b/src/routes/locations.rs
@@ -488,11 +488,12 @@ pub struct CreateLocationForm {
 
 pub async fn create_location(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::Form(form): axum::Form<CreateLocationForm>,
 ) -> Result<impl IntoResponse, AppError> {
     // Story 7-1 decision 1a: location creation promoted from Admin → Librarian.
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     let pool = &state.pool;
     let location = LocationService::create_location(
@@ -555,7 +556,7 @@ pub async fn edit_location_page(
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
     // Story 7-1 decision 1a: Admin → Librarian.
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let pool = &state.pool;
     let loc = locale.0;
@@ -617,12 +618,13 @@ pub struct UpdateLocationForm {
 
 pub async fn update_location(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     Path(id): Path<u64>,
     axum::Form(form): axum::Form<UpdateLocationForm>,
 ) -> Result<impl IntoResponse, AppError> {
     // Story 7-1 decision 1a: Admin → Librarian.
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
 
     LocationService::update_location(
         &state.pool,
@@ -645,7 +647,7 @@ pub async fn delete_location(
     State(state): State<AppState>,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Admin)?;
+    session.require_role(Role::Admin, locale.0)?;
     let loc = locale.0;
 
     LocationService::delete_location(&state.pool, id).await?;
@@ -663,11 +665,12 @@ pub async fn delete_location(
 
 pub async fn next_lcode(
     session: Session,
+    Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     OriginalUri(uri): OriginalUri,
 ) -> Result<impl IntoResponse, AppError> {
     // Story 7-1 decision 1a: Admin → Librarian (used by create-location form).
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let lcode = LocationService::get_next_available_lcode(&state.pool).await?;
     Ok(axum::Json(serde_json::json!({"lcode": lcode})))

--- a/src/routes/series.rs
+++ b/src/routes/series.rs
@@ -661,7 +661,7 @@ pub async fn delete_series(
         }
         Err(e) => {
             let message = match &e {
-                AppError::NotFound(msg) => msg.clone(),
+                AppError::NotFound(msg) | AppError::Conflict(msg) => msg.clone(),
                 _ => rust_i18n::t!("error.internal", locale = loc).to_string(),
             };
             Ok(Html(feedback_html_pub("error", &message, "")).into_response())

--- a/src/routes/series.rs
+++ b/src/routes/series.rs
@@ -401,7 +401,7 @@ pub async fn create_series_form(
     Extension(locale): Extension<Locale>,
     OriginalUri(uri): OriginalUri,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
 
     let template = form_template_labels(
         &session,
@@ -451,9 +451,10 @@ fn default_series_type() -> String {
 pub async fn create_series(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     axum::Form(form): axum::Form<CreateSeriesForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     let series_type = form
@@ -480,7 +481,7 @@ pub async fn edit_series_form(
     OriginalUri(uri): OriginalUri,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(Role::Librarian, uri.path())?;
+    session.require_role_with_return(Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -522,10 +523,11 @@ pub struct UpdateSeriesForm {
 pub async fn update_series(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     Path(id): Path<u64>,
     axum::Form(form): axum::Form<UpdateSeriesForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     let series_type = form
@@ -579,7 +581,7 @@ pub async fn delete_modal(
     // Preserve the series-detail return path so an anonymous user who
     // hits this URL directly (or whose session expired) lands back on the
     // series page after login, not on /home.
-    session.require_role_with_return(Role::Librarian, &format!("/series/{id}"))?;
+    session.require_role_with_return(Role::Librarian, &format!("/series/{id}"), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -639,7 +641,7 @@ pub async fn delete_series(
     HxRequest(is_htmx): HxRequest,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -444,7 +444,7 @@ pub async fn title_edit_form(
     OriginalUri(uri): OriginalUri,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role_with_return(crate::middleware::auth::Role::Librarian, uri.path())?;
+    session.require_role_with_return(crate::middleware::auth::Role::Librarian, uri.path(), locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -547,7 +547,7 @@ pub async fn update_title(
     Path(id): Path<u64>,
     Form(form): Form<TitleEditForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(crate::middleware::auth::Role::Librarian)?;
+    session.require_role(crate::middleware::auth::Role::Librarian, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -672,7 +672,7 @@ pub async fn redownload_metadata(
     Extension(locale): Extension<Locale>,
     Path(id): Path<u64>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(crate::middleware::auth::Role::Librarian)?;
+    session.require_role(crate::middleware::auth::Role::Librarian, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -900,7 +900,7 @@ pub async fn confirm_metadata(
     Path(id): Path<u64>,
     Form(form): Form<MetadataConfirmForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(crate::middleware::auth::Role::Librarian)?;
+    session.require_role(crate::middleware::auth::Role::Librarian, locale.0)?;
     let pool = &state.pool;
     let loc = locale.0;
 
@@ -1900,10 +1900,11 @@ pub struct AssignToSeriesForm {
 pub async fn assign_to_series(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     Path(title_id): Path<u64>,
     Form(form): Form<AssignToSeriesForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     let is_omnibus = form.omnibus.as_deref() == Some("on");
@@ -1938,10 +1939,11 @@ pub struct UnassignFromSeriesForm {
 pub async fn unassign_omnibus_from_series(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     Path(title_id): Path<u64>,
     Form(form): Form<UnassignFromSeriesForm>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     SeriesService::unassign_all_from_series(pool, title_id, form.series_id).await?;
@@ -1952,9 +1954,10 @@ pub async fn unassign_omnibus_from_series(
 pub async fn unassign_from_series(
     State(state): State<AppState>,
     session: Session,
+    Extension(locale): Extension<Locale>,
     Path((title_id, assignment_id)): Path<(u64, u64)>,
 ) -> Result<impl IntoResponse, AppError> {
-    session.require_role(Role::Librarian)?;
+    session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
 
     SeriesService::unassign_title(pool, assignment_id, title_id).await?;

--- a/templates/components/tooltip.html
+++ b/templates/components/tooltip.html
@@ -34,9 +34,20 @@ No CSS transition: `display: none` (from `hidden`) cancels any
    tooltip is a description of the associated FORM CONTROL, not of the
    help-icon button itself. Callers add `aria-describedby="{{ tooltip.id }}"`
    to the input / select they want the help to apply to. The button keeps
-   `aria-label="{{ summary }}"` as its accessible name. #}
-<button type="button" data-tooltip-trigger="{{ tooltip.id }}" aria-label="{{ summary }}" class="help-icon ml-1 inline-flex items-center justify-center w-5 h-5 rounded-full text-stone-500 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2 text-sm font-semibold">?</button>
-<span role="tooltip" id="{{ tooltip.id }}" class="hidden absolute z-10 px-3 py-2 text-sm bg-stone-900 dark:bg-stone-100 text-white dark:text-stone-900 rounded-md shadow-lg max-w-xs">{{ tooltip.text }}</span>
+   `aria-label="{{ summary }}"` as its accessible name.
+
+   1.2.1 fix for #154 follow-up: wrap button + tooltip-span in a
+   `<span class="relative inline-block">` so the absolute span positions
+   relative to a wrapper tight around the button, not the outer form-
+   field group. `top-full left-0 mt-1` places the tooltip BELOW the
+   trigger (matches the docstring intent) and stops the tooltip from
+   intercepting pointer events on the button itself once #154's hoist-
+   out-of-label refactor moved both elements into a flex row where the
+   span's default static position was right on top of the button. #}
+<span class="relative inline-block ml-1">
+    <button type="button" data-tooltip-trigger="{{ tooltip.id }}" aria-label="{{ summary }}" class="help-icon inline-flex items-center justify-center w-5 h-5 rounded-full text-stone-500 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 focus-visible:outline-2 focus-visible:outline-indigo-500 focus-visible:outline-offset-2 text-sm font-semibold">?</button>
+    <span role="tooltip" id="{{ tooltip.id }}" class="hidden absolute top-full left-0 mt-1 z-20 px-3 py-2 text-sm bg-stone-900 dark:bg-stone-100 text-white dark:text-stone-900 rounded-md shadow-lg max-w-xs">{{ tooltip.text }}</span>
+</span>
 {% else %}
 <span id="{{ tooltip.id }}" class="sr-only">{{ tooltip.text }}</span>
 {% endif %}

--- a/templates/fragments/setup_step_admin.html
+++ b/templates/fragments/setup_step_admin.html
@@ -16,7 +16,10 @@
 
     <div class="space-y-4">
         <div class="relative">
-            <label for="setup-username" class="block text-sm font-medium text-stone-700 dark:text-stone-200">{{ username_label }}{% let tooltip = step_admin_help %}{% include "components/tooltip.html" %}</label>
+            <div class="flex items-center">
+                <label for="setup-username" class="block text-sm font-medium text-stone-700 dark:text-stone-200">{{ username_label }}</label>
+                {% let tooltip = step_admin_help %}{% include "components/tooltip.html" %}
+            </div>
             <input
                 aria-describedby="{{ step_admin_help.id }}"
                 type="text"

--- a/templates/fragments/setup_step_preferences.html
+++ b/templates/fragments/setup_step_preferences.html
@@ -4,7 +4,8 @@
     <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
 
     <fieldset class="relative space-y-2">
-        <legend class="block text-sm font-medium text-stone-700 dark:text-stone-200">{{ language_label }}{% let tooltip = step_preferences_help %}{% include "components/tooltip.html" %}</legend>
+        <legend class="block text-sm font-medium text-stone-700 dark:text-stone-200">{{ language_label }}</legend>
+        {% let tooltip = step_preferences_help %}{% include "components/tooltip.html" %}
         <label class="flex items-center gap-2">
             <input
                 aria-describedby="{{ step_preferences_help.id }}"

--- a/templates/pages/borrower_edit.html
+++ b/templates/pages/borrower_edit.html
@@ -17,14 +17,20 @@
         </div>
 
         <div class="relative">
-            <label for="edit-email" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ email_label }}{% let tooltip = email_help %}{% include "components/tooltip.html" %}</label>
+            <div class="flex items-center">
+                <label for="edit-email" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ email_label }}</label>
+                {% let tooltip = email_help %}{% include "components/tooltip.html" %}
+            </div>
             <input type="email" id="edit-email" name="email" value="{{ borrower.email.as_deref().unwrap_or_default() }}"
                    aria-describedby="{{ email_help.id }}"
                    class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
         </div>
 
         <div class="relative">
-            <label for="edit-phone" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ phone_label }}{% let tooltip = phone_help %}{% include "components/tooltip.html" %}</label>
+            <div class="flex items-center">
+                <label for="edit-phone" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ phone_label }}</label>
+                {% let tooltip = phone_help %}{% include "components/tooltip.html" %}
+            </div>
             <input type="tel" id="edit-phone" name="phone" value="{{ borrower.phone.as_deref().unwrap_or_default() }}"
                    aria-describedby="{{ phone_help.id }}"
                    class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">

--- a/templates/pages/borrowers.html
+++ b/templates/pages/borrowers.html
@@ -25,13 +25,19 @@
                        class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-700 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
             </div>
             <div class="relative">
-                <label for="new-email" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ email_label }}{% let tooltip = email_help %}{% include "components/tooltip.html" %}</label>
+                <div class="flex items-center">
+                    <label for="new-email" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ email_label }}</label>
+                    {% let tooltip = email_help %}{% include "components/tooltip.html" %}
+                </div>
                 <input type="email" id="new-email" name="email"
                        aria-describedby="{{ email_help.id }}"
                        class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-700 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
             </div>
             <div class="relative">
-                <label for="new-phone" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ phone_label }}{% let tooltip = phone_help %}{% include "components/tooltip.html" %}</label>
+                <div class="flex items-center">
+                    <label for="new-phone" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ phone_label }}</label>
+                    {% let tooltip = phone_help %}{% include "components/tooltip.html" %}
+                </div>
                 <input type="tel" id="new-phone" name="phone"
                        aria-describedby="{{ phone_help.id }}"
                        class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-700 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">

--- a/templates/pages/series_form.html
+++ b/templates/pages/series_form.html
@@ -34,7 +34,10 @@
         </div>
 
         <div class="relative">
-            <label for="series-type" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ type_label }}{% let tooltip = series_type_help %}{% include "components/tooltip.html" %}</label>
+            <div class="flex items-center">
+                <label for="series-type" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ type_label }}</label>
+                {% let tooltip = series_type_help %}{% include "components/tooltip.html" %}
+            </div>
             <select id="series-type" name="series_type"
                     aria-describedby="{{ series_type_help.id }}"
                     class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-700 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">

--- a/templates/pages/volume_edit.html
+++ b/templates/pages/volume_edit.html
@@ -11,7 +11,10 @@
         <input type="hidden" name="version" value="{{ version }}">
 
         <div class="relative">
-            <label for="condition" class="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-1">{{ condition_label }}{% let tooltip = volume_condition_help %}{% include "components/tooltip.html" %}</label>
+            <div class="flex items-center mb-1">
+                <label for="condition" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ condition_label }}</label>
+                {% let tooltip = volume_condition_help %}{% include "components/tooltip.html" %}
+            </div>
             <select id="condition" name="condition_state_id"
                     aria-describedby="{{ volume_condition_help.id }}"
                     class="w-full px-3 py-2 border border-stone-300 dark:border-stone-600 rounded-md bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 min-h-[44px]">

--- a/tests/e2e/specs/journeys/series.spec.ts
+++ b/tests/e2e/specs/journeys/series.spec.ts
@@ -107,11 +107,8 @@ test.describe("Series CRUD & Listing (Story 5-3)", () => {
     await expect(page.getByText(SERIES_NAME)).not.toBeVisible();
   });
 
-  // Story 9-13 conflict path — locks the inline-feedback path on conflict.
-  // Note: feedback copy is the generic "error.internal" string ("An internal
-  // error occurred" / "Une erreur interne est survenue"), NOT the meaningful
-  // series.delete_has_titles message — that's a latent UX bug preserved by
-  // 9-13 (see story file's reality-check section + the deferred GH issue).
+  // Story 9-13 conflict path — verifies the meaningful series.delete_has_titles
+  // copy is surfaced (not the generic error.internal copy). 1.2.1 fix for #139.
   test("delete series with assigned titles shows block message", async ({
     page,
   }) => {
@@ -165,9 +162,9 @@ test.describe("Series CRUD & Listing (Story 5-3)", () => {
     // Modal closes after the 200 response
     await expect(page.locator("#modal-slot dialog[open]")).not.toBeVisible();
 
-    // #series-feedback contains the GENERIC internal-error copy (latent bug)
+    // #series-feedback contains the meaningful series.delete_has_titles copy
     await expect(page.locator("#series-feedback")).toContainText(
-      /An internal error occurred|Une erreur interne est survenue/i,
+      /title\(s\) assigned|titre\(s\) assigné/i,
     );
 
     // No redirect — the series was NOT deleted; URL stays on /series/:id

--- a/tests/series_delete_modal.rs
+++ b/tests/series_delete_modal.rs
@@ -464,18 +464,11 @@ async fn delete_series_via_existing_handler_still_works(pool: MySqlPool) {
 
 #[sqlx::test(migrations = "./migrations")]
 async fn delete_series_with_assigned_titles_returns_inline_conflict_feedback(pool: MySqlPool) {
-    // LATENT UX BUG: series delete_series matches only NotFound; Conflict
-    // falls into the catch-all generic copy. Story 9-13 preserves this
-    // server contract; fix is deferred to a future chore PR.
-    //
-    // The title-assignment guard in `SeriesService::delete_series`
-    // returns `AppError::Conflict(series.delete_has_titles)`, but the
-    // route handler at `src/routes/series.rs` matches only `NotFound` and
-    // routes everything else through `error.internal`. The user sees the
-    // generic "internal error" copy instead of the meaningful payload.
-    // When the bug is fixed (likely `Err(AppError::NotFound(msg) |
-    // AppError::Conflict(msg)) => msg.clone()`), this test will fail and
-    // force the fixer to flip the assertion in the same chore PR.
+    // Regression test for #139: series delete_series must surface the
+    // meaningful `series.delete_has_titles` payload (not the generic
+    // `error.internal` copy) when SeriesService::delete_series returns
+    // AppError::Conflict. The original handler matched only NotFound;
+    // 1.2.1 extended the match arm to NotFound | Conflict.
     let id = insert_series(&pool, "Guard Series").await;
     let _title_id = assign_title_to_series(&pool, id).await;
     let lib_cookie = seed_session(&pool, "librarian").await;
@@ -500,17 +493,14 @@ async fn delete_series_with_assigned_titles_returns_inline_conflict_feedback(poo
         "no HX-Redirect on conflict — feedback must land in #series-feedback"
     );
     let html = body_text(resp).await;
-    // LATENT BUG ASSERTION: the rendered copy is the GENERIC error.internal
-    // text, NOT the meaningful series.delete_has_titles payload.
     assert!(
-        html.contains("An internal error occurred")
-            || html.contains("Une erreur interne est survenue"),
-        "inline feedback must carry the GENERIC error.internal copy (latent bug); got: {html}"
+        html.contains("title(s) assigned") || html.contains("titre(s) assigné"),
+        "inline feedback must carry the meaningful series.delete_has_titles payload; got: {html}"
     );
     assert!(
-        !html.contains("title(s) assigned") && !html.contains("titre(s) assigné"),
-        "feedback must NOT carry the meaningful series.delete_has_titles payload \
-         (locks the latent UX bug — when fixed, this assertion flips); got: {html}"
+        !html.contains("An internal error occurred")
+            && !html.contains("Une erreur interne est survenue"),
+        "feedback must NOT carry the generic error.internal copy; got: {html}"
     );
 
     let (deleted_at_count,): (i64,) = sqlx::query_as(


### PR DESCRIPTION
## Summary

1.2.1 bundle — four user-visible bug fixes deferred from 1.2.0 retro.

| Issue | Fix |
|---|---|
| **#139** | `series.rs::delete_series` now matches `NotFound \| Conflict` so the meaningful `series.delete_has_titles` payload surfaces instead of the generic `error.internal` copy. 2 regression tests flipped from "lock the latent bug" to "verify the fix". |
| **#154** | Help-icon `<button>` hoisted out of `<label>` on 6 surfaces (setup admin/preferences, borrowers create/edit email+phone, series-type, volume-condition) via a sibling-flex pattern. HTML5 compliance + a11y improvement. |
| **#133** | `return_modal_handler` reads `HX-Current-URL`, validates the extracted path via the existing `is_safe_next` guard, and passes it as `return_path` to `require_role_with_return`. Falls back to `/loans` on missing/invalid header. New `extract_safe_path` helper with 5 unit tests. |
| **#219** | `AppError::Forbidden` becomes `Forbidden(&'static str)` carrying the request locale. `Session::require_role` and `require_role_with_return` gain a `loc: &'static str` parameter that flows from `Extension<Locale>` at the handler. ~93 call sites updated mechanically; 2 new round-trip tests for FR/EN body rendering. |

## Test plan

- [x] cargo check + cargo clippy -- -D warnings clean
- [x] cargo test --lib — 839 passed against test DB
- [x] cargo test --tests — all integration suites pass except tests/navbar_role_visibility.rs (5 fails identical to main — confirmed pre-existing local-env flake; v1.2.0 shipped with this passing in CI, so unrelated to this PR)
- [ ] CI green on this branch
- [ ] Manual verify: FR user clicks admin-only action as Librarian → French 403 message
- [ ] Manual verify: anonymous user on /borrower/:id clicks Return → after login lands on /borrower/:id

## Release flow

Per the v1.1.9 / v1.2.0 precedent, the version bump + manual sync lives in a separate chore/release-1.2.1 PR that lands AFTER this fix PR merges. Foundation Rule #19 applies to the release commit, not to this fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)