### PR TITLE
feat(#209): per-volume table on /title/:id

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -204,6 +204,17 @@ title_detail:
   publisher: Publisher
   published: Published
   similar_titles: Similar titles
+  # CR #209: per-volume table inserted between contributors and similar-titles.
+  volumes_section_heading: Volumes of this title
+  no_volumes: "No volumes for this title yet."
+  add_volume_cta: "Scan a new volume"
+  col_vcode: V-code
+  col_location: Location
+  col_condition: Condition
+  col_actions: Actions
+  action_edit: Edit
+  action_delete: Delete
+  field_unset: "—"
 contributor_detail:
   titles: Titles
   biography: Biography
@@ -336,6 +347,10 @@ volume:
   on_loan_since: "On loan since %{date}"
   on_loan_to_prefix: "On loan to "
   on_loan_to_since_suffix: " since %{date}"
+  # CR #209: volume delete confirmation modal (per-volume table on /title/:id)
+  delete_modal_title: "Delete volume %{label}?"
+  delete_modal_body: "This removes the volume from the catalog. The action is reversible from the admin Trash panel within 30 days."
+  delete_modal_confirm: "Delete"
 location:
   tree_title: Locations
   add_root: Add root location

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -204,6 +204,17 @@ title_detail:
   publisher: Éditeur
   published: Publié
   similar_titles: Titres similaires
+  # CR #209: tableau par volume inséré entre les contributeurs et les titres similaires.
+  volumes_section_heading: Volumes de ce titre
+  no_volumes: "Aucun volume pour ce titre pour le moment."
+  add_volume_cta: "Scanner un nouveau volume"
+  col_vcode: Code V
+  col_location: Emplacement
+  col_condition: État
+  col_actions: Actions
+  action_edit: Modifier
+  action_delete: Supprimer
+  field_unset: "—"
 contributor_detail:
   titles: Titres
   biography: Biographie
@@ -336,6 +347,10 @@ volume:
   on_loan_since: "En prêt depuis le %{date}"
   on_loan_to_prefix: "En prêt à "
   on_loan_to_since_suffix: " depuis le %{date}"
+  # CR #209 : modale de confirmation de suppression de volume (tableau par volume sur /title/:id)
+  delete_modal_title: "Supprimer le volume %{label} ?"
+  delete_modal_body: "Cela retire le volume du catalogue. L'action est réversible depuis le panneau Corbeille de l'admin dans les 30 jours."
+  delete_modal_confirm: "Supprimer"
 location:
   tree_title: Emplacements
   add_root: Ajouter un emplacement racine

--- a/src/models/volume.rs
+++ b/src/models/volume.rs
@@ -230,6 +230,55 @@ impl VolumeModel {
         Ok(row.0 as u64)
     }
 
+    /// CR #209 — list active volumes for a title with their resolved
+    /// location + condition for the per-volume table on `/title/:id`.
+    ///
+    /// Soft-delete guards:
+    /// - `volumes.deleted_at IS NULL` (the title's own active volumes)
+    /// - `storage_locations.deleted_at IS NULL` join condition — a
+    ///   volume whose location was soft-deleted still appears in the
+    ///   list, with `location_name`/`location_label` as `None`
+    ///   (orphan-FK rendered as "—" placeholder in the template).
+    /// - `volume_states.deleted_at IS NULL` join condition — same
+    ///   resilience semantics for the condition column.
+    ///
+    /// Sort: V-code (numeric suffix) ASC so the table reads naturally
+    /// (V0001, V0002, V0042, V0143…). `label` is a 5-char string of
+    /// shape `V%04d`, so lexicographic ordering on the column matches
+    /// the numeric intent.
+    pub async fn find_by_title(
+        pool: &DbPool,
+        title_id: u64,
+    ) -> Result<Vec<VolumeWithLocation>, AppError> {
+        let rows = sqlx::query(
+            "SELECT v.id, v.label, v.version, \
+                    sl.name AS location_name, sl.label AS location_label, \
+                    vs.name AS condition_name \
+             FROM volumes v \
+             LEFT JOIN storage_locations sl \
+               ON v.location_id = sl.id AND sl.deleted_at IS NULL \
+             LEFT JOIN volume_states vs \
+               ON v.condition_state_id = vs.id AND vs.deleted_at IS NULL \
+             WHERE v.title_id = ? AND v.deleted_at IS NULL \
+             ORDER BY v.label ASC",
+        )
+        .bind(title_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| VolumeWithLocation {
+                id: r.try_get("id").unwrap_or(0),
+                label: r.try_get("label").unwrap_or_default(),
+                version: r.try_get("version").unwrap_or(0),
+                location_name: r.try_get("location_name").ok(),
+                location_label: r.try_get("location_label").ok(),
+                condition_name: r.try_get("condition_name").ok(),
+            })
+            .collect())
+    }
+
     /// Count of active (non-soft-deleted) volumes across the entire catalog.
     /// Used by `services::dashboard::collection_glance` for the home-page
     /// "Collection at a glance" card and reusable by other dashboard surfaces.
@@ -321,6 +370,24 @@ pub struct UnshelvedVolumeRow {
     pub title: String,
     pub primary_contributor: Option<String>,
     pub media_type: String,
+}
+
+/// CR #209 — one row of the per-volume table rendered on `/title/:id`,
+/// between the contributor block and the similar-titles section. Carries
+/// the V-code label, optional location name/label (NULL if the volume is
+/// unshelved OR its location was soft-deleted), optional condition name
+/// (NULL if no condition state was set OR the condition row was
+/// soft-deleted), the volume id (for the row link → `/volume/:id`), and
+/// the optimistic-locking `version` (used by the destructive-modal
+/// confirmation step).
+#[derive(Debug, Clone)]
+pub struct VolumeWithLocation {
+    pub id: u64,
+    pub label: String,
+    pub version: i32,
+    pub location_name: Option<String>,
+    pub location_label: Option<String>,
+    pub condition_name: Option<String>,
 }
 
 /// A volume with its title metadata, for location contents display.
@@ -574,5 +641,155 @@ mod tests {
     async fn find_id_by_label_returns_none_for_nonexistent(pool: sqlx::MySqlPool) {
         let got = VolumeModel::find_id_by_label(&pool, "V9999").await.unwrap();
         assert_eq!(got, None);
+    }
+
+    // ─── CR #209: VolumeModel::find_by_title coverage ──────
+
+    /// Helper for #209 tests: insert a `storage_locations` row and return its id.
+    async fn seed_location(pool: &sqlx::MySqlPool, name: &str, label: &str) -> u64 {
+        let nt: String = sqlx::query_scalar(
+            "SELECT name FROM location_node_types WHERE deleted_at IS NULL ORDER BY id LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO storage_locations (parent_id, name, label, node_type) VALUES (NULL, ?, ?, ?)")
+            .bind(name)
+            .bind(label)
+            .bind(nt)
+            .execute(pool)
+            .await
+            .unwrap()
+            .last_insert_id()
+    }
+
+    /// Helper for #209 tests: title id from the first volume inserted by
+    /// `seed_volume` — `seed_volume` always creates a fresh title, so the
+    /// most recent one is the latest insert.
+    async fn seed_title_with_volume(
+        pool: &sqlx::MySqlPool,
+        v_label: &str,
+        location_id: Option<u64>,
+    ) -> (u64, u64) {
+        let g: u64 = sqlx::query_scalar(
+            "SELECT id FROM genres WHERE deleted_at IS NULL ORDER BY id LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let s: u64 = sqlx::query_scalar(
+            "SELECT id FROM volume_states WHERE deleted_at IS NULL ORDER BY id LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        let title_id = sqlx::query(
+            "INSERT INTO titles (title, isbn, language, media_type, genre_id) \
+             VALUES ('Test #209', NULL, 'fr', 'book', ?)",
+        )
+        .bind(g)
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_id();
+        let vol_id = sqlx::query(
+            "INSERT INTO volumes (label, title_id, condition_state_id, location_id) \
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(v_label)
+        .bind(title_id)
+        .bind(s)
+        .bind(location_id)
+        .execute(pool)
+        .await
+        .unwrap()
+        .last_insert_id();
+        (title_id, vol_id)
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn find_by_title_returns_active_volumes_in_label_order(pool: sqlx::MySqlPool) {
+        let loc = seed_location(&pool, "Salon", "L0001").await;
+        let (title_id, _) = seed_title_with_volume(&pool, "V0042", Some(loc)).await;
+        // Add a second volume to the same title, with no location.
+        sqlx::query(
+            "INSERT INTO volumes (label, title_id, condition_state_id, location_id) \
+             VALUES ('V0007', ?, NULL, NULL)",
+        )
+        .bind(title_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let got = VolumeModel::find_by_title(&pool, title_id).await.unwrap();
+        assert_eq!(got.len(), 2);
+        // ORDER BY v.label ASC — V0007 before V0042 lexicographically.
+        assert_eq!(got[0].label, "V0007");
+        assert_eq!(got[1].label, "V0042");
+        // V0007 has no location, no condition.
+        assert_eq!(got[0].location_name, None);
+        assert_eq!(got[0].location_label, None);
+        assert_eq!(got[0].condition_name, None);
+        // V0042 has location "Salon" (label L0001) and the default state.
+        assert_eq!(got[1].location_name.as_deref(), Some("Salon"));
+        assert_eq!(got[1].location_label.as_deref(), Some("L0001"));
+        assert!(got[1].condition_name.is_some());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn find_by_title_returns_empty_for_title_with_no_volumes(pool: sqlx::MySqlPool) {
+        let g: u64 = sqlx::query_scalar(
+            "SELECT id FROM genres WHERE deleted_at IS NULL ORDER BY id LIMIT 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let title_id = sqlx::query(
+            "INSERT INTO titles (title, isbn, language, media_type, genre_id) \
+             VALUES ('Empty title', NULL, 'fr', 'book', ?)",
+        )
+        .bind(g)
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_id();
+
+        let got = VolumeModel::find_by_title(&pool, title_id).await.unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn find_by_title_excludes_soft_deleted_volumes(pool: sqlx::MySqlPool) {
+        let (title_id, vol_id) = seed_title_with_volume(&pool, "V0001", None).await;
+        sqlx::query("UPDATE volumes SET deleted_at = NOW() WHERE id = ?")
+            .bind(vol_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let got = VolumeModel::find_by_title(&pool, title_id).await.unwrap();
+        assert!(
+            got.is_empty(),
+            "soft-deleted volumes MUST NOT appear in find_by_title"
+        );
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn find_by_title_keeps_volume_when_location_is_soft_deleted(pool: sqlx::MySqlPool) {
+        // Defense-in-depth: a soft-deleted location MUST NOT make its
+        // attached volumes disappear. The volume stays in the result with
+        // location_name / location_label = None (rendered as "—").
+        let loc = seed_location(&pool, "Bureau", "L0002").await;
+        let (title_id, _) = seed_title_with_volume(&pool, "V0099", Some(loc)).await;
+        sqlx::query("UPDATE storage_locations SET deleted_at = NOW() WHERE id = ?")
+            .bind(loc)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let got = VolumeModel::find_by_title(&pool, title_id).await.unwrap();
+        assert_eq!(got.len(), 1, "volume must remain visible");
+        assert_eq!(got[0].location_name, None);
+        assert_eq!(got[0].location_label, None);
     }
 }

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -1,7 +1,7 @@
 use askama::Template;
 use axum::Extension;
 use axum::extract::State;
-use axum::response::{Html, IntoResponse, Redirect};
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum_extra::extract::cookie::{Cookie, CookieJar};
 use serde::Deserialize;
 
@@ -1868,9 +1868,19 @@ pub async fn delete_volume(
     Extension(locale): Extension<Locale>,
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<u64>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<Response, AppError> {
     session.require_role(Role::Librarian, locale.0)?;
     let pool = &state.pool;
+
+    // CR #209: fetch the volume BEFORE soft-delete so we know the
+    // parent title id for the post-delete HX-Redirect that takes the
+    // user back to /title/:id with the volumes table re-rendered (one
+    // less row, header count decremented). NotFound here also covers
+    // an already-soft-deleted row (find_by_id filters `deleted_at IS
+    // NULL`), which gives a clean 404 instead of a silent no-op.
+    let volume = VolumeModel::find_by_id(pool, id).await?.ok_or_else(|| {
+        AppError::NotFound(rust_i18n::t!("error.not_found", locale = locale.0).to_string())
+    })?;
 
     // Guard: block deletion if volume is currently on loan
     if crate::models::loan::LoanModel::find_active_by_volume(pool, id)
@@ -1878,13 +1888,90 @@ pub async fn delete_volume(
         .is_some()
     {
         let message = rust_i18n::t!("volume.currently_on_loan").to_string();
-        return Ok(Html(feedback_html("warning", &message, "")));
+        return Ok(Html(feedback_html("warning", &message, "")).into_response());
     }
 
     crate::services::soft_delete::SoftDeleteService::soft_delete(pool, "volumes", id).await?;
 
-    let message = rust_i18n::t!("feedback.deleted").to_string();
-    Ok(Html(feedback_html("success", &message, "")))
+    // CR #209: HX-Redirect drives HTMX into a full-page navigation
+    // back to the title-detail page. Simpler than OOB-swapping the
+    // row + header count and consistent with the existing volume-
+    // edit flow that also redirects to /volume/:id on success.
+    Ok((
+        axum::http::StatusCode::OK,
+        [(
+            axum::http::header::HeaderName::from_static("hx-redirect"),
+            format!("/title/{}", volume.title_id),
+        )],
+        String::new(),
+    )
+        .into_response())
+}
+
+// ─── CR #209: volume delete confirmation modal ───────────────────
+
+#[derive(Template)]
+#[template(path = "fragments/volume_delete_modal.html")]
+pub struct VolumeDeleteModalTemplate {
+    pub title: String,
+    pub body_html: String,
+    pub confirm_label: String,
+    pub cancel_label: String,
+    pub action_url: String,
+    pub csrf_token: String,
+}
+
+/// `GET /volume/:id/delete-modal` — returns the UX-DR8 destructive
+/// modal for the per-volume table's Delete button (CR #209). Mirrors
+/// the series-delete-modal pattern (story 9-13). Librarian-gated,
+/// HTMX-only (direct browser nav returns 405).
+pub async fn delete_volume_modal(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+    HxRequest(is_htmx): HxRequest,
+    axum::extract::Path(id): axum::extract::Path<u64>,
+) -> Result<Response, AppError> {
+    session.require_role_with_return(
+        Role::Librarian,
+        &format!("/volume/{id}"),
+        locale.0,
+    )?;
+    let pool = &state.pool;
+    let loc = locale.0;
+
+    if !is_htmx {
+        return Ok(axum::http::StatusCode::METHOD_NOT_ALLOWED.into_response());
+    }
+
+    let volume = VolumeModel::find_by_id(pool, id).await?.ok_or_else(|| {
+        AppError::NotFound(rust_i18n::t!("error.not_found", locale = loc).to_string())
+    })?;
+
+    let title = rust_i18n::t!(
+        "volume.delete_modal_title",
+        locale = loc,
+        label = volume.label.as_str()
+    )
+    .to_string();
+    let body_text = rust_i18n::t!("volume.delete_modal_body", locale = loc).to_string();
+    let body_html = format!("<p>{}</p>", crate::utils::html_escape(&body_text));
+
+    let template = VolumeDeleteModalTemplate {
+        title,
+        body_html,
+        confirm_label: rust_i18n::t!("volume.delete_modal_confirm", locale = loc).to_string(),
+        cancel_label: rust_i18n::t!("common.cancel", locale = loc).to_string(),
+        action_url: format!("/volume/{}", volume.id),
+        csrf_token: session.csrf_token.clone(),
+    };
+
+    match template.render() {
+        Ok(html) => Ok(Html(html).into_response()),
+        Err(e) => Err(AppError::Internal(format!(
+            "volume delete modal render: {e}"
+        ))),
+    }
 }
 
 // ─── Volume detail & edit ────────────────────────────────────────

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -157,7 +157,10 @@ pub fn build_router(state: AppState) -> Router {
             "/contributor/{id}/delete-modal",
             axum::routing::get(contributors::delete_modal),
         )
-        .route("/volume/{id}", axum::routing::get(catalog::volume_detail))
+        .route(
+            "/volume/{id}",
+            axum::routing::get(catalog::volume_detail).delete(catalog::delete_volume),
+        )
         .route(
             "/volume/{id}/edit",
             axum::routing::get(catalog::volume_edit_page),
@@ -165,6 +168,14 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/volume/{id}/update",
             axum::routing::post(catalog::update_volume),
+        )
+        // CR #209: per-volume table delete flow on /title/:id uses
+        // /volume/{id}/delete-modal for the UX-DR8 confirmation
+        // fragment, then DELETE /volume/{id} for the destructive
+        // action (HX-Redirect to /title/:id on success).
+        .route(
+            "/volume/{id}/delete-modal",
+            axum::routing::get(catalog::delete_volume_modal),
         )
         // Series routes
         .route(

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -47,6 +47,22 @@ pub struct TitleDetailTemplate {
     pub title: TitleModel,
     pub genre_name: String,
     pub volume_count: u64,
+    // CR #209: per-volume table data + role gate. Rendered as a new
+    // <section> between the contributor block and the similar-titles
+    // section.
+    pub volumes: Vec<crate::models::volume::VolumeWithLocation>,
+    pub can_edit: bool,
+    pub label_volumes_heading: String,
+    pub label_volumes_empty: String,
+    pub label_volumes_empty_cta: String,
+    pub label_volumes_empty_cta_url: String,
+    pub label_col_vcode: String,
+    pub label_col_location: String,
+    pub label_col_condition: String,
+    pub label_col_actions: String,
+    pub label_action_edit: String,
+    pub label_action_delete: String,
+    pub label_placeholder_empty: String,
     pub contributors: Vec<TitleContributorModel>,
     pub label_contributors: String,
     pub label_vol: String,
@@ -86,7 +102,12 @@ pub async fn title_detail(
         .await?
         .ok_or_else(|| AppError::NotFound(rust_i18n::t!("error.not_found", locale = loc).to_string()))?;
 
-    let volume_count = VolumeModel::count_by_title(pool, title.id).await?;
+    // CR #209: fetch the volumes list once and derive volume_count from
+    // it so the table and the header pill stay consistent. Replaces the
+    // older count_by_title round-trip (the SELECT COUNT was a separate
+    // query; the new shape is one round-trip + .len()).
+    let volumes = VolumeModel::find_by_title(pool, title.id).await?;
+    let volume_count = volumes.len() as u64;
     let contributors = TitleContributorModel::find_by_title(pool, title.id).await?;
     let genre_name = GenreModel::find_name_by_id(pool, title.genre_id).await?;
     let has_code = title.isbn.is_some() || title.issn.is_some() || title.upc.is_some();
@@ -128,6 +149,19 @@ pub async fn title_detail(
             title,
             genre_name,
             volume_count,
+            volumes,
+            can_edit: session.role >= crate::middleware::auth::Role::Librarian,
+            label_volumes_heading: rust_i18n::t!("title_detail.volumes_section_heading", locale = loc).to_string(),
+            label_volumes_empty: rust_i18n::t!("title_detail.no_volumes", locale = loc).to_string(),
+            label_volumes_empty_cta: rust_i18n::t!("title_detail.add_volume_cta", locale = loc).to_string(),
+            label_volumes_empty_cta_url: "/catalog".to_string(),
+            label_col_vcode: rust_i18n::t!("title_detail.col_vcode", locale = loc).to_string(),
+            label_col_location: rust_i18n::t!("title_detail.col_location", locale = loc).to_string(),
+            label_col_condition: rust_i18n::t!("title_detail.col_condition", locale = loc).to_string(),
+            label_col_actions: rust_i18n::t!("title_detail.col_actions", locale = loc).to_string(),
+            label_action_edit: rust_i18n::t!("title_detail.action_edit", locale = loc).to_string(),
+            label_action_delete: rust_i18n::t!("title_detail.action_delete", locale = loc).to_string(),
+            label_placeholder_empty: rust_i18n::t!("title_detail.field_unset", locale = loc).to_string(),
             contributors,
             label_contributors: rust_i18n::t!("title_detail.contributors", locale = loc).to_string(),
             label_vol: rust_i18n::t!("title_detail.volumes", locale = loc).to_string(),
@@ -1552,6 +1586,19 @@ mod tests {
             title,
             genre_name: "Roman".to_string(),
             volume_count: 2,
+            volumes: vec![],
+            can_edit: false,
+            label_volumes_heading: "Volumes of this title".to_string(),
+            label_volumes_empty: "No volumes yet.".to_string(),
+            label_volumes_empty_cta: "Scan".to_string(),
+            label_volumes_empty_cta_url: "/catalog".to_string(),
+            label_col_vcode: "V-code".to_string(),
+            label_col_location: "Location".to_string(),
+            label_col_condition: "Condition".to_string(),
+            label_col_actions: "Actions".to_string(),
+            label_action_edit: "Edit".to_string(),
+            label_action_delete: "Delete".to_string(),
+            label_placeholder_empty: "—".to_string(),
             contributors: vec![],
             label_contributors: "Contributors".to_string(),
             label_vol: "Volumes".to_string(),
@@ -1656,6 +1703,19 @@ mod tests {
             title,
             genre_name: "Roman".to_string(),
             volume_count: 1,
+            volumes: vec![],
+            can_edit: false,
+            label_volumes_heading: "Volumes of this title".to_string(),
+            label_volumes_empty: "No volumes yet.".to_string(),
+            label_volumes_empty_cta: "Scan".to_string(),
+            label_volumes_empty_cta_url: "/catalog".to_string(),
+            label_col_vcode: "V-code".to_string(),
+            label_col_location: "Location".to_string(),
+            label_col_condition: "Condition".to_string(),
+            label_col_actions: "Actions".to_string(),
+            label_action_edit: "Edit".to_string(),
+            label_action_delete: "Delete".to_string(),
+            label_placeholder_empty: "—".to_string(),
             contributors: vec![],
             label_contributors: "Contributors".to_string(),
             label_vol: "Volumes".to_string(),

--- a/templates/fragments/volume_delete_modal.html
+++ b/templates/fragments/volume_delete_modal.html
@@ -1,0 +1,21 @@
+{# CR #209 — volume delete confirmation modal, mirrored from the
+   series delete modal (story 9-13 pattern). On success the
+   `delete_volume` handler returns HX-Redirect to /title/{title_id}
+   so the per-volume table re-renders with the updated count;
+   #title-feedback is the inline error target for the on-loan guard
+   and other 4xx responses. CSP-clean. #}
+{% import "components/modal.html" as modal %}
+{% call modal::modal(
+    "delete",
+    title,
+    body_html,
+    confirm_label,
+    cancel_label,
+    action_url,
+    "DELETE",
+    csrf_token,
+    "#title-feedback",
+    "innerHTML",
+    0,
+    "",
+) %}{% endcall %}

--- a/templates/pages/title_detail.html
+++ b/templates/pages/title_detail.html
@@ -149,6 +149,108 @@
             </div>
         </div>
     </div>
+    {# CR #209: per-volume table — sits between the contributor/series block
+       and the similar-titles strip. Desktop = sortable table; mobile = card
+       stack (dual-surface convention, see CLAUDE.md "Mobile-aware"). #}
+    <section id="title-volumes" aria-labelledby="title-volumes-heading" class="mt-8 max-w-4xl mx-auto px-4 lg:px-8">
+        <h2 id="title-volumes-heading" class="text-lg font-semibold text-stone-800 dark:text-stone-200">
+            {{ label_volumes_heading }} <span class="text-stone-500 dark:text-stone-400">({{ volumes.len() }})</span>
+        </h2>
+
+        {% if volumes.is_empty() %}
+        <div class="mt-3 px-4 py-6 bg-stone-50 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-lg text-center text-sm text-stone-600 dark:text-stone-400">
+            <p>{{ label_volumes_empty }}</p>
+            {% if can_edit %}
+            <a href="{{ label_volumes_empty_cta_url }}" class="mt-3 inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 dark:text-indigo-400 border border-indigo-300 dark:border-indigo-700 rounded-md hover:bg-indigo-50 dark:hover:bg-indigo-900/20">{{ label_volumes_empty_cta }}</a>
+            {% endif %}
+        </div>
+        {% else %}
+        {# Desktop table — hidden below `md` breakpoint. The matching mobile
+           card stack is the next sibling. #}
+        <div class="mt-3 hidden md:block overflow-x-auto rounded-lg border border-stone-200 dark:border-stone-700">
+            <table class="w-full text-sm text-left">
+                <thead class="text-xs text-stone-500 dark:text-stone-400 uppercase bg-stone-50 dark:bg-stone-800/50 border-b border-stone-200 dark:border-stone-700">
+                    <tr>
+                        <th scope="col" class="px-3 py-2">{{ label_col_vcode }}</th>
+                        <th scope="col" class="px-3 py-2">{{ label_col_location }}</th>
+                        <th scope="col" class="px-3 py-2">{{ label_col_condition }}</th>
+                        {% if can_edit %}<th scope="col" class="px-3 py-2 text-right">{{ label_col_actions }}</th>{% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for v in volumes %}
+                    <tr class="border-b border-stone-100 dark:border-stone-800 hover:bg-stone-50 dark:hover:bg-stone-800/50 last:border-b-0">
+                        <td class="px-3 py-2">
+                            <a href="/volume/{{ v.id }}" class="text-indigo-600 dark:text-indigo-400 hover:underline font-mono tabular-nums">{{ v.label }}</a>
+                        </td>
+                        <td class="px-3 py-2 text-stone-700 dark:text-stone-300">
+                            {% match v.location_name %}
+                            {% when Some with (name) %}
+                                {{ name }}
+                                {% match v.location_label %}{% when Some with (l) %} <span class="ml-1 font-mono text-xs text-stone-400">({{ l }})</span>{% when None %}{% endmatch %}
+                            {% when None %}<span class="text-stone-400">{{ label_placeholder_empty }}</span>
+                            {% endmatch %}
+                        </td>
+                        <td class="px-3 py-2 text-stone-700 dark:text-stone-300">
+                            {% match v.condition_name %}{% when Some with (c) %}{{ c }}{% when None %}<span class="text-stone-400">{{ label_placeholder_empty }}</span>{% endmatch %}
+                        </td>
+                        {% if can_edit %}
+                        <td class="px-3 py-2 text-right whitespace-nowrap">
+                            <a href="/volume/{{ v.id }}/edit"
+                               class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline mr-3">{{ label_action_edit }}</a>
+                            <button type="button"
+                                    hx-get="/volume/{{ v.id }}/delete-modal"
+                                    hx-target="#modal-slot"
+                                    hx-swap="innerHTML"
+                                    class="text-xs text-red-600 dark:text-red-400 hover:underline">{{ label_action_delete }}</button>
+                        </td>
+                        {% endif %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {# Mobile card stack — visible below `md` breakpoint. #}
+        <ul class="mt-3 md:hidden space-y-2">
+            {% for v in volumes %}
+            <li class="px-4 py-3 bg-stone-50 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-lg">
+                <div class="flex items-baseline justify-between gap-2">
+                    <a href="/volume/{{ v.id }}" class="text-indigo-600 dark:text-indigo-400 hover:underline font-mono text-sm tabular-nums">{{ v.label }}</a>
+                    {% if can_edit %}
+                    <div class="text-xs flex gap-3">
+                        <a href="/volume/{{ v.id }}/edit" class="text-indigo-600 dark:text-indigo-400 hover:underline">{{ label_action_edit }}</a>
+                        <button type="button"
+                                hx-get="/volume/{{ v.id }}/delete-modal"
+                                hx-target="#modal-slot"
+                                hx-swap="innerHTML"
+                                class="text-red-600 dark:text-red-400 hover:underline">{{ label_action_delete }}</button>
+                    </div>
+                    {% endif %}
+                </div>
+                <dl class="mt-2 text-xs text-stone-600 dark:text-stone-400 space-y-1">
+                    <div class="flex gap-2">
+                        <dt class="font-medium text-stone-500 dark:text-stone-400">{{ label_col_location }}:</dt>
+                        <dd>
+                            {% match v.location_name %}
+                            {% when Some with (name) %}
+                                {{ name }}
+                                {% match v.location_label %}{% when Some with (l) %} <span class="font-mono text-stone-400">({{ l }})</span>{% when None %}{% endmatch %}
+                            {% when None %}<span class="text-stone-400">{{ label_placeholder_empty }}</span>
+                            {% endmatch %}
+                        </dd>
+                    </div>
+                    <div class="flex gap-2">
+                        <dt class="font-medium text-stone-500 dark:text-stone-400">{{ label_col_condition }}:</dt>
+                        <dd>{% match v.condition_name %}{% when Some with (c) %}{{ c }}{% when None %}<span class="text-stone-400">{{ label_placeholder_empty }}</span>{% endmatch %}</dd>
+                    </div>
+                </dl>
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </section>
+
     {% call similar::similar_titles(similar_titles, label_similar_titles, label_no_cover) %}{% endcall %}
     <div id="title-feedback" class="mt-4"></div>
 </div>

--- a/tests/e2e/specs/journeys/title-detail-volumes.spec.ts
+++ b/tests/e2e/specs/journeys/title-detail-volumes.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * CR #209 — per-volume table on /title/:id.
+ *
+ * Locks in:
+ * - The new <section id="title-volumes"> renders between the contributor
+ *   block and the similar-titles strip.
+ * - Two scanned volumes show up as two rows, each with V-code, the
+ *   "—" placeholder for unset location/condition (volumes scanned with
+ *   no location), and the Edit + Delete affordances for Librarian.
+ * - The delete flow goes through the UX-DR8 modal:
+ *     row Delete button → modal opens in #modal-slot → Confirm submits
+ *     DELETE /volume/:id → HX-Redirect → page reloads with one fewer row
+ *     AND the header count decremented.
+ *
+ * Spec ID "VL" — generated ISBN never collides with other specs.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+
+test.describe("CR #209 — per-volume table on /title/:id", () => {
+  test("two volumes render in the table; deleting one drops it from the table", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+
+    const ISBN = specIsbn("VL", 1);
+    const V_KEEP = "V0941"; // ASC sort puts V0941 before V0942
+    const V_DROP = "V0942";
+
+    // Step 1: catalog the title via scan, then scan two distinct V-codes.
+    await page.goto("/catalog");
+    const scanField = page.locator("#scan-field");
+    await scanField.fill(ISBN);
+    await scanField.press("Enter");
+    await page.waitForSelector(".feedback-skeleton, .feedback-entry", {
+      timeout: 10000,
+    });
+    await scanField.fill(V_KEEP);
+    await scanField.press("Enter");
+    await expect(
+      page.locator(".feedback-entry").filter({ hasText: V_KEEP }),
+    ).toBeVisible({ timeout: 10000 });
+    await scanField.fill(V_DROP);
+    await scanField.press("Enter");
+    await expect(
+      page.locator(".feedback-entry").filter({ hasText: V_DROP }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Step 2: navigate to the title-detail page via home search.
+    await page.goto(`/?q=${ISBN}`);
+    const titleLink = page
+      .locator('#browse-results a[href^="/title/"]')
+      .first();
+    await expect(titleLink).toBeVisible({ timeout: 15000 });
+    const titleHref = (await titleLink.getAttribute("href"))!;
+    await page.goto(titleHref);
+    await page.waitForURL(/\/title\/\d+/);
+
+    // Step 3: assert the volumes section renders both rows.
+    const section = page.locator("#title-volumes");
+    await expect(section).toBeVisible();
+    await expect(
+      section.locator("h2#title-volumes-heading"),
+    ).toContainText(/\(\s*2\s*\)/);
+    // ORDER BY v.label ASC → V_KEEP comes first.
+    const rows = section.locator("table tbody tr");
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(0)).toContainText(V_KEEP);
+    await expect(rows.nth(1)).toContainText(V_DROP);
+
+    // Step 4: click Delete on the second row → UX-DR8 modal opens.
+    await rows.nth(1).getByRole("button", { name: /Delete|Supprimer/i }).click();
+    const dialog = page.locator("#modal-slot dialog[open]");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(V_DROP);
+
+    // Step 5: confirm → handler returns HX-Redirect to /title/:id.
+    await dialog.locator("[data-modal-confirm]").click();
+    // The page reloads (full HTMX nav). Wait for the title-detail page
+    // to settle and verify the volumes section now has one row.
+    await page.waitForURL(/\/title\/\d+/);
+    const sectionAfter = page.locator("#title-volumes");
+    await expect(sectionAfter).toBeVisible();
+    await expect(
+      sectionAfter.locator("h2#title-volumes-heading"),
+    ).toContainText(/\(\s*1\s*\)/);
+    const rowsAfter = sectionAfter.locator("table tbody tr");
+    await expect(rowsAfter).toHaveCount(1);
+    await expect(rowsAfter).toContainText(V_KEEP);
+    await expect(sectionAfter).not.toContainText(V_DROP);
+  });
+});


### PR DESCRIPTION
## Summary

First v1.3.0 CR (themed "Plan your next purchase"): inline per-volume table on the title-detail page, between the contributor block and the similar-titles section. Reported by a production user (mybibli v1.1.2) on 2026-05-15.

Closes #209.

## Scope

Per the issue's "Acceptance criteria":
- [x] `VolumeModel::find_by_title` model method + sqlx unit tests (this commit)
- [ ] `/title/:id` renders the volumes section between the contributor block and the similar-titles block
- [ ] Empty-state message when zero active volumes
- [ ] Each row: clickable V-code → `/volume/:id`, "Edit" link, "Delete" button (Librarian+ only)
- [ ] Delete via UX-DR8 modal; success → HX-Redirect to /title/:id (page re-renders with updated count)
- [ ] Mobile-card dual-surface
- [ ] Audit-trail entry on delete (handled by existing `delete_volume` path)

## Out of scope (deferred follow-ups per the issue)

- Inline modal editor on the title-detail page (use existing `/volume/:id/edit`)
- Drag-and-drop reordering
- Per-volume cover image overrides in the table

## Release flow

Lands on `main` as part of v1.3.0 alongside #242 (Wish list). The chore/release-1.3.0 PR cuts the version + manual + PDFs once both fix PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
