### PR TITLE
chore: gitignore /marketing/ for local-only marketing workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ static/css/output.css
 # Tailwind build (root level, not tests/)
 /package.json
 .claude/scheduled_tasks.lock
+
+# Marketing — drafts, ideas, channel notes, outreach trackers.
+# Intentionally local-only per memory [[feedback-marketing-drafts-stay-local]];
+# any published material lands on the project's public surfaces (README,
+# website, manual) via a regular PR, not from inside this directory.
+/marketing/


### PR DESCRIPTION
## Summary

- Adds `/marketing/` to `.gitignore` so the maintainer's local marketing workspace (drafts, channel notes, positioning iterations, outreach trackers) stays off the public repo.
- Codifies memory [[feedback-marketing-drafts-stay-local]] as a gitignore rule rather than just a discipline.

Any material that needs to land on the project's public surfaces (README, website, manual) still goes through a regular PR — this rule does not block that path.

## Test plan

- [ ] After merge, `git check-ignore -v marketing/anything.md` resolves to this rule
- [ ] `git status` on the maintainer's machine no longer surfaces `marketing/` content as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)