### PR TITLE
docs: align README + website with v1.7.5 production state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Built for collectors who want more than a spreadsheet:
 
-- **Barcode-first cataloging.** Scan an ISBN / EAN-13 and the title resolves asynchronously through a metadata provider chain (BnF, Google Books, Open Library, MusicBrainz, OMDb, TMDB, BDGest), with cover-image download and similar-title detection.
+- **Barcode-first cataloging.** Scan an ISBN / EAN-13 and the title resolves asynchronously through a metadata provider chain (BnF, Google Books, Open Library, Library of Congress, MusicBrainz, OMDb, TMDb, BDGest), with cover-image download and similar-title detection.
 - **Multi-media support.** Books, BD/comics (with multi-position omnibus volumes), audio releases, films/series — each typed correctly and with the right metadata provider chosen automatically.
 - **Series + collection awareness.** Gap detection on series volumes, Dewey-based browsing, similar-titles section.
 - **Storage-location tracking.** Configurable hierarchy (room → shelf → row → …), barcode-on-shelf workflow.
@@ -32,7 +32,7 @@ Built for collectors who want more than a spreadsheet:
 
 ## Screenshots
 
-Live production install (`v1.7.0`, household NAS, ~88 titles cataloged):
+Live production install (`v1.7.5`, household NAS, 200+ volumes catalogued and growing):
 
 <p align="center">
   <img src="docs/screenshots/home.png" alt="mybibli home page — search bar, genre filters, dashboard counters, and a recent-additions strip with cover thumbnails." width="780">

--- a/website/index.html
+++ b/website/index.html
@@ -121,20 +121,20 @@
           <!-- Status snapshot -->
           <div class="mt-12 grid grid-cols-2 sm:grid-cols-4 gap-4 max-w-2xl">
             <div>
-              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">8/9</div>
-              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">epics done</div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">200+</div>
+              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">volumes in prod</div>
             </div>
             <div>
               <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">~900</div>
               <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">tests green</div>
             </div>
             <div>
-              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">7</div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">8</div>
               <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">metadata providers</div>
             </div>
             <div>
-              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">2</div>
-              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">languages (EN/FR)</div>
+              <div class="text-2xl sm:text-3xl font-bold text-stone-900 dark:text-stone-50">4</div>
+              <div class="text-xs sm:text-sm text-stone-500 dark:text-stone-400">languages (EN/FR/DE/IT)</div>
             </div>
           </div>
         </div>
@@ -192,7 +192,7 @@
             </div>
             <h3 class="mt-4 text-lg font-semibold text-stone-900 dark:text-stone-50">Barcode-first cataloging</h3>
             <p class="mt-2 text-sm text-stone-600 dark:text-stone-400 leading-relaxed">
-              Scan an ISBN or EAN-13. Title metadata resolves asynchronously through a chain of seven providers — BnF, Google Books, Open Library, MusicBrainz, OMDb, TMDB, BDGest — with cover-image download.
+              Scan an ISBN or EAN-13. Title metadata resolves asynchronously through a chain of eight providers — BnF, Google Books, Open Library, Library of Congress, MusicBrainz, OMDb, TMDb, BDGest — with cover-image download.
             </p>
           </article>
 

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -196,7 +196,7 @@
               <h3 class="text-lg font-semibold text-stone-900 dark:text-stone-50">All my media types</h3>
               <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">✓ Done</span>
             </div>
-            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Provider chain (BnF / Google Books / Open Library / MusicBrainz / OMDb / TMDB / BDGest), media-type-aware scanning, cover image management, metadata editing and re-download.</p>
+            <p class="mt-2 text-sm text-stone-600 dark:text-stone-400">Provider chain (BnF / Google Books / Open Library / Library of Congress / MusicBrainz / OMDb / TMDb / BDGest), media-type-aware scanning, cover image management, metadata editing and re-download.</p>
           </li>
 
           <!-- Epic 4 -->


### PR DESCRIPTION
## Summary

- README: bump v1.7.0 → v1.7.5, "88 titles" → "200+ volumes", complete the provider chain (add **Library of Congress**, fix `TMDB` → `TMDb` casing).
- `website/index.html` stats snapshot: "8/9 epics done" → "200+ volumes in prod", `7` → `8` providers, `2` → `4` languages (EN/FR/DE/IT). Features-section provider list aligned.
- `website/roadmap.html`: scanning-block provider list aligned (8 providers, TMDb casing).

No code change. Public-facing docs only — readying the GitHub repo / GitHub Pages surface before an external announcement.

## Test plan

- [ ] Visual check on GitHub Pages once merged: stats snapshot on the home page shows 200+ / ~900 / 8 / 4.
- [ ] `grep -n "TMDB" README.md website/*.html` returns no provider-name match (env-var `TMDB_API_KEY` is intentional).
- [ ] Provider count matches between README intro, website features section, roadmap snapshot, and the Reddit draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)