### PR TITLE
feat(#271 #272): title lifecycle — delete (no volumes) + edit ISBN

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -157,6 +157,12 @@ title:
   current_banner: "Current: %{title}"
   current_banner_with_volumes: "Current: %{title} — %{count} vol"
   current_banner_with_author: "Current: %{title} — %{author} — %{count} vol"
+  # CR #271 — delete a title that has no volumes.
+  delete_title_button: "Delete title"
+  delete_modal_title: "Delete \"%{title}\"?"
+  delete_modal_body: "This title has no volumes attached. Deleting it removes the record from the catalog (recoverable from the Trash panel for 30 days)."
+  delete_modal_confirm: "Delete title"
+  delete_blocked_has_volumes: "Cannot delete: this title now has volumes attached. Reload the page to see them."
   form:
     heading: New title
     title_label: Title
@@ -339,6 +345,8 @@ error:
     required: Title is required
   isbn:
     invalid_checksum: Invalid ISBN checksum
+    invalid_format: "Invalid ISBN format — must be 13 digits"
+    already_used: "Another title already uses this ISBN — refusing to create a duplicate"
     not_found: ISBN not found
   genre:
     required: Genre is required
@@ -480,6 +488,12 @@ metadata:
     total_duration: "Duration (min)"
     age_rating: Age rating
     issue_number: Issue number
+    # CR #272 — editable identifier fields in the metadata-edit form.
+    identifiers: Identifiers
+    identifiers_help: "ISBN-13 must be 13 digits with a valid checksum. ISSN / UPC are accepted as-is. Leave blank to clear a field."
+    isbn: ISBN
+    issn: ISSN
+    upc: UPC
 media_type:
   book: Book
   bd: BD

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -157,6 +157,12 @@ title:
   current_banner: "En cours : %{title}"
   current_banner_with_volumes: "En cours : %{title} — %{count} vol"
   current_banner_with_author: "En cours : %{title} — %{author} — %{count} vol"
+  # CR #271 — supprimer un titre qui n'a aucun volume.
+  delete_title_button: "Supprimer le titre"
+  delete_modal_title: "Supprimer « %{title} » ?"
+  delete_modal_body: "Ce titre n'a aucun volume attaché. Sa suppression retire l'enregistrement du catalogue (récupérable depuis le panneau Corbeille pendant 30 jours)."
+  delete_modal_confirm: "Supprimer le titre"
+  delete_blocked_has_volumes: "Suppression impossible : ce titre a maintenant des volumes attachés. Rechargez la page pour les voir."
   form:
     heading: Nouveau titre
     title_label: Titre
@@ -339,6 +345,8 @@ error:
     required: Le titre est obligatoire
   isbn:
     invalid_checksum: Checksum ISBN invalide
+    invalid_format: "Format ISBN invalide — doit contenir 13 chiffres"
+    already_used: "Un autre titre utilise déjà cet ISBN — refus de créer un doublon"
     not_found: ISBN introuvable
   genre:
     required: Le genre est obligatoire
@@ -480,6 +488,13 @@ metadata:
     total_duration: "Durée (min)"
     age_rating: "Classification d'âge"
     issue_number: Numéro
+    # CR #272 — champs d'identifiants éditables dans le formulaire de
+    # modification des métadonnées.
+    identifiers: Identifiants
+    identifiers_help: "L'ISBN-13 doit comporter 13 chiffres avec un checksum valide. ISSN et UPC sont acceptés tels quels. Laissez vide pour effacer un champ."
+    isbn: ISBN
+    issn: ISSN
+    upc: UPC
 media_type:
   book: Livre
   bd: BD

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -455,6 +455,75 @@ impl TitleModel {
             .ok_or_else(|| AppError::Internal("Failed to retrieve updated title".to_string()))
     }
 
+    /// CR #272 — extension of [`Self::update_metadata`] that ALSO updates
+    /// the three identifier columns (`isbn`, `issn`, `upc`). Used by the
+    /// metadata editing form when the user corrects a wrong-scan ISBN.
+    /// The re-download / conflict-confirm flows keep calling
+    /// [`Self::update_metadata`] because the provider response always
+    /// carries back the same identifier that was looked up.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_full(
+        pool: &DbPool,
+        id: u64,
+        version: i32,
+        title: &str,
+        subtitle: Option<&str>,
+        description: Option<&str>,
+        publisher: Option<&str>,
+        language: &str,
+        genre_id: u64,
+        publication_date: Option<chrono::NaiveDate>,
+        dewey_code: Option<&str>,
+        page_count: Option<i32>,
+        track_count: Option<i32>,
+        total_duration: Option<i32>,
+        age_rating: Option<&str>,
+        issue_number: Option<i32>,
+        manually_edited_fields: Option<&str>,
+        isbn: Option<&str>,
+        issn: Option<&str>,
+        upc: Option<&str>,
+    ) -> Result<TitleModel, AppError> {
+        let result = sqlx::query(
+            "UPDATE titles SET title = ?, subtitle = ?, description = ?, \
+             publisher = ?, language = ?, genre_id = ?, \
+             publication_date = ?, dewey_code = ?, \
+             page_count = ?, track_count = ?, total_duration = ?, \
+             age_rating = ?, issue_number = ?, \
+             manually_edited_fields = ?, \
+             isbn = ?, issn = ?, upc = ?, \
+             version = version + 1, updated_at = NOW() \
+             WHERE id = ? AND version = ? AND deleted_at IS NULL",
+        )
+        .bind(title)
+        .bind(subtitle)
+        .bind(description)
+        .bind(publisher)
+        .bind(language)
+        .bind(genre_id)
+        .bind(publication_date)
+        .bind(dewey_code)
+        .bind(page_count)
+        .bind(track_count)
+        .bind(total_duration)
+        .bind(age_rating)
+        .bind(issue_number)
+        .bind(manually_edited_fields)
+        .bind(isbn)
+        .bind(issn)
+        .bind(upc)
+        .bind(id)
+        .bind(version)
+        .execute(pool)
+        .await?;
+
+        crate::services::locking::check_update_result(result.rows_affected(), "title")?;
+
+        TitleModel::find_by_id(pool, id)
+            .await?
+            .ok_or_else(|| AppError::Internal("Failed to retrieve updated title".to_string()))
+    }
+
     /// Update all metadata fields on a title with optimistic locking.
     /// Used by the metadata editing form and re-download confirmation.
     #[allow(clippy::too_many_arguments)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod admin_api_keys;
+pub mod title_lifecycle;
 pub mod admin_reference_data;
 pub mod admin_system;
 pub mod api_v1;
@@ -122,7 +123,13 @@ pub fn build_router(state: AppState) -> Router {
         // Detail pages
         .route(
             "/title/{id}",
-            axum::routing::get(titles::title_detail).post(titles::update_title),
+            axum::routing::get(titles::title_detail)
+                .post(titles::update_title)
+                .delete(title_lifecycle::delete_title),
+        )
+        .route(
+            "/title/{id}/delete-modal",
+            axum::routing::get(title_lifecycle::delete_title_modal),
         )
         .route(
             "/title/{id}/edit",

--- a/src/routes/title_lifecycle.rs
+++ b/src/routes/title_lifecycle.rs
@@ -190,11 +190,15 @@ mod tests {
     }
 
     async fn seed_title(pool: &MySqlPool, name: &str, isbn: Option<&str>) -> u64 {
-        let (genre_id,): (i64,) =
-            sqlx::query_as("SELECT MIN(id) FROM genres WHERE deleted_at IS NULL")
-                .fetch_one(pool)
-                .await
-                .unwrap();
+        // CLAUDE.md MariaDB gotcha #2: `genres.id` is `BIGINT UNSIGNED`
+        // and SQLx can't decode it directly as `i64`. CAST to SIGNED so
+        // the type unifier picks the signed shape `query_as` expects.
+        let (genre_id,): (i64,) = sqlx::query_as(
+            "SELECT CAST(MIN(id) AS SIGNED) FROM genres WHERE deleted_at IS NULL",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
         let r = sqlx::query(
             "INSERT INTO titles (title, language, genre_id, media_type, isbn) VALUES (?, 'en', ?, 'book', ?)",
         )

--- a/src/routes/title_lifecycle.rs
+++ b/src/routes/title_lifecycle.rs
@@ -1,0 +1,427 @@
+//! Title lifecycle handlers — delete + (future: archive, merge, …).
+//!
+//! Split from `routes/titles.rs` per Foundation Rule #12 — that file
+//! is already over the 2000-line soft cap. New title-level actions
+//! land here.
+//!
+//! ## CR #271 — Delete a title with no volumes
+//!
+//! Production-driven (Guy, 2026-05-19 on v1.4.0): a wrong ISBN scan
+//! created a title with zero volumes and there was no UI affordance
+//! to remove it. The Delete button on the title detail page appears
+//! ONLY when `VolumeModel::count_by_title == 0`; the handler enforces
+//! the same invariant as defense-in-depth.
+
+use askama::Template;
+use axum::Extension;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+
+use crate::AppState;
+use crate::error::AppError;
+use crate::middleware::auth::{Role, Session};
+use crate::middleware::htmx::HxRequest;
+use crate::middleware::locale::Locale;
+use crate::models::title::TitleModel;
+use crate::models::volume::VolumeModel;
+
+#[derive(Template)]
+#[template(path = "fragments/title_delete_modal.html")]
+pub struct TitleDeleteModalTemplate {
+    pub modal_title: String,
+    pub body_html: String,
+    pub confirm_label: String,
+    pub cancel_label: String,
+    pub action_url: String,
+    pub csrf_token: String,
+}
+
+/// `GET /title/{id}/delete-modal` — UX-DR8 destructive-action modal
+/// for the title detail page's Delete button. Librarian-gated,
+/// HTMX-only (direct nav returns 405). Refuses to render if the title
+/// still has any active volume — the guard runs server-side so a
+/// stale page that still shows the button can't bypass it.
+pub async fn delete_title_modal(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+    HxRequest(is_htmx): HxRequest,
+    Path(id): Path<u64>,
+) -> Result<Response, AppError> {
+    session.require_role_with_return(Role::Librarian, &format!("/title/{id}"), locale.0)?;
+    let pool = &state.pool;
+    let loc = locale.0;
+
+    if !is_htmx {
+        return Ok(StatusCode::METHOD_NOT_ALLOWED.into_response());
+    }
+
+    let title = TitleModel::find_by_id(pool, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(rust_i18n::t!("error.not_found", locale = loc).to_string()))?;
+
+    // Defense-in-depth: the button is hidden on volumes > 0, but
+    // a stale tab + a race could let the modal request through.
+    // Refuse with a friendly conflict feedback the UI swaps in.
+    let volume_count = VolumeModel::count_by_title(pool, id).await?;
+    if volume_count > 0 {
+        return Err(AppError::Conflict(
+            rust_i18n::t!("title.delete_blocked_has_volumes", locale = loc).to_string(),
+        ));
+    }
+
+    let modal_title = rust_i18n::t!(
+        "title.delete_modal_title",
+        locale = loc,
+        title = title.title.as_str()
+    )
+    .to_string();
+    let body_text = rust_i18n::t!("title.delete_modal_body", locale = loc).to_string();
+    let body_html = format!("<p>{}</p>", crate::utils::html_escape(&body_text));
+
+    let template = TitleDeleteModalTemplate {
+        modal_title,
+        body_html,
+        confirm_label: rust_i18n::t!("title.delete_modal_confirm", locale = loc).to_string(),
+        cancel_label: rust_i18n::t!("common.cancel", locale = loc).to_string(),
+        action_url: format!("/title/{}", title.id),
+        csrf_token: session.csrf_token.clone(),
+    };
+    template
+        .render()
+        .map(|html| Html(html).into_response())
+        .map_err(|e| AppError::Internal(format!("title delete modal render: {e}")))
+}
+
+/// `DELETE /title/{id}` — soft-delete a title that has no active
+/// volumes. Librarian-gated, optimistic conflict on the "has volumes"
+/// guard. On success: HX-Redirect to `/` (home) so the user lands on
+/// a useful page; the catalog list will no longer surface the row.
+pub async fn delete_title(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+    Path(id): Path<u64>,
+) -> Result<Response, AppError> {
+    session.require_role(Role::Librarian, locale.0)?;
+    let pool = &state.pool;
+    let loc = locale.0;
+
+    let title = TitleModel::find_by_id(pool, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(rust_i18n::t!("error.not_found", locale = loc).to_string()))?;
+
+    // Same guard as the modal — the modal request and the destructive
+    // action are two HTTP round-trips, a volume could land between them.
+    let volume_count = VolumeModel::count_by_title(pool, id).await?;
+    if volume_count > 0 {
+        return Err(AppError::Conflict(
+            rust_i18n::t!("title.delete_blocked_has_volumes", locale = loc).to_string(),
+        ));
+    }
+
+    crate::services::soft_delete::SoftDeleteService::soft_delete(pool, "titles", id).await?;
+
+    // Audit row — attribution travels via session.user_id. Details carry
+    // the title + identifiers so an admin reviewing the trail later sees
+    // exactly which row went down even after the soft-delete row is
+    // permanently purged.
+    let details = serde_json::json!({
+        "title": title.title,
+        "isbn": title.isbn,
+        "issn": title.issn,
+        "upc": title.upc,
+    });
+    if let Err(e) = crate::models::admin_audit::AdminAuditModel::create(
+        pool,
+        session.user_id.unwrap_or(0),
+        "title_delete",
+        Some("titles"),
+        Some(id),
+        Some(details),
+    )
+    .await
+    {
+        tracing::warn!(
+            title_id = id,
+            error = %e,
+            "title_delete audit insert failed — soft-delete has already committed"
+        );
+    }
+
+    tracing::info!(title_id = id, "Title soft-deleted (CR #271)");
+
+    Ok((
+        StatusCode::OK,
+        [(
+            axum::http::header::HeaderName::from_static("hx-redirect"),
+            "/".to_string(),
+        )],
+        String::new(),
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    //! DB-backed tests for CR #271 — the delete-title route. Each test
+    //! seeds a Librarian session cookie + CSRF token, drives a real
+    //! request through `tower::oneshot` so middleware (CSRF, session,
+    //! locale) all run as in production.
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use sqlx::MySqlPool;
+    use tower::ServiceExt;
+
+    async fn seed_librarian(pool: &MySqlPool) -> String {
+        let username = "title_lifecycle_librarian";
+        // Argon2 hash of "librarian" — same fixture used by other
+        // route-integration suites.
+        let password_hash = "$argon2id$v=19$m=19456,t=2,p=1$NfI9SYT0huhcqAanQWa9pw$mSEHLW8Wl8wlk504MRpzyS42JlcU9w2CXYVVFMFvbcU";
+        sqlx::query("INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'librarian')")
+            .bind(username)
+            .bind(password_hash)
+            .execute(pool)
+            .await
+            .unwrap();
+        username.to_string()
+    }
+
+    async fn seed_title(pool: &MySqlPool, name: &str, isbn: Option<&str>) -> u64 {
+        let (genre_id,): (i64,) =
+            sqlx::query_as("SELECT MIN(id) FROM genres WHERE deleted_at IS NULL")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        let r = sqlx::query(
+            "INSERT INTO titles (title, language, genre_id, media_type, isbn) VALUES (?, 'en', ?, 'book', ?)",
+        )
+        .bind(name)
+        .bind(genre_id)
+        .bind(isbn)
+        .execute(pool)
+        .await
+        .unwrap();
+        r.last_insert_id()
+    }
+
+    async fn seed_volume(pool: &MySqlPool, title_id: u64) -> u64 {
+        let r = sqlx::query("INSERT INTO volumes (title_id, label) VALUES (?, ?)")
+            .bind(title_id)
+            .bind(format!("V{title_id:04}"))
+            .execute(pool)
+            .await
+            .unwrap();
+        r.last_insert_id()
+    }
+
+    fn state_with_pool(pool: MySqlPool) -> crate::AppState {
+        use std::sync::{Arc, RwLock};
+        crate::AppState {
+            pool,
+            settings: Arc::new(RwLock::new(crate::config::AppSettings::default())),
+            http_client: reqwest::Client::new(),
+            registry: Arc::new(crate::metadata::registry::ProviderRegistry::new()),
+            covers_dir: std::path::PathBuf::from("/tmp"),
+            provider_health: crate::tasks::provider_health::new_provider_health_map(),
+            mariadb_version_cache: crate::services::admin_health::new_mariadb_version_cache(),
+            setup_gate: Arc::new(RwLock::new(
+                crate::middleware::setup_gate::SetupGateState::default(),
+            )),
+            bulk_cover_fetch: Arc::new(RwLock::new(
+                crate::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+            )),
+        }
+    }
+
+    async fn login(router: &axum::Router, username: &str) -> (String, String) {
+        let body = format!("username={username}&password=librarian");
+        let res = router
+            .clone()
+            .oneshot(
+                Request::post("/login")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SEE_OTHER);
+        let cookie = res
+            .headers()
+            .get_all(axum::http::header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .find(|s| s.starts_with("session="))
+            .and_then(|s| s.split(';').next())
+            .and_then(|kv| kv.split_once('='))
+            .map(|(_, v)| {
+                percent_encoding::percent_decode_str(v)
+                    .decode_utf8_lossy()
+                    .to_string()
+            })
+            .unwrap();
+        let html = {
+            let r = router
+                .clone()
+                .oneshot(
+                    Request::get("/")
+                        .header("cookie", format!("session={}", cookie))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let bytes = axum::body::to_bytes(r.into_body(), 1024 * 1024)
+                .await
+                .unwrap();
+            String::from_utf8(bytes.to_vec()).unwrap()
+        };
+        let needle = "name=\"csrf-token\" content=\"";
+        let start = html.find(needle).unwrap() + needle.len();
+        let rest = &html[start..];
+        let end = rest.find('"').unwrap();
+        (cookie, rest[..end].to_string())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn delete_title_with_zero_volumes_succeeds(pool: MySqlPool) {
+        let username = seed_librarian(&pool).await;
+        let id = seed_title(&pool, "Lone title", None).await;
+        let router = crate::routes::build_router(state_with_pool(pool.clone()));
+        let (cookie, csrf) = login(&router, &username).await;
+
+        let res = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/title/{id}"))
+                    .header("cookie", format!("session={}", cookie))
+                    .header("hx-request", "true")
+                    .header("x-csrf-token", csrf)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(
+            res.headers().get("hx-redirect").is_some(),
+            "success path must emit HX-Redirect"
+        );
+
+        let (deleted_at,): (Option<chrono::NaiveDateTime>,) =
+            sqlx::query_as("SELECT deleted_at FROM titles WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(deleted_at.is_some(), "title must be soft-deleted");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn delete_title_with_active_volumes_returns_conflict(pool: MySqlPool) {
+        let username = seed_librarian(&pool).await;
+        let id = seed_title(&pool, "Title with vol", None).await;
+        let _v = seed_volume(&pool, id).await;
+        let router = crate::routes::build_router(state_with_pool(pool.clone()));
+        let (cookie, csrf) = login(&router, &username).await;
+
+        let res = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/title/{id}"))
+                    .header("cookie", format!("session={}", cookie))
+                    .header("hx-request", "true")
+                    .header("x-csrf-token", csrf)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+
+        // Row must NOT be soft-deleted.
+        let (deleted_at,): (Option<chrono::NaiveDateTime>,) =
+            sqlx::query_as("SELECT deleted_at FROM titles WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(deleted_at.is_none());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn delete_modal_renders_for_zero_volume_title(pool: MySqlPool) {
+        let username = seed_librarian(&pool).await;
+        let id = seed_title(&pool, "Modal title", None).await;
+        let router = crate::routes::build_router(state_with_pool(pool.clone()));
+        let (cookie, _csrf) = login(&router, &username).await;
+
+        let res = router
+            .clone()
+            .oneshot(
+                Request::get(format!("/title/{id}/delete-modal"))
+                    .header("cookie", format!("session={}", cookie))
+                    .header("hx-request", "true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024).await.unwrap();
+        let html = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(html.contains("Modal title"));
+        assert!(html.contains(&format!("/title/{id}")));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn delete_modal_blocked_when_title_has_volumes(pool: MySqlPool) {
+        let username = seed_librarian(&pool).await;
+        let id = seed_title(&pool, "Blocked title", None).await;
+        let _v = seed_volume(&pool, id).await;
+        let router = crate::routes::build_router(state_with_pool(pool));
+        let (cookie, _csrf) = login(&router, &username).await;
+
+        let res = router
+            .clone()
+            .oneshot(
+                Request::get(format!("/title/{id}/delete-modal"))
+                    .header("cookie", format!("session={}", cookie))
+                    .header("hx-request", "true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn delete_modal_direct_nav_returns_405(pool: MySqlPool) {
+        let username = seed_librarian(&pool).await;
+        let id = seed_title(&pool, "Direct nav", None).await;
+        let router = crate::routes::build_router(state_with_pool(pool));
+        let (cookie, _csrf) = login(&router, &username).await;
+
+        // No hx-request header → direct browser nav. Per the pattern
+        // used by delete_volume_modal, this returns 405.
+        let res = router
+            .clone()
+            .oneshot(
+                Request::get(format!("/title/{id}/delete-modal"))
+                    .header("cookie", format!("session={}", cookie))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/src/routes/title_lifecycle.rs
+++ b/src/routes/title_lifecycle.rs
@@ -317,8 +317,11 @@ mod tests {
             "success path must emit HX-Redirect"
         );
 
+        // CLAUDE.md MariaDB gotcha #4: titles.deleted_at is TIMESTAMP
+        // (not DATETIME), so a bare `SELECT deleted_at` can't decode
+        // into NaiveDateTime via dynamic query_as. Cast to DATETIME.
         let (deleted_at,): (Option<chrono::NaiveDateTime>,) =
-            sqlx::query_as("SELECT deleted_at FROM titles WHERE id = ?")
+            sqlx::query_as("SELECT CAST(deleted_at AS DATETIME) FROM titles WHERE id = ?")
                 .bind(id)
                 .fetch_one(&pool)
                 .await
@@ -351,8 +354,11 @@ mod tests {
         assert_eq!(res.status(), StatusCode::CONFLICT);
 
         // Row must NOT be soft-deleted.
+        // CLAUDE.md MariaDB gotcha #4: titles.deleted_at is TIMESTAMP
+        // (not DATETIME), so a bare `SELECT deleted_at` can't decode
+        // into NaiveDateTime via dynamic query_as. Cast to DATETIME.
         let (deleted_at,): (Option<chrono::NaiveDateTime>,) =
-            sqlx::query_as("SELECT deleted_at FROM titles WHERE id = ?")
+            sqlx::query_as("SELECT CAST(deleted_at AS DATETIME) FROM titles WHERE id = ?")
                 .bind(id)
                 .fetch_one(&pool)
                 .await

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -70,6 +70,8 @@ pub struct TitleDetailTemplate {
     pub label_no_cover: String,
     pub label_edit: String,
     pub label_redownload: String,
+    // CR #271 — Delete-title button shown only when volume_count == 0.
+    pub label_delete_title: String,
     pub has_code: bool,
     pub series_assignments: Vec<TitleSeriesAssignment>,
     pub all_series: Vec<SeriesModel>,
@@ -172,6 +174,7 @@ pub async fn title_detail(
             label_no_cover: rust_i18n::t!("cover.no_cover", locale = loc).to_string(),
             label_edit: rust_i18n::t!("metadata.edit_metadata", locale = loc).to_string(),
             label_redownload: rust_i18n::t!("metadata.redownload", locale = loc).to_string(),
+            label_delete_title: rust_i18n::t!("title.delete_title_button", locale = loc).to_string(),
             has_code,
             series_assignments,
             all_series,
@@ -476,6 +479,12 @@ struct TitleEditFormTemplate {
     label_age_rating: String,
     label_issue_number: String,
     label_media_type: String,
+    // CR #272 — editable ISBN/ISSN/UPC fields in the metadata-edit form.
+    label_identifiers: String,
+    label_identifiers_help: String,
+    label_isbn: String,
+    label_issn: String,
+    label_upc: String,
     label_save: String,
     label_cancel: String,
 }
@@ -513,6 +522,15 @@ pub async fn title_edit_form(
         label_age_rating: rust_i18n::t!("metadata.field.age_rating", locale = loc).to_string(),
         label_issue_number: rust_i18n::t!("metadata.field.issue_number", locale = loc).to_string(),
         label_media_type: rust_i18n::t!("title.form.media_type", locale = loc).to_string(),
+        // CR #272 — identifier fields are editable; help text explains the
+        // ISBN-13 checksum guard so the user knows why a typo'd value
+        // bounces back as 400.
+        label_identifiers: rust_i18n::t!("metadata.field.identifiers", locale = loc).to_string(),
+        label_identifiers_help: rust_i18n::t!("metadata.field.identifiers_help", locale = loc)
+            .to_string(),
+        label_isbn: rust_i18n::t!("metadata.field.isbn", locale = loc).to_string(),
+        label_issn: rust_i18n::t!("metadata.field.issn", locale = loc).to_string(),
+        label_upc: rust_i18n::t!("metadata.field.upc", locale = loc).to_string(),
         label_save: rust_i18n::t!("metadata.save_changes", locale = loc).to_string(),
         label_cancel: rust_i18n::t!("metadata.cancel", locale = loc).to_string(),
     };
@@ -563,6 +581,15 @@ pub struct TitleEditForm {
     pub age_rating: Option<String>,
     #[serde(default, deserialize_with = "crate::routes::series::deserialize_optional_i32")]
     pub issue_number: Option<i32>,
+    // CR #272 — editable identifiers. Empty input = clear to NULL via
+    // `non_empty()` below. ISBN-13 checksum validation runs in the
+    // handler; bad input bounces back as 400 with i18n'd copy.
+    #[serde(default)]
+    pub isbn: Option<String>,
+    #[serde(default)]
+    pub issn: Option<String>,
+    #[serde(default)]
+    pub upc: Option<String>,
 }
 
 fn default_language() -> String {
@@ -622,6 +649,47 @@ pub async fn update_title(
     let dewey_code = non_empty(&form.dewey_code);
     let age_rating = non_empty(&form.age_rating);
 
+    // CR #272 — identifier edit path. Normalize: strip spaces and dashes
+    // from ISBN so a "978-2-07-036024-6" pasted from a barcode reader
+    // gets accepted (the provider chain stores the canonical 13-digit
+    // form). Empty → None ("clear the column").
+    let isbn = form.isbn.as_ref().map(|s| {
+        s.chars().filter(|c| !c.is_whitespace() && *c != '-').collect::<String>()
+    }).filter(|s| !s.is_empty());
+    let issn = non_empty(&form.issn).map(|s| s.replace('-', ""));
+    let upc = non_empty(&form.upc).map(|s| {
+        s.chars().filter(|c| !c.is_whitespace() && *c != '-').collect::<String>()
+    });
+
+    // ISBN-13 checksum guard. Only validate if the user actually
+    // changed the value (a corrupt existing ISBN should still
+    // round-trip — fixing it is what they're trying to do).
+    if let Some(ref new_isbn) = isbn
+        && new_isbn.as_str() != old_title.isbn.as_deref().unwrap_or("")
+    {
+        if new_isbn.len() != 13 || !new_isbn.chars().all(|c| c.is_ascii_digit()) {
+            return Err(AppError::BadRequest(
+                rust_i18n::t!("error.isbn.invalid_format", locale = loc).to_string(),
+            ));
+        }
+        if !crate::services::title::TitleService::validate_isbn13_checksum(new_isbn) {
+            return Err(AppError::BadRequest(
+                rust_i18n::t!("error.isbn.invalid_checksum", locale = loc).to_string(),
+            ));
+        }
+        // Collision guard — another title may already carry this ISBN
+        // (the schema allows duplicates because re-scan is intentional,
+        // but for the EDIT path we surface the conflict rather than
+        // silently creating a hidden dupe).
+        if let Some(existing) = TitleModel::find_by_isbn(pool, new_isbn).await?
+            && existing.id != id
+        {
+            return Err(AppError::Conflict(
+                rust_i18n::t!("error.isbn.already_used", locale = loc).to_string(),
+            ));
+        }
+    }
+
     let publication_date = form.publication_date.as_deref().and_then(|s| {
         let t = s.trim();
         if t.is_empty() {
@@ -668,7 +736,15 @@ pub async fn update_title(
         Some(serde_json::to_string(&v).unwrap_or_default())
     };
 
-    let updated = TitleModel::update_metadata(
+    // CR #272 — capture old identifiers BEFORE the update so the audit
+    // row carries the before/after diff for forensics. Comparing to the
+    // post-update DTO would only show the new values; the audit needs
+    // both sides.
+    let old_isbn = old_title.isbn.clone();
+    let old_issn = old_title.issn.clone();
+    let old_upc = old_title.upc.clone();
+
+    let updated = TitleModel::update_full(
         pool,
         id,
         form.version,
@@ -686,8 +762,38 @@ pub async fn update_title(
         age_rating.as_deref(),
         form.issue_number,
         edited_json.as_deref(),
+        isbn.as_deref(),
+        issn.as_deref(),
+        upc.as_deref(),
     )
     .await?;
+
+    // CR #272 — audit any identifier change. Skipped when the
+    // identifier columns are byte-identical to what was in the row
+    // before this PATCH.
+    let identifiers_changed = old_isbn != updated.isbn
+        || old_issn != updated.issn
+        || old_upc != updated.upc;
+    if identifiers_changed
+        && let Err(e) = crate::models::admin_audit::AdminAuditModel::create(
+            pool,
+            session.user_id.unwrap_or(0),
+            "title_identifiers_edit",
+            Some("titles"),
+            Some(id),
+            Some(serde_json::json!({
+                "old": { "isbn": old_isbn, "issn": old_issn, "upc": old_upc },
+                "new": { "isbn": updated.isbn, "issn": updated.issn, "upc": updated.upc },
+            })),
+        )
+        .await
+    {
+        tracing::warn!(
+            title_id = id,
+            error = %e,
+            "title_identifiers_edit audit insert failed — title update has already committed"
+        );
+    }
 
     let genre_name = GenreModel::find_name_by_id(pool, updated.genre_id).await?;
     let has_code = updated.isbn.is_some() || updated.issn.is_some() || updated.upc.is_some();
@@ -1615,6 +1721,7 @@ mod tests {
             label_no_cover: "No cover available".to_string(),
             label_edit: "Edit metadata".to_string(),
             label_redownload: "Re-download".to_string(),
+            label_delete_title: "Delete title".to_string(),
             has_code: true,
             series_assignments: vec![],
             all_series: vec![],
@@ -1738,6 +1845,7 @@ mod tests {
             label_no_cover: "No cover available".to_string(),
             label_edit: "Edit metadata".to_string(),
             label_redownload: "Re-download".to_string(),
+            label_delete_title: "Delete title".to_string(),
             has_code: false,
             series_assignments: vec![],
             all_series: vec![],

--- a/templates/fragments/title_delete_modal.html
+++ b/templates/fragments/title_delete_modal.html
@@ -1,0 +1,19 @@
+{# CR #271 — title delete confirmation modal. Mirrors the volume-delete
+   modal from CR #209: UX-DR8 destructive-action pattern, no hx-confirm=,
+   server returns HX-Redirect to / on success so the user lands on the
+   home page. CSP-clean. #}
+{% import "components/modal.html" as modal %}
+{% call modal::modal(
+    "delete",
+    modal_title,
+    body_html,
+    confirm_label,
+    cancel_label,
+    action_url,
+    "DELETE",
+    csrf_token,
+    "#title-feedback",
+    "innerHTML",
+    0,
+    "",
+) %}{% endcall %}

--- a/templates/fragments/title_edit_form.html
+++ b/templates/fragments/title_edit_form.html
@@ -100,15 +100,36 @@
     </div>
     {% endif %}
 
-    {% if let Some(isbn) = title.isbn %}
-    <p class="text-xs text-stone-400">ISBN: {{ isbn }}</p>
-    {% endif %}
-    {% if let Some(issn) = title.issn %}
-    <p class="text-xs text-stone-400">ISSN: {{ issn }}</p>
-    {% endif %}
-    {% if let Some(upc) = title.upc %}
-    <p class="text-xs text-stone-400">UPC: {{ upc }}</p>
-    {% endif %}
+    {# CR #272 — editable identifier fields. Originally read-only
+       <p> lines; promoted to <input> so a wrong-scan can be corrected.
+       Empty input means "clear" (the route's non_empty() helper
+       converts empty strings to None). ISBN-13 checksum validation
+       runs server-side in update_title; ISSN / UPC accept any
+       reasonable string for v1. #}
+    <fieldset class="border border-stone-200 dark:border-stone-700 rounded-md p-3">
+        <legend class="text-xs font-medium text-stone-500 dark:text-stone-400 px-1">{{ label_identifiers }}</legend>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-1">
+            <div>
+                <label for="edit-isbn" class="block text-xs font-medium text-stone-700 dark:text-stone-300">{{ label_isbn }}</label>
+                <input type="text" id="edit-isbn" name="isbn" value="{{ title.isbn.as_deref().unwrap_or_default() }}"
+                       autocomplete="off" inputmode="numeric" pattern="[0-9X]{0,13}" maxlength="13"
+                       class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono">
+            </div>
+            <div>
+                <label for="edit-issn" class="block text-xs font-medium text-stone-700 dark:text-stone-300">{{ label_issn }}</label>
+                <input type="text" id="edit-issn" name="issn" value="{{ title.issn.as_deref().unwrap_or_default() }}"
+                       autocomplete="off" maxlength="9"
+                       class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono">
+            </div>
+            <div>
+                <label for="edit-upc" class="block text-xs font-medium text-stone-700 dark:text-stone-300">{{ label_upc }}</label>
+                <input type="text" id="edit-upc" name="upc" value="{{ title.upc.as_deref().unwrap_or_default() }}"
+                       autocomplete="off" inputmode="numeric" pattern="[0-9]{0,14}" maxlength="14"
+                       class="mt-1 block w-full rounded-md border-stone-300 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono">
+            </div>
+        </div>
+        <p class="mt-2 text-xs text-stone-500 dark:text-stone-400">{{ label_identifiers_help }}</p>
+    </fieldset>
     <p class="text-xs text-stone-400">{{ label_media_type }}: {{ title.media_type }}</p>
 
     <div class="flex justify-end gap-3 pt-2">

--- a/templates/pages/title_detail.html
+++ b/templates/pages/title_detail.html
@@ -43,7 +43,7 @@
                 </div>
                 {% endif %}
                 {% if role == "librarian" || role == "admin" %}
-                <div class="mt-4 flex gap-3">
+                <div class="mt-4 flex flex-wrap gap-3">
                     <button hx-get="/title/{{ title.id }}/edit" hx-target="#title-metadata" hx-swap="innerHTML"
                             class="px-3 py-1.5 text-sm font-medium text-indigo-600 dark:text-indigo-400 border border-indigo-300 dark:border-indigo-700 rounded-md hover:bg-indigo-50 dark:hover:bg-indigo-900/20">
                         {{ label_edit }}
@@ -56,6 +56,17 @@
                         <span id="redownload-spinner" class="htmx-indicator ml-1">
                             <svg class="animate-spin inline h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
                         </span>
+                    </button>
+                    {% endif %}
+                    {# CR #271: Delete-title button — only when volume_count == 0
+                       (the title row has no active volumes; deletion is then
+                       harmless since no children get orphaned). UX-DR8 modal. #}
+                    {% if volume_count == 0 %}
+                    <button hx-get="/title/{{ title.id }}/delete-modal"
+                            hx-target="#modal-slot"
+                            hx-swap="innerHTML"
+                            class="px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20">
+                        {{ label_delete_title }}
                     </button>
                     {% endif %}
                 </div>


### PR DESCRIPTION
## Summary

Third PR of **v1.5.0 — "Know what you have, and what it's worth"**. Bundles two production-driven affordances surfaced by Guy after a fake ISBN scan created an orphan title with no recovery path on v1.4.0.

Closes #271. Closes #272.

## #271 — Delete a title that has no volumes

- `GET /title/{id}/delete-modal` — UX-DR8 destructive modal (HTMX-only, 405 on direct nav).
- `DELETE /title/{id}` — soft-deletes via `SoftDeleteService` after re-checking `VolumeModel::count_by_title == 0` (defense-in-depth — handler guard mirrors the template-side `{% if volume_count == 0 %}`).
- New module `src/routes/title_lifecycle.rs` (split from `titles.rs` which sits at 2047 lines — Foundation Rule #12).
- Audit row `action = "title_delete"` carries the title + identifiers for post-soft-delete forensics.
- Title detail page renders a red **Delete title** button next to Edit + Re-download, only for Librarian/Admin and only when the title has zero active volumes.

## #272 — Edit ISBN/ISSN/UPC in the metadata-edit form

- Three new optional fields in `TitleEditForm` (`isbn`, `issn`, `upc`), wired into a new "Identifiers" fieldset on `title_edit_form.html`.
- Empty input clears the column (via the existing `non_empty()` helper); dashes and whitespace are stripped server-side for ISBN/UPC normalization.
- ISBN-13 checksum validated server-side via `TitleService::validate_isbn13_checksum` when the value changed; bad input bounces back as 400 with i18n'd `error.isbn.invalid_format` / `invalid_checksum`.
- Collision guard — if another title row already carries the new ISBN, the request rejects with 409 + `error.isbn.already_used`. The schema permits duplicates (re-scan is intentional) but the *edit* path explicitly surfaces the conflict.
- New `TitleModel::update_full` method extends `update_metadata` with the 3 identifier columns. The re-download / conflict-confirm flows keep calling `update_metadata` (the provider response always carries back the same ISBN, no edit there).
- Audit row `action = "title_identifiers_edit"` carries the per-field old/new diff.

## Test plan

- [x] 5 new sqlx::test integration tests in `routes::title_lifecycle::tests`: zero-volume success, volume-present 409 (route + modal), modal-renders-with-data, direct-nav 405
- [x] `cargo check` + `cargo check --tests` clean
- [x] `cargo clippy --lib --tests -- -D warnings` clean
- [x] Templates audit green (CSP `style-src 'self'` not relaxed)
- [ ] CI green
- [ ] Manual smoke after v1.5.0 ships: scan a fake ISBN → create stuck title → confirm Delete button appears → delete OK; edit form lets me correct ISBN on a different title

🤖 Generated with [Claude Code](https://claude.com/claude-code)