### PR TITLE
feat(#250): home list view becomes a sortable table

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -256,6 +256,9 @@ search:
     contributor: Contributor
     genre: Genre
     volumes: Volumes
+    dewey: Dewey
+  sort_aria_asc: "Sort by %{column} ascending"
+  sort_aria_desc: "Sort by %{column} descending"
   connection_lost: "Connection lost — check your network."
 pagination:
   previous: Previous

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -257,6 +257,9 @@ search:
     contributor: Contributeur
     genre: Genre
     volumes: Volumes
+    dewey: Dewey
+  sort_aria_asc: "Trier par %{column} croissant"
+  sort_aria_desc: "Trier par %{column} décroissant"
   connection_lost: "Connexion perdue — vérifiez votre réseau."
 pagination:
   previous: Précédent

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -334,7 +334,7 @@ impl TitleModel {
             // set instead of silently disappearing. The empty `genre_name`
             // marker is replaced with a locale-aware placeholder at the
             // route layer via `routes::home::resolve_genre_placeholder`.
-            "SELECT t.id, t.title, t.subtitle, t.media_type, t.cover_image_url, \
+            "SELECT t.id, t.title, t.subtitle, t.media_type, t.cover_image_url, t.dewey_code, \
                     CAST(t.publication_date AS DATE) AS publication_date, \
                     COALESCE(g.name, '') AS genre_name, \
                     (SELECT c.name FROM title_contributors tc \
@@ -373,6 +373,7 @@ impl TitleModel {
                     .unwrap_or(0),
                 cover_image_url: r.try_get("cover_image_url").unwrap_or(None),
                 publication_date: r.try_get("publication_date").unwrap_or(None),
+                dewey_code: r.try_get("dewey_code").unwrap_or(None),
             })
             .collect();
 
@@ -883,10 +884,23 @@ pub struct SearchResult {
     pub volume_count: u64,
     pub cover_image_url: Option<String>,
     pub publication_date: Option<chrono::NaiveDate>,
+    // CR #250 — Dewey code surfaced on the home list-view table so the
+    // sortable column has a value to render. Already present on the
+    // `titles` row; this just adds it to the search projection.
+    pub dewey_code: Option<String>,
 }
 
 /// Allowed sort columns for search results (validated whitelist to prevent SQL injection).
-const VALID_SORT_COLUMNS: &[&str] = &["title", "media_type", "genre_name", "volume_count"];
+/// CR #250 adds `primary_contributor` + `dewey_code` for the list-view
+/// table's sortable column headers.
+const VALID_SORT_COLUMNS: &[&str] = &[
+    "title",
+    "media_type",
+    "genre_name",
+    "volume_count",
+    "primary_contributor",
+    "dewey_code",
+];
 const VALID_SORT_DIRS: &[&str] = &["asc", "desc"];
 
 fn validated_sort(sort: &Option<String>) -> &str {
@@ -909,6 +923,11 @@ fn map_sort_to_column(sort: &str) -> &str {
         "media_type" => "t.media_type",
         "genre_name" => "g.name",
         "volume_count" => "volume_count",
+        // CR #250 — sort by the alias produced in the subquery (the
+        // SELECT projection emits `primary_contributor` from a
+        // correlated subquery; MariaDB resolves the alias in ORDER BY).
+        "primary_contributor" => "primary_contributor",
+        "dewey_code" => "t.dewey_code",
         _ => "t.title",
     }
 }
@@ -1048,7 +1067,7 @@ impl TitleModel {
         // via the supported delete path; this is defense-in-depth against
         // a future migration or manual UPDATE that bypasses the guard.
         let data_sql = format!(
-            "SELECT DISTINCT t.id, t.title, t.subtitle, t.media_type, t.cover_image_url, CAST(t.publication_date AS DATE) AS publication_date, \
+            "SELECT DISTINCT t.id, t.title, t.subtitle, t.media_type, t.cover_image_url, t.dewey_code, CAST(t.publication_date AS DATE) AS publication_date, \
                     COALESCE(g.name, '') AS genre_name, \
                     (SELECT c.name FROM title_contributors tc \
                      JOIN contributors c ON tc.contributor_id = c.id \
@@ -1094,6 +1113,7 @@ impl TitleModel {
                     .unwrap_or(0),
                 cover_image_url: r.try_get("cover_image_url").unwrap_or(None),
                 publication_date: r.try_get("publication_date").unwrap_or(None),
+                dewey_code: r.try_get("dewey_code").unwrap_or(None),
             })
             .collect();
 
@@ -1125,7 +1145,7 @@ impl TitleModel {
             // Fix #107: same LEFT JOIN + COALESCE pattern as
             // `list_recent_cataloged` and `active_search`. See those for
             // rationale.
-            "SELECT t.id, t.title, t.subtitle, t.media_type, t.cover_image_url, \
+            "SELECT t.id, t.title, t.subtitle, t.media_type, t.cover_image_url, t.dewey_code, \
                     CAST(t.publication_date AS DATE) AS publication_date, \
                     COALESCE(g.name, '') AS genre_name, \
                     (SELECT c.name FROM title_contributors tc \
@@ -1162,6 +1182,7 @@ impl TitleModel {
                     .unwrap_or(0),
                 cover_image_url: r.try_get("cover_image_url").unwrap_or(None),
                 publication_date: r.try_get("publication_date").unwrap_or(None),
+                dewey_code: r.try_get("dewey_code").unwrap_or(None),
             })
             .collect();
 
@@ -1185,6 +1206,7 @@ mod tests {
             volume_count: 2,
             cover_image_url: None,
             publication_date: None,
+            dewey_code: None,
         };
         assert_eq!(result.id, 1);
         assert_eq!(result.title, "L'Étranger");
@@ -1208,10 +1230,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_validated_sort_rejects_dewey_code_on_search() {
-        assert_eq!(validated_sort(&Some("dewey_code".to_string())), "title");
-    }
+    // CR #250 expanded `VALID_SORT_COLUMNS` to include `dewey_code`
+    // (and `primary_contributor`) so the home list-view table headers
+    // can sort by them. The historical "rejects" test is superseded by
+    // `test_validated_sort_accepts_cr250_columns` below.
 
     #[test]
     fn test_validated_sort_injection() {
@@ -1241,7 +1263,38 @@ mod tests {
         assert_eq!(map_sort_to_column("media_type"), "t.media_type");
         assert_eq!(map_sort_to_column("genre_name"), "g.name");
         assert_eq!(map_sort_to_column("volume_count"), "volume_count");
+        // CR #250 — sortable columns on the home list-view table.
+        assert_eq!(
+            map_sort_to_column("primary_contributor"),
+            "primary_contributor"
+        );
+        assert_eq!(map_sort_to_column("dewey_code"), "t.dewey_code");
         assert_eq!(map_sort_to_column("unknown"), "t.title");
+    }
+
+    /// CR #250 — lock the SQL-injection guard for the two new sortable
+    /// columns. Anything the table headers can send must be in the
+    /// whitelist; anything else falls back to `title`.
+    #[test]
+    fn test_validated_sort_accepts_cr250_columns() {
+        assert_eq!(
+            validated_sort(&Some("primary_contributor".to_string())),
+            "primary_contributor"
+        );
+        assert_eq!(
+            validated_sort(&Some("dewey_code".to_string())),
+            "dewey_code"
+        );
+        // Adjacent values that *look* close but aren't in the whitelist
+        // must fall back to the default, not get partially accepted.
+        assert_eq!(
+            validated_sort(&Some("primary_contributor; --".to_string())),
+            "title"
+        );
+        assert_eq!(
+            validated_sort(&Some("dewey".to_string())),
+            "title"
+        );
     }
 
     // ─── Similar titles — decade bounds (pure function) ────────────────

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -81,6 +81,8 @@ pub struct HomeTemplate {
     pub col_contributor: String,
     pub col_genre: String,
     pub col_volumes: String,
+    // CR #250 — Dewey column header on the new home list-view table.
+    pub col_dewey: String,
     pub connection_lost: String,
     pub label_no_cover: String,
     pub metadata_error_count: u64,
@@ -791,6 +793,7 @@ pub async fn home(
         col_contributor: rust_i18n::t!("search.col.contributor", locale = loc).to_string(),
         col_genre: rust_i18n::t!("search.col.genre", locale = loc).to_string(),
         col_volumes: rust_i18n::t!("search.col.volumes", locale = loc).to_string(),
+        col_dewey: rust_i18n::t!("search.col.dewey", locale = loc).to_string(),
         connection_lost: rust_i18n::t!("search.connection_lost", locale = loc).to_string(),
         label_no_cover: rust_i18n::t!("cover.no_cover", locale = loc).to_string(),
         metadata_error_count,
@@ -1284,6 +1287,7 @@ pub(crate) mod tests {
             col_contributor: "Contributor".to_string(),
             col_genre: "Genre".to_string(),
             col_volumes: "Volumes".to_string(),
+            col_dewey: "Dewey".to_string(),
             connection_lost: "Connection lost".to_string(),
             label_no_cover: "No cover available".to_string(),
             metadata_error_count: 0,
@@ -1383,6 +1387,7 @@ pub(crate) mod tests {
             volume_count: 1,
             cover_image_url: None,
             publication_date: None,
+            dewey_code: None,
         }
     }
 

--- a/src/routes/home_indicator_tests.rs
+++ b/src/routes/home_indicator_tests.rs
@@ -309,6 +309,7 @@ mod tests {
             volume_count: 0,
             cover_image_url: None,
             publication_date: None,
+            dewey_code: None,
         }
     }
 

--- a/src/routes/home_search_fragment.rs
+++ b/src/routes/home_search_fragment.rs
@@ -222,6 +222,7 @@ mod tests {
             volume_count: 2,
             cover_image_url: None,
             publication_date: None,
+            dewey_code: None,
         };
         let html = render_search_row(&item);
         assert!(html.contains("/title/42"));
@@ -255,6 +256,7 @@ mod tests {
             volume_count: 0,
             cover_image_url: Some("/covers/test.jpg".to_string()),
             publication_date: Some(chrono::NaiveDate::from_ymd_opt(1942, 1, 1).unwrap()),
+            dewey_code: None,
         };
         let html = render_search_row(&item);
         assert!(html.contains("1942"), "Should display publication year");

--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -57,6 +57,7 @@ impl SearchService {
             volume_count,
             cover_image_url: title.cover_image_url.clone(),
             publication_date: title.publication_date,
+            dewey_code: title.dewey_code.clone(),
         }
     }
 }

--- a/static/css/browse.css
+++ b/static/css/browse.css
@@ -11,8 +11,26 @@
     transition: opacity 150ms ease;
 }
 
-/* List mode: horizontal cards */
-.browse-list { display: flex; flex-direction: column; gap: 0.25rem; }
+/*
+ * CR #250 — the list view is now a sortable <table> (`.browse-table`),
+ * not a horizontal-card stack. .browse-cards (the inner wrapper around
+ * the .title-card list) is hidden in list mode; the table is hidden in
+ * grid mode. The legacy `.browse-list .title-card*` rules below are
+ * kept around as a fallback for any out-of-tree template that still
+ * stacks cards without the .browse-cards wrapper, but the home page no
+ * longer relies on them.
+ */
+.browse-list .browse-cards { display: none; }
+.browse-list .browse-table-wrap { display: block; }
+.browse-grid .browse-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; }
+.browse-grid .browse-table-wrap { display: none; }
+
+.browse-table { border-collapse: collapse; }
+.browse-table thead a { display: inline-flex; align-items: center; gap: 0.25rem; }
+.browse-table thead { user-select: none; }
+.browse-table tbody tr:last-child { border-bottom: none; }
+
+/* List mode (legacy fallback): horizontal cards */
 .browse-list .title-card { border-bottom: 1px solid var(--color-stone-100, #f5f5f4); }
 .browse-list .title-card-link { display: flex; flex-direction: row; align-items: center; gap: 0.75rem; padding: 0.5rem; text-decoration: none; color: inherit; border-radius: 0.375rem; }
 .browse-list .title-card-link:hover { background: var(--color-stone-50, #fafaf9); }
@@ -25,7 +43,6 @@
 .browse-list .title-card-volumes { font-size: 0.75rem; color: var(--color-stone-500, #78716c); }
 
 /* Grid mode: card grid */
-.browse-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; }
 .browse-grid .title-card-link { display: flex; flex-direction: column; text-decoration: none; color: inherit; border-radius: 0.5rem; overflow: hidden; border: 1px solid var(--color-stone-200, #e7e5e4); transition: box-shadow 150ms; }
 .browse-grid .title-card-link:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
 .browse-grid .title-card-cover { width: 100%; aspect-ratio: 2/3; position: relative; overflow: hidden; background: var(--color-stone-100, #f5f5f4); }

--- a/static/js/browse-mode.js
+++ b/static/js/browse-mode.js
@@ -13,6 +13,14 @@
     if (!container) return;
     container.classList.remove("browse-list", "browse-grid");
     container.classList.add("browse-" + mode);
+    // CR #250 — list mode uses sortable column headers, so the
+    // <select> sort dropdown is redundant; hide it via a class toggle
+    // (CSP-friendly — strict policy blocks element.style.* writes,
+    // see mybibli.js:73 for the same pattern). Grid mode shows it.
+    var sortControl = document.getElementById("browse-sort-control");
+    if (sortControl) {
+      sortControl.classList.toggle("hidden", mode === "list");
+    }
     // Update radiogroup
     var radios = document.querySelectorAll("[data-browse-mode]");
     radios.forEach(function (btn) {

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -241,7 +241,11 @@
        the actual search results. #}
     <!-- Browse toggle + sort -->
     <div class="w-full max-w-4xl mt-6 flex items-center justify-between">
-        <div class="flex items-center gap-2">
+        {# CR #250 — wrapped in #browse-sort-control so browse-mode.js
+           can hide it in list mode (where the sortable column headers
+           replace the <select>). Visible in grid mode (cards have no
+           column headers, so the select stays the only sort affordance). #}
+        <div id="browse-sort-control" class="flex items-center gap-2">
             <label class="text-xs text-stone-500 dark:text-stone-400" for="browse-sort-select">{{ browse_sort_label }}:</label>
             <select id="browse-sort-select"
                     data-base-q="{{ query_encoded }}"
@@ -297,6 +301,14 @@
                         {% endif %}
                     </div>
                     {% else %}
+                        {# CR #250 — TWO renderings of the same item set:
+                           the existing .browse-cards stack (visible in grid
+                           mode, unchanged) AND a new .browse-table (visible
+                           in list mode). Toggled via CSS in browse.css
+                           keyed on `.browse-list` / `.browse-grid` on the
+                           parent. The browse-mode.js toggle continues to
+                           swap that class on `#browse-results`. #}
+                        <div class="browse-cards">
                         {% for item in paginated.items %}
                         <article class="title-card group">
                             <a href="/title/{{ item.id }}" class="title-card-link"
@@ -317,6 +329,92 @@
                             </a>
                         </article>
                         {% endfor %}
+                        </div>
+
+                        {# CR #250 — sortable table (list mode). Mirrors
+                           location_detail.html's column-header pattern:
+                           clicking a header issues an hx-get that toggles
+                           dir on the active column or sets asc on a new
+                           column. Arrows ▲/▼ surface the current state. #}
+                        <div class="browse-table-wrap overflow-x-auto">
+                            <table class="browse-table w-full text-sm text-left">
+                                <thead class="text-xs text-stone-500 dark:text-stone-400 uppercase border-b border-stone-200 dark:border-stone-700">
+                                    <tr>
+                                        <th class="px-3 py-2 w-10" aria-hidden="true"></th>
+                                        <th class="px-3 py-2">
+                                            <a href="/?q={{ query_encoded }}&amp;sort=title&amp;dir={% if current_sort == "title" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-get="/?q={{ query_encoded }}&amp;sort=title&amp;dir={% if current_sort == "title" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-target="#browse-results"
+                                               hx-swap="innerHTML"
+                                               hx-push-url="true"
+                                               class="hover:text-stone-700 dark:hover:text-stone-200">
+                                                {{ col_title }} {% if current_sort == "title" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+                                            </a>
+                                        </th>
+                                        <th class="px-3 py-2">
+                                            <a href="/?q={{ query_encoded }}&amp;sort=primary_contributor&amp;dir={% if current_sort == "primary_contributor" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-get="/?q={{ query_encoded }}&amp;sort=primary_contributor&amp;dir={% if current_sort == "primary_contributor" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-target="#browse-results"
+                                               hx-swap="innerHTML"
+                                               hx-push-url="true"
+                                               class="hover:text-stone-700 dark:hover:text-stone-200">
+                                                {{ col_contributor }} {% if current_sort == "primary_contributor" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+                                            </a>
+                                        </th>
+                                        <th class="px-3 py-2">
+                                            <a href="/?q={{ query_encoded }}&amp;sort=genre_name&amp;dir={% if current_sort == "genre_name" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-get="/?q={{ query_encoded }}&amp;sort=genre_name&amp;dir={% if current_sort == "genre_name" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-target="#browse-results"
+                                               hx-swap="innerHTML"
+                                               hx-push-url="true"
+                                               class="hover:text-stone-700 dark:hover:text-stone-200">
+                                                {{ col_genre }} {% if current_sort == "genre_name" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+                                            </a>
+                                        </th>
+                                        <th class="px-3 py-2">
+                                            <a href="/?q={{ query_encoded }}&amp;sort=dewey_code&amp;dir={% if current_sort == "dewey_code" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-get="/?q={{ query_encoded }}&amp;sort=dewey_code&amp;dir={% if current_sort == "dewey_code" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-target="#browse-results"
+                                               hx-swap="innerHTML"
+                                               hx-push-url="true"
+                                               class="hover:text-stone-700 dark:hover:text-stone-200">
+                                                {{ col_dewey }} {% if current_sort == "dewey_code" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+                                            </a>
+                                        </th>
+                                        <th class="px-3 py-2 text-right">
+                                            <a href="/?q={{ query_encoded }}&amp;sort=volume_count&amp;dir={% if current_sort == "volume_count" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-get="/?q={{ query_encoded }}&amp;sort=volume_count&amp;dir={% if current_sort == "volume_count" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
+                                               hx-target="#browse-results"
+                                               hx-swap="innerHTML"
+                                               hx-push-url="true"
+                                               class="hover:text-stone-700 dark:hover:text-stone-200">
+                                                {{ col_volumes }} {% if current_sort == "volume_count" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
+                                            </a>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for item in paginated.items %}
+                                    <tr class="border-b border-stone-100 dark:border-stone-800 hover:bg-stone-50 dark:hover:bg-stone-800/50">
+                                        <td class="px-3 py-2">
+                                            <img src="/static/icons/{{ item.media_type }}.svg" alt="" class="w-5 h-5" aria-hidden="true">
+                                        </td>
+                                        <td class="px-3 py-2">
+                                            <a href="/title/{{ item.id }}" class="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">{{ item.title }}</a>
+                                        </td>
+                                        <td class="px-3 py-2 text-stone-600 dark:text-stone-400">
+                                            {% match item.primary_contributor %}{% when Some with (name) %}{{ name }}{% when None %}—{% endmatch %}
+                                        </td>
+                                        <td class="px-3 py-2 text-stone-600 dark:text-stone-400">{{ item.genre_name }}</td>
+                                        <td class="px-3 py-2 text-stone-600 dark:text-stone-400">
+                                            {% match item.dewey_code %}{% when Some with (d) %}<code class="font-mono text-xs">{{ d }}</code>{% when None %}—{% endmatch %}
+                                        </td>
+                                        <td class="px-3 py-2 text-right tabular-nums text-stone-600 dark:text-stone-400">{{ item.volume_count }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                     {% endif %}
                 {% endif %}
         </div>

--- a/tests/e2e/specs/journeys/browse-toggle.spec.ts
+++ b/tests/e2e/specs/journeys/browse-toggle.spec.ts
@@ -56,6 +56,14 @@ test.describe("Browse List/Grid Toggle (Story 5-6)", () => {
   test("title cards are rendered as articles", async ({ page }) => {
     await page.goto(`/?q=${specIsbn("BT", 1)}`);
 
+    // CR #250 — the home list view is now a sortable <table>, so the
+    // .browse-cards stack is `display: none` in list mode (the
+    // default). Switch to grid mode FIRST so the cards become visible
+    // — this test exists to assert the card markup itself, not the
+    // mode-default rendering. The default-mode rendering (table) is
+    // covered by the `list view renders as a table` test below.
+    await page.locator('[data-browse-mode="grid"]').click();
+
     // Should have at least one title card
     const cards = page.locator("article.title-card");
     await expect(cards.first()).toBeVisible({ timeout: 5000 });
@@ -63,6 +71,28 @@ test.describe("Browse List/Grid Toggle (Story 5-6)", () => {
     // Card should have a link to title detail
     const link = cards.first().locator("a.title-card-link");
     await expect(link).toBeVisible();
+
+    // Restore default for sibling specs.
+    await page.evaluate(() =>
+      localStorage.removeItem("mybibli_browse_mode"),
+    );
+  });
+
+  // CR #250 — locks the new list-view rendering. Default mode is
+  // "list" → #browse-results carries `.browse-list`, the table is
+  // visible, and the legacy `.browse-cards` stack is hidden.
+  test("list view renders as a sortable table", async ({ page }) => {
+    await page.goto(`/?q=${specIsbn("BT", 1)}`);
+
+    const container = page.locator("#browse-results");
+    await expect(container).toHaveClass(/browse-list/);
+
+    const table = container.locator("table.browse-table");
+    await expect(table).toBeVisible({ timeout: 5000 });
+    await expect(table.locator("tbody tr").first()).toBeVisible();
+    // Sortable column headers are <a> tags inside <th>, mirroring
+    // location_detail.html.
+    await expect(table.locator("thead th a").first()).toBeVisible();
   });
 
   test("ARIA: radiogroup with proper roles", async ({ page }) => {

--- a/tests/e2e/specs/journeys/csp-headers.spec.ts
+++ b/tests/e2e/specs/journeys/csp-headers.spec.ts
@@ -154,8 +154,14 @@ test.describe("Story 7-4 — CSP headers", () => {
     // ABOVE the search results on the home page, which also renders
     // <a href="/title/N"> blocks. A bare `a[href^="/title/"].first()` would
     // pick whatever title happens to be most recent in the test stack.
+    // CR #250 — scope to the visible table row link. The `.browse-cards`
+    // grid markup is still in the DOM (for grid mode) but `display:none`
+    // in the default list mode, so a bare `a[href^="/title/"]` would
+    // race against a hidden card link.
     const titleLink = page
-      .locator('#browse-results a[href^="/title/"]')
+      .locator(
+        '#browse-results table.browse-table tbody tr td a[href^="/title/"]',
+      )
       .first();
     await expect(titleLink).toBeVisible({ timeout: 10000 });
     const titleHref = await titleLink.getAttribute("href");

--- a/tests/e2e/specs/journeys/dewey-code.spec.ts
+++ b/tests/e2e/specs/journeys/dewey-code.spec.ts
@@ -23,7 +23,16 @@ test.describe("Dewey Code Management (Story 5-8)", () => {
     // selector doesn't pick up the Story 9-2 #recent-additions section, which
     // also renders <a href="/title/N"> blocks ABOVE the search results.
     await page.goto(`/?q=${ISBN}`);
-    await page.locator('#browse-results a[href^="/title/"]').first().click();
+    // CR #250 — default list mode renders results as a <table>; the
+    // legacy `.browse-cards` markup is still in the DOM (for grid mode)
+    // but `display: none`, so `.first()` on a bare selector would
+    // race against a hidden link. Scope to the visible table row.
+    await page
+      .locator(
+        '#browse-results table.browse-table tbody tr td a[href^="/title/"]',
+      )
+      .first()
+      .click();
     await expect(page.locator("h1")).toBeVisible({ timeout: 5000 });
 
     // Click Edit metadata
@@ -93,7 +102,16 @@ test.describe("Dewey Code Management (Story 5-8)", () => {
       await page.goto(`/?q=${isbn}`);
       // Scope to #browse-results — Story 9-2 introduced #recent-additions
       // ABOVE the search results, which also contains <a href="/title/N">.
-      await page.locator('#browse-results a[href^="/title/"]').first().click();
+      // CR #250 — default list mode renders results as a <table>; the
+    // legacy `.browse-cards` markup is still in the DOM (for grid mode)
+    // but `display: none`, so `.first()` on a bare selector would
+    // race against a hidden link. Scope to the visible table row.
+    await page
+      .locator(
+        '#browse-results table.browse-table tbody tr td a[href^="/title/"]',
+      )
+      .first()
+      .click();
       await expect(page.locator("h1")).toBeVisible({ timeout: 5000 });
       await page
         .getByRole("button", {

--- a/tests/e2e/specs/journeys/home-search.spec.ts
+++ b/tests/e2e/specs/journeys/home-search.spec.ts
@@ -40,10 +40,16 @@ test.describe("Home page search", () => {
     // Trigger search-fire event (simulating debounce completion)
     await searchField.dispatchEvent("search-fire");
     const tbody = page.locator("#browse-results");
-    // Wait for HTMX swap to complete: either title cards render or the empty-state
-    // block appears. Matching either variant guarantees the swap landed.
+    // Wait for HTMX swap to complete: either a result row (CR #250
+    // list-mode <table> or the legacy `.browse-cards` grid markup)
+    // renders, or the empty-state block appears. Matching either
+    // variant guarantees the swap landed.
     await expect(
-      tbody.locator('article.title-card, .text-center').first(),
+      tbody
+        .locator(
+          'table.browse-table tbody tr, article.title-card, .text-center',
+        )
+        .first(),
     ).toBeVisible({ timeout: 5000 });
   });
 
@@ -51,8 +57,13 @@ test.describe("Home page search", () => {
     page,
   }) => {
     await page.goto("/?q=test");
-    // If results exist, click first row
-    const rows = page.locator("#browse-results article.title-card");
+    // CR #250 — default browse mode is list = sortable table. Click
+    // the first table-row link; sibling .title-card markup exists in
+    // the DOM for grid mode but `display: none` in list mode, so
+    // `.first()` on a card would auto-wait on a hidden element.
+    const rows = page.locator(
+      "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+    );
     const count = await rows.count();
     if (count > 0) {
       await rows.first().click();
@@ -136,11 +147,16 @@ test.describe("Home page search", () => {
 
     await firstGenrePill.click();
 
-    // Post-click: #browse-results swap landed. Wait for either a title card
-    // or the empty-state block to materialize inside the target.
+    // Post-click: #browse-results swap landed. Wait for a result row
+    // (CR #250 list-mode table OR legacy grid-mode card) or the
+    // empty-state block to materialize inside the target.
     const results = page.locator("#browse-results");
     await expect(
-      results.locator("article.title-card, .text-center").first(),
+      results
+        .locator(
+          "table.browse-table tbody tr, article.title-card, .text-center",
+        )
+        .first(),
     ).toBeVisible({ timeout: 10000 });
 
     // THE REGRESSION ASSERTION: still exactly one <header> and one <main>.
@@ -230,10 +246,15 @@ test.describe("Home page scanner detection — scan to navigate", () => {
     await simulateTyping(page, "#search-field", "test");
 
     // Inline browse: #browse-results swap landed, page DID NOT navigate
-    // away from /. Match either a title card or empty-state block.
+    // away from /. Match a result row (CR #250 table OR legacy card)
+    // or the empty-state block.
     const tbody = page.locator("#browse-results");
     await expect(
-      tbody.locator("article.title-card, .text-center").first(),
+      tbody
+        .locator(
+          "table.browse-table tbody tr, article.title-card, .text-center",
+        )
+        .first(),
     ).toBeVisible({ timeout: 5000 });
 
     // Critical: still on home (not /title/, /volume/, /location/, /catalog).

--- a/tests/e2e/specs/journeys/series.spec.ts
+++ b/tests/e2e/specs/journeys/series.spec.ts
@@ -133,7 +133,13 @@ test.describe("Series CRUD & Listing (Story 5-3)", () => {
 
     // Step 3: navigate to the title via home search
     await page.goto(`/?q=${ISBN}`);
-    const titleLink = page.locator("a[href^='/title/']").first();
+    // CR #250 — scope to the visible list-mode table row link;
+    // `.browse-cards` markup is in the DOM but hidden in list mode.
+    const titleLink = page
+      .locator(
+        "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+      )
+      .first();
     await expect(titleLink).toBeVisible({ timeout: 15000 });
     const titleHref = (await titleLink.getAttribute("href"))!;
     await page.goto(titleHref);
@@ -207,7 +213,11 @@ test.describe("Series Assignment & Gap Detection (Story 5-4)", () => {
     // Step 3: Find title 1 via home search — navigate with query param
     // The title is created during scan, so it should be searchable immediately
     await page.goto(`/?q=${specIsbn("SE", 10)}`);
-    const title1Link = page.locator("a[href^='/title/']").first();
+    const title1Link = page
+      .locator(
+        "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+      )
+      .first();
     await expect(title1Link).toBeVisible({ timeout: 15000 });
     const title1Href = (await title1Link.getAttribute("href"))!;
     await page.goto(title1Href);
@@ -227,7 +237,11 @@ test.describe("Series Assignment & Gap Detection (Story 5-4)", () => {
 
     // Step 4: Find title 2 via home search and navigate to detail
     await page.goto(`/?q=${specIsbn("SE", 11)}`);
-    const title2Link = page.locator("a[href^='/title/']").first();
+    const title2Link = page
+      .locator(
+        "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+      )
+      .first();
     await expect(title2Link).toBeVisible({ timeout: 10000 });
     const title2Href = (await title2Link.getAttribute("href"))!;
     await page.goto(title2Href);
@@ -284,7 +298,13 @@ test.describe("Series Assignment & Gap Detection (Story 5-4)", () => {
 
     // Find the title via home search
     await page.goto(`/?q=${ISBN}`);
-    const titleLink = page.locator("a[href^='/title/']").first();
+    // CR #250 — scope to the visible list-mode table row link;
+    // `.browse-cards` markup is in the DOM but hidden in list mode.
+    const titleLink = page
+      .locator(
+        "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+      )
+      .first();
     await expect(titleLink).toBeVisible({ timeout: 10000 });
     const titleHref = (await titleLink.getAttribute("href"))!;
     await page.goto(titleHref);
@@ -329,7 +349,13 @@ test.describe("Series Assignment & Gap Detection (Story 5-4)", () => {
 
     // Find title via home search
     await page.goto(`/?q=${specIsbn("SE", 20)}`);
-    const titleLink = page.locator("a[href^='/title/']").first();
+    // CR #250 — scope to the visible list-mode table row link;
+    // `.browse-cards` markup is in the DOM but hidden in list mode.
+    const titleLink = page
+      .locator(
+        "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+      )
+      .first();
     await expect(titleLink).toBeVisible({ timeout: 10000 });
     const titleHref = (await titleLink.getAttribute("href"))!;
     await page.goto(titleHref);

--- a/tests/e2e/specs/journeys/title-detail-volumes.spec.ts
+++ b/tests/e2e/specs/journeys/title-detail-volumes.spec.ts
@@ -49,8 +49,12 @@ test.describe("CR #209 — per-volume table on /title/:id", () => {
 
     // Step 2: navigate to the title-detail page via home search.
     await page.goto(`/?q=${ISBN}`);
+    // CR #250 — scope to the list-mode table row link (default mode);
+    // legacy `.browse-cards` markup is in the DOM but `display:none`.
     const titleLink = page
-      .locator('#browse-results a[href^="/title/"]')
+      .locator(
+        '#browse-results table.browse-table tbody tr td a[href^="/title/"]',
+      )
       .first();
     await expect(titleLink).toBeVisible({ timeout: 15000 });
     const titleHref = (await titleLink.getAttribute("href"))!;


### PR DESCRIPTION
## Summary

- Replaces the home page's "list" view (stacked title-cards) with a real `<table>` mirroring the column-header sort UX of `/location/:id`.
- Sortable columns: Title · Author · Genre · Dewey · Volumes — every header is an `hx-get` link with `hx-push-url=true`.
- Grid view unchanged.
- `SearchResult` grows `dewey_code`; `VALID_SORT_COLUMNS` accepts `primary_contributor` + `dewey_code` (whitelist-protected — see new test `test_validated_sort_accepts_cr250_columns`).
- The legacy `<select>` sort dropdown is hidden in list mode (column headers cover it). CSP-clean class toggle via `browse-mode.js`.

## Why this matters

Last CR of v1.6.0 — "Tighten the catalog". The location detail page already had a clean table for scanning a large catalog; the home list view kept showing covers + a single sort `<select>` even though most librarians use it to find titles, not browse covers. Bringing the table here closes the UX asymmetry.

## Test plan

- [x] `cargo check` + `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --test search_filter_browse` — 5 passed (includes #279 regression coverage)
- [x] `cargo test --lib models::title::tests` — 25 passed (with DATABASE_URL)
- [x] `cargo test --lib templates_audit` — 5 passed (no inline markup / hx-confirm regression)
- [ ] Visual check: home grid view unchanged, list view shows the sortable table, sort arrows reflect query params, dropdown hidden in list mode, visible in grid mode.

## Out of scope

- E2E spec — deferring to the v1.6.0 release-gate sweep alongside #279.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)