### PR TITLE
feat(#279): filter chip "Titles without volumes" on home dashboard

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -136,6 +136,7 @@ home:
   remove_filter_aria: "Remove filter"
   filter:
     uncategorized: "Uncategorized"
+    no_volumes: "Titles without volumes"
   genre_filter_no_longer_exists: "This genre no longer exists — showing all titles."
 catalog:
   title: Catalog

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -137,6 +137,7 @@ home:
   remove_filter_aria: "Retirer le filtre"
   filter:
     uncategorized: "Sans genre"
+    no_volumes: "Titres sans exemplaire"
   genre_filter_no_longer_exists: "Ce genre n'existe plus — affichage de tous les titres."
 catalog:
   title: Catalogue

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -915,6 +915,7 @@ fn map_sort_to_column(sort: &str) -> &str {
 
 impl TitleModel {
     /// Full-text search across titles with pagination, sorting, and optional genre/state filters.
+    #[allow(clippy::too_many_arguments)]
     pub async fn active_search(
         pool: &DbPool,
         query: &str,
@@ -923,6 +924,12 @@ impl TitleModel {
         sort: &Option<String>,
         dir: &Option<String>,
         page: u32,
+        // CR #279 — when `true`, restrict to titles that have no
+        // active volume row. Implemented as a `NOT EXISTS` guard
+        // because LEFT JOIN + COUNT(...) = 0 would require GROUP BY,
+        // which collides with the DISTINCT shape the data query
+        // already needs.
+        no_volumes_only: bool,
     ) -> Result<PaginatedList<SearchResult>, AppError> {
         let sort_col = validated_sort(sort);
         let sort_dir = validated_dir(dir);
@@ -984,6 +991,15 @@ impl TitleModel {
         if let Some(gid) = genre_id {
             conditions.push("t.genre_id = ?".to_string());
             genre_bind = Some(gid);
+        }
+
+        if no_volumes_only {
+            // CR #279 — title with zero active volumes.
+            conditions.push(
+                "NOT EXISTS (SELECT 1 FROM volumes v_no WHERE v_no.title_id = t.id \
+                 AND v_no.deleted_at IS NULL)"
+                    .to_string(),
+            );
         }
 
         if let Some(ref state_name) = volume_state {

--- a/src/routes/api_v1.rs
+++ b/src/routes/api_v1.rs
@@ -90,6 +90,7 @@ pub async fn list_titles(
         &None,
         &None,
         page,
+        false, // no_volumes_only — not exposed via API in v1
     )
     .await?;
 

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -175,6 +175,14 @@ pub struct HomeTemplate {
     pub audit_indicator_label: String,
     pub audit_indicator_count: i64,
     pub audit_indicator_cta: String,
+    // CR #279 — "Titles without any volume" filter chip. Librarian+
+    // only (Anonymous shouldn't see catalog-cleanup affordances).
+    // `show_no_volumes_chip` is the gate (role-derived in the handler);
+    // `no_volumes_filter_active` toggles between the link variant and
+    // the active-with-remove variant (mirrors the Uncategorized chip).
+    pub show_no_volumes_chip: bool,
+    pub no_volumes_filter_active: bool,
+    pub label_no_volumes: String,
 }
 
 /// One row of the "By genre" dashboard section.
@@ -321,7 +329,13 @@ pub async fn home(
     // downstream. `parse_filter` itself stays pure / non-async / DB-
     // free so existing call sites and tests don't have to move.
     let mut stale_genre_filter = false;
-    let (genre_id, volume_state) = if parsed_indicator.is_some() {
+    // CR #279 — `?filter=no_volumes` short-circuit. Same handler-level
+    // alias shape as `uncategorized` (#205): bypass `parse_filter`,
+    // hand the SearchService a flag instead of a magic genre id. Only
+    // Librarian+ — Anonymous shouldn't see catalog-cleanup affordances.
+    let no_volumes_filter_active = params.filter.as_deref() == Some("no_volumes")
+        && session.role >= crate::middleware::auth::Role::Librarian;
+    let (genre_id, volume_state) = if parsed_indicator.is_some() || no_volumes_filter_active {
         (None, None)
     } else if params.filter.as_deref() == Some("uncategorized") {
         let default_genre_id = TitleService::find_default_genre_id(pool).await?;
@@ -370,6 +384,7 @@ pub async fn home(
             &params.sort,
             &params.dir,
             page,
+            no_volumes_filter_active,
         )
         .await?;
 
@@ -871,6 +886,9 @@ pub async fn home(
         audit_indicator_count,
         audit_indicator_cta: rust_i18n::t!("dashboard.audit_indicator.cta", locale = loc)
             .to_string(),
+        show_no_volumes_chip: session.role >= crate::middleware::auth::Role::Librarian,
+        no_volumes_filter_active,
+        label_no_volumes: rust_i18n::t!("home.filter.no_volumes", locale = loc).to_string(),
     };
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
@@ -1333,6 +1351,9 @@ pub(crate) mod tests {
             audit_indicator_label: "Volumes to check".to_string(),
             audit_indicator_count: 0,
             audit_indicator_cta: "Open audit".to_string(),
+            show_no_volumes_chip: false,
+            no_volumes_filter_active: false,
+            label_no_volumes: "Titles without volumes".to_string(),
         }
     }
 

--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -69,6 +69,7 @@ pub enum SearchOutcome {
 
 impl SearchService {
     /// Perform a search: detect code patterns first, then fall through to fulltext.
+    #[allow(clippy::too_many_arguments)]
     pub async fn search(
         pool: &DbPool,
         query: &str,
@@ -77,12 +78,14 @@ impl SearchService {
         sort: &Option<String>,
         dir: &Option<String>,
         page: u32,
+        // CR #279 — title without any active volume.
+        no_volumes_only: bool,
     ) -> Result<SearchOutcome, AppError> {
         let trimmed = query.trim();
         // Browse-without-query path: empty query + no filter → no results.
         // Empty query WITH a genre/state filter falls through to `fulltext_search`
         // (pill-driven browse, e.g. clicking "BD" on the home page).
-        if trimmed.is_empty() && genre_id.is_none() && volume_state.is_none() {
+        if trimmed.is_empty() && genre_id.is_none() && volume_state.is_none() && !no_volumes_only {
             return Ok(SearchOutcome::Results(PaginatedList::new(
                 vec![],
                 1,
@@ -95,8 +98,17 @@ impl SearchService {
 
         // Empty query + filter set → skip code detection, go straight to fulltext_search.
         if trimmed.is_empty() {
-            return Self::fulltext_search(pool, trimmed, genre_id, volume_state, sort, dir, page)
-                .await;
+            return Self::fulltext_search(
+                pool,
+                trimmed,
+                genre_id,
+                volume_state,
+                sort,
+                dir,
+                page,
+                no_volumes_only,
+            )
+            .await;
         }
 
         match detect_code(trimmed) {
@@ -125,6 +137,7 @@ impl SearchService {
                             sort,
                             dir,
                             page,
+                            no_volumes_only,
                         )
                         .await
                     }
@@ -145,6 +158,7 @@ impl SearchService {
                             sort,
                             dir,
                             page,
+                            no_volumes_only,
                         )
                         .await
                     }
@@ -174,17 +188,29 @@ impl SearchService {
                             sort,
                             dir,
                             page,
+                            no_volumes_only,
                         )
                         .await
                     }
                 }
             }
             CodeType::Text => {
-                Self::fulltext_search(pool, trimmed, genre_id, volume_state, sort, dir, page).await
+                Self::fulltext_search(
+                    pool,
+                    trimmed,
+                    genre_id,
+                    volume_state,
+                    sort,
+                    dir,
+                    page,
+                    no_volumes_only,
+                )
+                .await
             }
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn fulltext_search(
         pool: &DbPool,
         query: &str,
@@ -193,9 +219,19 @@ impl SearchService {
         sort: &Option<String>,
         dir: &Option<String>,
         page: u32,
+        no_volumes_only: bool,
     ) -> Result<SearchOutcome, AppError> {
-        let results =
-            TitleModel::active_search(pool, query, genre_id, volume_state, sort, dir, page).await?;
+        let results = TitleModel::active_search(
+            pool,
+            query,
+            genre_id,
+            volume_state,
+            sort,
+            dir,
+            page,
+            no_volumes_only,
+        )
+        .await?;
         Ok(SearchOutcome::Results(results))
     }
 }

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -116,6 +116,33 @@
            aria-label="Filter by: {{ label_uncategorized }}">{{ label_uncategorized }}</a>
         {% endif %}
 
+        {# CR #279 — "Titles without any volume" filter chip. Librarian+
+           only (catalog-cleanup affordance, not surfaced to Anonymous).
+           Same shape as the Uncategorized chip above. #}
+        {% if show_no_volumes_chip %}
+        {% if no_volumes_filter_active %}
+        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-sm" role="status" aria-label="Active filter: {{ label_no_volumes }}. Press to remove filter">
+            {{ label_no_volumes }}
+            <button type="button"
+                    hx-get="/?q={{ query_encoded }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+                    hx-target="#browse-results"
+                    hx-swap="innerHTML"
+                    hx-push-url="true"
+                    class="ml-1 text-amber-600 hover:text-amber-800"
+                    aria-label="{{ remove_filter_aria }}">&times;</button>
+        </span>
+        {% else %}
+        <a href="/?q={{ query_encoded }}&amp;filter=no_volumes&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+           hx-get="/?q={{ query_encoded }}&amp;filter=no_volumes&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+           hx-target="#browse-results"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           class="px-3 py-1 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 text-sm hover:bg-stone-200 dark:hover:bg-stone-700"
+           role="link"
+           aria-label="Filter by: {{ label_no_volumes }}">{{ label_no_volumes }}</a>
+        {% endif %}
+        {% endif %}
+
         <input type="hidden" name="filter" id="filter-hidden" value="{{ active_filter }}">
         <input type="hidden" name="sort" value="{{ current_sort }}">
         <input type="hidden" name="dir" value="{{ current_dir }}">

--- a/tests/search_filter_browse.rs
+++ b/tests/search_filter_browse.rs
@@ -63,7 +63,7 @@ async fn empty_query_with_genre_filter_returns_filtered_titles(pool: MySqlPool) 
     let _ = seed_title(&pool, "Matching Two", genre_a).await;
     let _ = seed_title(&pool, "Other genre", genre_b).await;
 
-    let outcome = SearchService::search(&pool, "", Some(genre_a), None, &None, &None, 1)
+    let outcome = SearchService::search(&pool, "", Some(genre_a), None, &None, &None, 1, false)
         .await
         .expect("search must succeed");
 
@@ -92,7 +92,7 @@ async fn empty_query_without_filter_returns_empty(pool: MySqlPool) {
     let genre_a = first_genre_id(&pool).await;
     let _ = seed_title(&pool, "Something", genre_a).await;
 
-    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1)
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, false)
         .await
         .expect("search must succeed");
 
@@ -114,7 +114,7 @@ async fn whitespace_query_with_filter_is_treated_as_filter_only_browse(pool: MyS
     let genre_a = first_genre_id(&pool).await;
     let _ = seed_title(&pool, "Matching", genre_a).await;
 
-    let outcome = SearchService::search(&pool, "   ", Some(genre_a), None, &None, &None, 1)
+    let outcome = SearchService::search(&pool, "   ", Some(genre_a), None, &None, &None, 1, false)
         .await
         .expect("search must succeed");
 
@@ -124,6 +124,85 @@ async fn whitespace_query_with_filter_is_treated_as_filter_only_browse(pool: MyS
                 paginated.items.len(),
                 1,
                 "whitespace-only query + filter must still browse by filter"
+            );
+        }
+        SearchOutcome::Redirect(_) => panic!("unexpected redirect"),
+    }
+}
+
+/// CR #279 — the `no_volumes_only` flag restricts results to titles
+/// that have no active volume row. Locks the `NOT EXISTS` branch in
+/// `TitleModel::active_search`. Seeds 3 titles: one bare, one with a
+/// live volume, one with a soft-deleted volume only. The bare title
+/// AND the title with only soft-deleted volumes must surface; the
+/// title with a live volume must NOT.
+#[sqlx::test(migrations = "./migrations")]
+async fn no_volumes_only_filters_titles_with_active_volumes(pool: MySqlPool) {
+    let genre = first_genre_id(&pool).await;
+
+    let _bare = seed_title(&pool, "Bare Title", genre).await;
+    let with_volume = seed_title(&pool, "Has Volume", genre).await;
+    let soft_only = seed_title(&pool, "Soft Only", genre).await;
+
+    sqlx::query("INSERT INTO volumes (title_id, label) VALUES (?, 'V9001')")
+        .bind(with_volume)
+        .execute(&pool)
+        .await
+        .expect("insert live volume");
+
+    // Soft-deleted volume on `soft_only` — NOT EXISTS guard must still
+    // surface this title (the `WHERE deleted_at IS NULL` inside the
+    // subquery is the load-bearing predicate).
+    sqlx::query("INSERT INTO volumes (title_id, label, deleted_at) VALUES (?, 'V9002', NOW())")
+        .bind(soft_only)
+        .execute(&pool)
+        .await
+        .expect("insert soft-deleted volume");
+
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, true)
+        .await
+        .expect("search must succeed");
+
+    match outcome {
+        SearchOutcome::Results(paginated) => {
+            let titles: Vec<&str> = paginated.items.iter().map(|i| i.title.as_str()).collect();
+            assert!(
+                titles.contains(&"Bare Title"),
+                "bare title must surface, got {:?}",
+                titles
+            );
+            assert!(
+                titles.contains(&"Soft Only"),
+                "title with only soft-deleted volumes must surface (deleted_at-aware), got {:?}",
+                titles
+            );
+            assert!(
+                !titles.contains(&"Has Volume"),
+                "title with a live volume must NOT surface, got {:?}",
+                titles
+            );
+        }
+        SearchOutcome::Redirect(_) => panic!("unexpected redirect for no_volumes browse"),
+    }
+}
+
+/// CR #279 — when `no_volumes_only` is `true`, the empty-query
+/// short-circuit must NOT fire. The handler-shortcut depends on this:
+/// `?filter=no_volumes` lands with no query and no genre filter set.
+#[sqlx::test(migrations = "./migrations")]
+async fn no_volumes_only_disables_empty_query_short_circuit(pool: MySqlPool) {
+    let genre = first_genre_id(&pool).await;
+    let _ = seed_title(&pool, "Bare", genre).await;
+
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, true)
+        .await
+        .expect("search must succeed");
+
+    match outcome {
+        SearchOutcome::Results(paginated) => {
+            assert!(
+                paginated.total_items >= 1,
+                "no_volumes filter must override the empty-query short-circuit"
             );
         }
         SearchOutcome::Redirect(_) => panic!("unexpected redirect"),


### PR DESCRIPTION
## Summary

- One-click home-dashboard chip surfacing titles that have no active volume — catalog noise that doesn't show up on any volume-level view.
- Implemented as a `no_volumes_only: bool` cascade through `SearchService::search` → `TitleModel::active_search`, with a `NOT EXISTS (SELECT 1 FROM volumes ... WHERE deleted_at IS NULL)` guard.
- Librarian+ only — Anonymous doesn't see catalog-cleanup affordances.
- Handler shortcut: `?filter=no_volumes` mirrors `?filter=uncategorized` from #205.

## Why this matters

A title row can exist without any active volume — either because the volumes were soft-deleted or because the title was created without ever being shelved. These titles don't appear on browse views that rely on volume joins, and no other indicator surfaces them. The chip gives the librarian a clean way to find and clean them up.

## Test plan

- [x] `cargo check` + `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --test search_filter_browse` (5 passed — includes 2 new tests covering the `NOT EXISTS` branch + the empty-query short-circuit override)
- [x] `cargo test --lib templates_audit` (5 passed — no inline markup regression)
- [ ] Visual check: chip appears on `/` for Librarian/Admin, hidden for Anonymous, toggles `active` styling when clicked

## Out of scope

- E2E spec — deferring to the v1.6.0 release-gate sweep (will land before the chore/release-1.6.0 PR).

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)