### PR TITLE
docs(seo): Google Search Console verification meta tag

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,6 +6,7 @@
   <title>mybibli — self-hosted library catalog (books, comics, manga) — Calibre alternative</title>
   <meta name="description" content="Open-source Calibre alternative — self-hosted cataloging for books, comics, manga, audio &amp; films. ISBN barcode scanner, loan tracking, runs on your NAS. Rust + Docker, AGPL." />
   <meta name="robots" content="index, follow" />
+  <meta name="google-site-verification" content="39C0ysZ3QU2jW8Jnh_Dl2e6jZATFlSFrI-GzpJ6x_ag" />
   <link rel="canonical" href="https://guycorbaz.github.io/mybibli/" />
   <meta property="og:title" content="mybibli — self-hosted library catalog (books, comics, manga)" />
   <meta property="og:description" content="Self-hosted library cataloging app — books, comics, manga, audio, films. Open-source Calibre alternative with ISBN barcode scanning, series gap detection, multi-user loan tracking. Runs on your NAS via Docker. Built in Rust + HTMX, AGPL licensed." />


### PR DESCRIPTION
## Summary

- Adds Google Search Console verification meta tag to `website/index.html`
- Enables submission of `sitemap.xml` (added in #337) once Google verifies the property at `https://guycorbaz.github.io/mybibli/`

## Test plan

- [ ] After merge + Pages redeploy, the meta tag is visible in the live page source
- [ ] User clicks "Verify" in Google Search Console — verification succeeds
- [ ] User submits `sitemap.xml` via GSC Sitemaps tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)