### PR TITLE
patch(v1.7.7): test rigor bundle + series view card layout

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -327,6 +327,7 @@ series:
   assigned: "%{series} auf Position %{position} zugeordnet."
   unassigned: "Aus der Serie entfernt."
   missing_volume: "Fehlendes Exemplar Nr."
+  volume_short: "Bd."
   ongoing: "laufend, zuletzt bekannt: Nr. %{position}"
   no_assignments: "Keiner Serie zugeordnet."
   sort:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -327,6 +327,10 @@ series:
   assigned: "Assigned to %{series} at position %{position}."
   unassigned: "Removed from series."
   missing_volume: "Missing volume #"
+  # CR #336 — short prefix for the volume number on series-detail cards
+  # (e.g. "Vol. 3"). Stays untranslated in DE/IT below because "Vol." is
+  # a borrowed abbreviation in those languages too.
+  volume_short: "Vol."
   ongoing: "ongoing, last known: #%{position}"
   no_assignments: "Not assigned to any series."
   sort:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -328,6 +328,7 @@ series:
   assigned: "Assigné à %{series} à la position %{position}."
   unassigned: "Retiré de la série."
   missing_volume: "Volume manquant #"
+  volume_short: "Vol."
   ongoing: "en cours, dernier connu : #%{position}"
   no_assignments: "Non assigné à aucune série."
   sort:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -322,6 +322,7 @@ series:
   assigned: "Assegnato a %{series} alla posizione %{position}."
   unassigned: "Rimosso dalla serie."
   missing_volume: "Esemplare mancante n."
+  volume_short: "Vol."
   ongoing: "in corso, ultimo noto: n.%{position}"
   no_assignments: "Non assegnato ad alcuna serie."
   sort:

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -343,6 +343,12 @@ pub struct TitleSeriesRow {
     /// Fix #235: surfaced so the series-detail page can sort positions
     /// by Dewey, alongside the existing default sort by position number.
     pub dewey_code: Option<String>,
+    /// CR #336: card layout on series detail. None ⇒ media-type fallback icon.
+    pub cover_image_url: Option<String>,
+    /// CR #336: card layout on series detail. Resolved via the same
+    /// LIMIT 1 ordered subquery the title-list queries use, so the
+    /// "primary contributor" choice stays consistent across surfaces.
+    pub primary_contributor: Option<String>,
 }
 
 /// A series assignment as seen from a title (for title detail page).
@@ -437,7 +443,14 @@ impl TitleSeriesModel {
     ) -> Result<Vec<TitleSeriesRow>, AppError> {
         let rows = sqlx::query(
             "SELECT ts.id, ts.title_id, ts.series_id, ts.position_number, ts.is_omnibus, \
-             t.title AS title_name, t.media_type, t.dewey_code \
+             t.title AS title_name, t.media_type, t.dewey_code, t.cover_image_url, \
+             (SELECT c.name FROM title_contributors tc \
+              JOIN contributors c ON tc.contributor_id = c.id \
+              JOIN contributor_roles cr ON tc.role_id = cr.id \
+              WHERE tc.title_id = t.id AND tc.deleted_at IS NULL \
+                AND c.deleted_at IS NULL AND cr.deleted_at IS NULL \
+              ORDER BY CASE WHEN cr.name = 'Auteur' THEN 0 ELSE 1 END, tc.id ASC \
+              LIMIT 1) AS primary_contributor \
              FROM title_series ts \
              JOIN titles t ON ts.title_id = t.id \
              WHERE ts.series_id = ? AND ts.deleted_at IS NULL AND t.deleted_at IS NULL \
@@ -458,6 +471,8 @@ impl TitleSeriesModel {
                     title_name: r.try_get("title_name")?,
                     media_type: r.try_get("media_type")?,
                     dewey_code: r.try_get("dewey_code")?,
+                    cover_image_url: r.try_get("cover_image_url").unwrap_or(None),
+                    primary_contributor: r.try_get("primary_contributor").unwrap_or(None),
                 })
             })
             .collect::<Result<Vec<_>, sqlx::Error>>()

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -2337,6 +2337,95 @@ pub(crate) mod tests {
         assert!(html.contains("href=\"/title/2\""));
     }
 
+    // CR #120 — AC5 single-active-filter contract: when `?filter=overdue`
+    // (or `?filter=unshelved`) is active, concurrent `?q=X&sort=Y` params
+    // are ignored — the indicator-list slot drives the response and the
+    // legacy search-fragment branch short-circuits. The handler enforces
+    // this by setting `query = String::new()` and `has_filter = false`
+    // when an indicator filter is active (see home.rs:376-379), which
+    // keeps `results = None`. These tests lock the symptom at the
+    // template layer: when `results = None` and the indicator is active,
+    // #browse-results renders only its empty shell — no `.browse-table`
+    // and no `.title-card` content — and #recent-additions does not
+    // coexist with the indicator list. A future handler regression that
+    // accidentally populates `results` would fire these.
+    #[test]
+    fn home_overdue_filter_active_with_concurrent_query_does_not_render_search_results() {
+        let mut t = make_test_home_template_with_counts("librarian", true, 10, 20, 5);
+        t.overdue_filter_active = true;
+        t.overdue_loans = vec![fake_loan_with_details(
+            1, "Alice", "V0001", "Sample Title", 35,
+        )];
+        // Simulate the post-handler state on `?filter=overdue&q=foo&sort=date`:
+        // handler cleared query, never ran search → results stays None.
+        t.query = String::new();
+        t.active_filter = String::new();
+        t.results = None;
+
+        let html = t.render().expect("render");
+
+        // Indicator path is the one that wins.
+        assert!(
+            html.contains("id=\"overdue-list\""),
+            "AC5: overdue-list must render when filter is active"
+        );
+        assert!(html.contains("Alice"));
+        assert!(html.contains("V0001"));
+        assert!(html.contains("Sample Title"));
+
+        // 3-way mutual exclusion guard.
+        assert!(
+            !html.contains("id=\"recent-additions\""),
+            "AC5: recent-additions MUST NOT coexist with overdue-list"
+        );
+
+        // AC5 short-circuit lock: #browse-results stays in the DOM (it's
+        // the HTMX swap target), but NO search-content children render.
+        assert!(
+            html.contains("id=\"browse-results\""),
+            "browse-results shell stays in DOM (HTMX target)"
+        );
+        assert!(
+            !html.contains("class=\"browse-table\""),
+            "AC5: no .browse-table when overdue filter is active (results=None)"
+        );
+        assert!(
+            !html.contains("class=\"title-card\""),
+            "AC5: no .title-card when overdue filter is active (results=None)"
+        );
+    }
+
+    #[test]
+    fn home_unshelved_filter_active_with_concurrent_query_does_not_render_search_results() {
+        // Symmetric of the overdue test above — same AC5 contract,
+        // unshelved branch.
+        let tags = vec![fake_indicator_tag("Unshelved volumes", 1, "unshelved", true)];
+        let mut t = make_test_home_template_with_indicators(
+            "librarian",
+            tags,
+            true,
+            vec![fake_unshelved_row(101, "V8001", 1, "Sample Title", "Sample Author")],
+        );
+        t.query = String::new();
+        t.active_filter = String::new();
+        t.results = None;
+
+        let html = t.render().expect("render");
+
+        assert!(html.contains("id=\"unshelved-list\""));
+        assert!(html.contains("V8001"));
+        assert!(!html.contains("id=\"recent-additions\""));
+        assert!(html.contains("id=\"browse-results\""));
+        assert!(
+            !html.contains("class=\"browse-table\""),
+            "AC5: no .browse-table when unshelved filter is active"
+        );
+        assert!(
+            !html.contains("class=\"title-card\""),
+            "AC5: no .title-card when unshelved filter is active"
+        );
+    }
+
     /// AC6 defensive empty-state: `unshelved_filter_active=true` AND
     /// `unshelved_volumes.is_empty()` (count > 0 but a race emptied the
     /// list) renders the inline empty-state copy inside `#unshelved-list`,

--- a/src/routes/series.rs
+++ b/src/routes/series.rs
@@ -194,6 +194,8 @@ pub struct SeriesDetailTemplate {
     pub positions: Vec<SeriesPositionInfo>,
     pub position_label: String,
     pub missing_label: String,
+    /// CR #336: short prefix for volume number on series-detail cards.
+    pub volume_short_label: String,
     pub grid_label: String,
     pub no_assignments_label: String,
     pub current_url: String,
@@ -280,6 +282,7 @@ pub async fn series_detail_page(
         positions,
         position_label: rust_i18n::t!("series.position", locale = loc).to_string(),
         missing_label: rust_i18n::t!("series.missing_volume", locale = loc).to_string(),
+        volume_short_label: rust_i18n::t!("series.volume_short", locale = loc).to_string(),
         grid_label: format!(
             "{} — {}",
             rust_i18n::t!("series.list_title", locale = loc),

--- a/src/services/series.rs
+++ b/src/services/series.rs
@@ -13,6 +13,17 @@ pub struct SeriesPositionInfo {
     /// for unassigned grid gaps. Used by `sort_positions` to support
     /// `?sort=dewey_code` on the series-detail page.
     pub dewey_code: Option<String>,
+    /// CR #336: card layout on series detail. `None` for both gaps
+    /// and titles without a cover (template falls back to a media-type
+    /// icon in the latter case).
+    pub cover_image_url: Option<String>,
+    /// CR #336: card layout on series detail. `None` for gaps; `None`
+    /// for filled positions whose title has no contributor row yet.
+    pub primary_contributor: Option<String>,
+    /// CR #336: media type ("book" / "bd" / etc.) used by the template
+    /// to pick the right `/static/icons/{media_type}.svg` fallback when
+    /// `cover_image_url` is None. Empty string for gaps.
+    pub media_type: String,
 }
 
 pub struct SeriesService;
@@ -261,6 +272,9 @@ impl SeriesService {
                     title_name: Some(a.title_name),
                     is_omnibus: a.is_omnibus,
                     dewey_code: a.dewey_code,
+                    cover_image_url: a.cover_image_url,
+                    primary_contributor: a.primary_contributor,
+                    media_type: a.media_type,
                 })
                 .collect());
         }
@@ -285,6 +299,9 @@ fn build_position_grid(
             title_name: assignment.map(|a| a.title_name.clone()),
             is_omnibus: assignment.is_some_and(|a| a.is_omnibus),
             dewey_code: assignment.and_then(|a| a.dewey_code.clone()),
+            cover_image_url: assignment.and_then(|a| a.cover_image_url.clone()),
+            primary_contributor: assignment.and_then(|a| a.primary_contributor.clone()),
+            media_type: assignment.map(|a| a.media_type.clone()).unwrap_or_default(),
         });
     }
     Ok(positions)
@@ -449,6 +466,9 @@ mod tests {
             title_name: name.map(String::from),
             is_omnibus: false,
             dewey_code: dewey.map(String::from),
+            cover_image_url: None,
+            primary_contributor: None,
+            media_type: String::new(),
         }
     }
 
@@ -591,6 +611,8 @@ mod tests {
             title_name: name.to_string(),
             media_type: "book".to_string(),
             dewey_code: None,
+            cover_image_url: None,
+            primary_contributor: None,
         }
     }
 
@@ -604,6 +626,8 @@ mod tests {
             title_name: name.to_string(),
             media_type: "book".to_string(),
             dewey_code: None,
+            cover_image_url: None,
+            primary_contributor: None,
         }
     }
 
@@ -639,6 +663,37 @@ mod tests {
         let grid = build_position_grid(5, &[]).unwrap();
         assert_eq!(grid.len(), 5);
         assert!(grid.iter().all(|p| p.title_id.is_none()));
+    }
+
+    // CR #336 regression — cover_image_url + primary_contributor +
+    // media_type must propagate from TitleSeriesRow → SeriesPositionInfo
+    // so the series-detail card grid can render them. Gaps must carry
+    // None / empty media_type so the template branches correctly.
+    #[test]
+    fn build_position_grid_propagates_cover_author_media_type() {
+        let filled = TitleSeriesRow {
+            id: 1,
+            title_id: 10,
+            series_id: 1,
+            position_number: 1,
+            is_omnibus: false,
+            title_name: "T1".to_string(),
+            media_type: "bd".to_string(),
+            dewey_code: None,
+            cover_image_url: Some("/covers/10.jpg".to_string()),
+            primary_contributor: Some("Hergé".to_string()),
+        };
+        let grid = build_position_grid(2, &[filled]).unwrap();
+        assert_eq!(grid.len(), 2);
+        assert_eq!(grid[0].cover_image_url.as_deref(), Some("/covers/10.jpg"));
+        assert_eq!(grid[0].primary_contributor.as_deref(), Some("Hergé"));
+        assert_eq!(grid[0].media_type, "bd");
+        // Position 2 is a gap — must have None / empty defaults so the
+        // template's `{% if let Some(cover) = ... %}` branch picks the
+        // gap rendering path.
+        assert!(grid[1].cover_image_url.is_none());
+        assert!(grid[1].primary_contributor.is_none());
+        assert_eq!(grid[1].media_type, "");
     }
 
     #[test]

--- a/templates/components/series_gap_grid.html
+++ b/templates/components/series_gap_grid.html
@@ -1,20 +1,43 @@
 <div role="grid" aria-label="{{ grid_label }}" class="mt-6">
-    <div class="grid grid-cols-4 lg:grid-cols-8 gap-2">
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
         {% for pos in positions %}
         {% if let Some(tid) = pos.title_id %}
         <a href="/title/{{ tid }}"
            role="gridcell"
-           aria-label="{{ pos.title_name.as_deref().unwrap_or("") }}, {{ position_label }} {{ pos.position }}"
-           title="{{ position_label }} {{ pos.position }}: {{ pos.title_name.as_deref().unwrap_or("") }}"
-           class="flex flex-col items-center justify-center p-2 rounded border border-green-300 dark:border-green-700 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/50 transition-colors cursor-pointer min-h-[3rem]">
-            <span class="text-xs font-medium">{{ pos.position }}</span>
+           aria-label="{{ volume_short_label }} {{ pos.position }} — {{ pos.title_name.as_deref().unwrap_or("") }}"
+           title="{{ volume_short_label }} {{ pos.position }} — {{ pos.title_name.as_deref().unwrap_or("") }}"
+           class="series-card flex flex-col rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 overflow-hidden hover:border-indigo-400 dark:hover:border-indigo-600 hover:shadow-md transition-all">
+            <div class="aspect-[2/3] bg-stone-100 dark:bg-stone-800 flex items-center justify-center overflow-hidden">
+                {% if let Some(cover) = pos.cover_image_url %}
+                <img src="{{ cover }}" alt="" loading="lazy" class="w-full h-full object-cover" />
+                {% else %}
+                <img src="/static/icons/{% if pos.media_type == "bd" %}bd{% else if pos.media_type == "cd" %}cd{% else if pos.media_type == "dvd" %}dvd{% else if pos.media_type == "magazine" %}magazine{% else %}book{% endif %}.svg"
+                     alt=""
+                     class="w-12 h-12 opacity-50" />
+                {% endif %}
+            </div>
+            <div class="p-2 flex flex-col gap-0.5">
+                <span class="text-lg font-bold text-indigo-700 dark:text-indigo-300 leading-tight">{{ volume_short_label }} {{ pos.position }}</span>
+                <span class="text-sm font-medium text-stone-900 dark:text-stone-100 truncate" title="{{ pos.title_name.as_deref().unwrap_or("") }}">{{ pos.title_name.as_deref().unwrap_or("") }}</span>
+                {% if let Some(author) = pos.primary_contributor %}
+                <span class="text-xs text-stone-500 dark:text-stone-400 truncate" title="{{ author }}">{{ author }}</span>
+                {% endif %}
+            </div>
         </a>
         {% else %}
         <div role="gridcell"
-             aria-label="{{ missing_label }} {{ pos.position }}"
-             title="{{ missing_label }} {{ pos.position }}"
-             class="series-gap-stripes flex flex-col items-center justify-center p-2 rounded border border-dashed border-red-300 dark:border-red-700 text-red-400 dark:text-red-500 min-h-[3rem]">
-            <span class="text-xs">{{ pos.position }}</span>
+             aria-label="{{ missing_label }}{{ pos.position }}"
+             title="{{ missing_label }}{{ pos.position }}"
+             class="series-card-gap series-gap-stripes flex flex-col rounded-md border border-dashed border-red-300 dark:border-red-700 overflow-hidden">
+            <div class="aspect-[2/3] flex items-center justify-center text-red-400 dark:text-red-500">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                </svg>
+            </div>
+            <div class="p-2 flex flex-col gap-0.5">
+                <span class="text-lg font-bold text-red-600 dark:text-red-400 leading-tight">{{ volume_short_label }} {{ pos.position }}</span>
+                <span class="text-xs text-red-500 dark:text-red-500">{{ missing_label }}{{ pos.position }}</span>
+            </div>
         </div>
         {% endif %}
         {% endfor %}

--- a/tests/e2e/helpers/db-snapshot.ts
+++ b/tests/e2e/helpers/db-snapshot.ts
@@ -1,0 +1,90 @@
+import { request, APIRequestContext } from "@playwright/test";
+
+export interface EntityCounts {
+  titles: number;
+  volumes: number;
+  contributors: number;
+  borrowers: number;
+  active_loans: number;
+}
+
+/**
+ * CR #43 — Snapshot the key entity counts surfaced by `/admin/health`.
+ *
+ * Used to PROVE that a 4xx/3xx rejected mutation (CSRF rejection,
+ * unauthorized redirect, role-gate refusal) actually left the DB
+ * untouched. Status-code-only assertions cannot catch a future
+ * regression where the middleware rejects with the right status while
+ * the mutation also fires — `expect(after).toEqual(before)` does.
+ *
+ * The helper spins up its own `APIRequestContext` authenticated as
+ * Admin so the caller test can keep its own cookie state (typically
+ * anonymous) intact. The auth + fetch + dispose round-trip costs ~150 ms.
+ *
+ * Counts are scraped from the admin/health HTML fragment in the
+ * project-locked render order (titles, volumes, contributors,
+ * borrowers, active_loans) — see `templates/fragments/admin_health_panel.html`.
+ * APP_LANGUAGE in `docker-compose.test.yml` is pinned to `en`, so the
+ * regex does not need to be locale-aware.
+ *
+ * @param baseURL — passed via `testInfo.project.use.baseURL`
+ * @throws on auth failure or unexpected admin/health markup shape
+ */
+export async function captureEntityCounts(baseURL: string): Promise<EntityCounts> {
+  const ctx: APIRequestContext = await request.newContext({ baseURL });
+  try {
+    // Login as admin — mirror loginAs() helper. CSRF token sits on the
+    // /login form as a hidden input; we scrape it before posting.
+    const loginHtml = await (await ctx.get("/login")).text();
+    const csrfMatch = /name="_csrf_token"\s+value="([^"]+)"/.exec(loginHtml);
+    if (!csrfMatch) {
+      throw new Error("captureEntityCounts: _csrf_token not found on /login");
+    }
+    const csrf = csrfMatch[1];
+
+    const username = process.env.TEST_ADMIN_USERNAME ?? "admin";
+    const password = process.env.TEST_ADMIN_PASSWORD ?? "admin";
+    const loginResp = await ctx.post("/login", {
+      form: { _csrf_token: csrf, username, password },
+      maxRedirects: 0,
+      failOnStatusCode: false,
+    });
+    if (loginResp.status() !== 303) {
+      throw new Error(
+        `captureEntityCounts: admin login failed (status ${loginResp.status()})`,
+      );
+    }
+
+    // Fetch admin/health as an HTMX fragment to skip the surrounding
+    // page chrome. Falls back to the full page if HX-Request handling
+    // ever changes — the regex below works against either shape.
+    const panelResp = await ctx.get("/admin/health", {
+      headers: { "HX-Request": "true" },
+    });
+    const html = await panelResp.text();
+
+    // Parse the 5 count cells. Stable hook is `class="…font-mono…">123</td>`
+    // — same `font-mono` class the project uses everywhere for numeric
+    // cells; locked by `templates/fragments/admin_health_panel.html`.
+    const re = /font-mono[^>]*>\s*([\d,]+)\s*<\/td>/g;
+    const matches: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(html)) !== null) {
+      matches.push(parseInt(m[1].replace(/,/g, ""), 10));
+    }
+    if (matches.length < 5) {
+      throw new Error(
+        `captureEntityCounts: expected ≥5 numeric cells in admin/health, got ${matches.length}`,
+      );
+    }
+    return {
+      titles: matches[0],
+      volumes: matches[1],
+      contributors: matches[2],
+      borrowers: matches[3],
+      active_loans: matches[4],
+    };
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/tests/e2e/specs/journeys/admin-permanent-delete.spec.ts
+++ b/tests/e2e/specs/journeys/admin-permanent-delete.spec.ts
@@ -1,126 +1,145 @@
-import { test, expect } from '@playwright/test';
-import { loginAs } from '../../helpers/auth';
+import { test, expect, Page } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
 
-const spec_id = 'PD'; // Permanent Delete
+// CR #62 — Rewrite of the 8-7 P9 spec. The original wrapped every
+// assertion in `if (tableExists) { if (btnExists) { ... } }`, which
+// silently no-op'd on a fresh DB and violated Foundation Rules #3 / #7.
+//
+// Each test now seeds its OWN soft-deleted series (simplest entity to
+// soft-delete via UI: no FK dependencies, owns the UX-DR8 delete modal
+// since story 9-13). The tests then exercise the permanent-delete
+// modal contracts against that seeded row.
+//
+// Auto-purge on startup (original Scenario 2) is covered by the Rust
+// integration tests in `tests/admin_auto_purge_*.rs`; the last-admin
+// guard (original Scenario 3) is covered by
+// `src/models/user.rs::test_deactivate_last_admin_is_blocked` and
+// `tests/admin_user_deactivate_modal.rs`. Both involve restart-cycle
+// or admin-user scaffolding that doesn't fit the E2E shape.
 
-test.describe('Story 8-7: Permanent Delete & Auto-Purge', () => {
+/** Seed a soft-deleted series and return its display name. */
+async function seedSoftDeletedSeries(page: Page, slug: string): Promise<string> {
+  const name = `PD-${slug}-${Date.now()}`;
+  await page.goto("/series/new");
+  await page.locator("#series-name").fill(name);
+  await page.locator('main button[type="submit"]').last().click();
+  await page.waitForURL(/\/series\/\d+/);
+
+  // Series detail page → click Delete → UX-DR8 modal opens → Confirm
+  const deleteBtn = page.getByRole("button", { name: /delete|supprimer/i });
+  await deleteBtn.click();
+  await expect(page.locator("#modal-slot dialog[open]")).toBeVisible();
+  await page.locator("[data-modal-confirm]").click();
+  // Series delete success redirects to /series
+  await page.waitForURL("**/series", { timeout: 5000 });
+  return name;
+}
+
+/** Navigate to /admin?tab=trash filtered to series and locate the row by name. */
+async function openTrashAndFindRow(page: Page, name: string) {
+  await page.goto("/admin?tab=trash", { waitUntil: "domcontentloaded" });
+  await expect(
+    page.locator('section[aria-labelledby="admin-trash-heading"]'),
+  ).toBeVisible({ timeout: 10000 });
+  // Filter to series to keep the DOM scoped
+  await page.locator("#filter-entity-type").selectOption("series");
+  // The HTMX swap replaces #admin-trash-panel — wait for the table row
+  const row = page.locator("tbody tr").filter({ hasText: name });
+  await expect(row).toBeVisible({ timeout: 10000 });
+  return row;
+}
+
+test.describe("Story 8-7: Permanent Delete & Auto-Purge", () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, 'admin');
+    await loginAs(page, "admin");
   });
 
-  test('SC1: Permanent delete requires confirmation modal with name friction', async ({
+  test("SC1: permanent-delete modal blocks confirm until exact name is typed", async ({
     page,
   }) => {
-    // Navigate directly to trash (assuming pre-existing soft-deleted items from other tests)
-    await page.goto('/admin?tab=trash', { waitUntil: 'domcontentloaded' });
-    // Wait for the trash panel section to land — replaces an arbitrary 3s sleep.
+    const name = await seedSoftDeletedSeries(page, "SC1");
+    const row = await openTrashAndFindRow(page, name);
+
+    // Click "Delete permanently" on our row → modal opens
+    const deleteBtn = row.locator("button[data-modal-trigger]");
+    await expect(deleteBtn).toBeVisible();
+    await deleteBtn.click();
+
+    const modal = page.locator("#modal-slot dialog[open]");
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await expect(modal).toContainText(/cannot be undone|impossible|irreversible/i);
+
+    // Confirm is disabled by default — name friction is the whole point
+    const confirmBtn = modal.locator("[data-modal-confirm]");
+    await expect(confirmBtn).toBeDisabled();
+
+    // Wrong name leaves it disabled
+    const input = modal.locator('input[type="text"]');
+    await input.fill("definitely not the right name");
+    await expect(confirmBtn).toBeDisabled();
+
+    // Typing the correct name enables it (locks the predicate end-to-end)
+    await input.clear();
+    await input.fill(name);
+    await expect(confirmBtn).toBeEnabled();
+
+    // Cancel without committing — leaves the row in trash for cleanup.
+    // `data-modal-cancel` is unambiguous here; `data-modal-default-focus`
+    // is also on the type-to-confirm input in this UX-DR8 macro variant.
+    const cancelBtn = modal.locator("[data-modal-cancel]");
+    await cancelBtn.click();
+    await expect(page.locator("#modal-slot dialog[open]")).not.toBeVisible();
+  });
+
+  test("SC2: permanent-delete with correct name removes the row and surfaces feedback", async ({
+    page,
+  }) => {
+    const name = await seedSoftDeletedSeries(page, "SC2");
+    const row = await openTrashAndFindRow(page, name);
+
+    await row.locator("button[data-modal-trigger]").click();
+    const modal = page.locator("#modal-slot dialog[open]");
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Type the exact name → confirm enables → click → modal closes
+    await modal.locator('input[type="text"]').fill(name);
+    const confirmBtn = modal.locator("[data-modal-confirm]");
+    await expect(confirmBtn).toBeEnabled();
+    await confirmBtn.click();
+
+    // Success path: server returns a fresh trash panel without our row
+    // (and may also emit a feedback entry).
+    await expect(page.locator("#modal-slot dialog[open]")).not.toBeVisible({
+      timeout: 5000,
+    });
     await expect(
-      page.locator('section[aria-labelledby="admin-trash-heading"]'),
-    ).toBeVisible({ timeout: 10000 });
-
-    // If there are items in trash, test the permanent delete modal
-    const trashTable = page.locator('table');
-    const tableExists = await trashTable.isVisible({ timeout: 5000 }).catch(() => false);
-
-    if (tableExists) {
-      const firstDeleteBtn = page.locator('button:has-text("Delete permanently")').first();
-      const btnExists = await firstDeleteBtn.isVisible({ timeout: 5000 }).catch(() => false);
-
-      if (btnExists) {
-        await firstDeleteBtn.click();
-
-        // Verify modal appears with name input
-        const modal = page.locator('dialog[open]');
-        await expect(modal).toBeVisible({ timeout: 5000 });
-        await expect(modal).toContainText(/cannot be undone/i);
-
-        // Verify confirm button is disabled until user types correct name
-        const confirmBtn = modal.locator('button[type="submit"]');
-        await expect(confirmBtn).toBeDisabled();
-
-        // Type wrong name - button should stay disabled
-        const input = modal.locator('input[type="text"]');
-        await input.fill('Wrong Name');
-        await expect(confirmBtn).toBeDisabled();
-
-        // Close modal and skip the rest if we can't get the correct name
-        const cancelBtn = modal.locator('button:has-text("Cancel")');
-        await cancelBtn.click();
-      }
-    }
-
-    // If no items in trash, the test passes (smoke test for modal structure)
+      page.locator("tbody tr").filter({ hasText: name }),
+    ).toHaveCount(0, { timeout: 5000 });
   });
 
-  test('SC2: Permanent delete modal name validation works correctly', async ({
+  test("SC3: trash UI structure renders and filter interaction updates the list", async ({
     page,
   }) => {
-    // Navigate to trash
-    await page.goto('/admin?tab=trash', { waitUntil: 'domcontentloaded' });
-    await expect(
-      page.locator('section[aria-labelledby="admin-trash-heading"]'),
-    ).toBeVisible({ timeout: 10000 });
+    await page.goto("/admin?tab=trash", { waitUntil: "domcontentloaded" });
 
-    // If there are items in trash, test name validation
-    const trashTable = page.locator('table');
-    const tableExists = await trashTable.isVisible({ timeout: 5000 }).catch(() => false);
+    const panel = page.locator('section[aria-labelledby="admin-trash-heading"]');
+    await expect(panel).toBeVisible({ timeout: 10000 });
 
-    if (tableExists) {
-      const deleteBtn = page.locator('button:has-text("Delete permanently")').first();
-      const btnExists = await deleteBtn.isVisible({ timeout: 5000 }).catch(() => false);
+    // Structural locks from the original spec (these still fail loudly
+    // if the trash panel chrome regresses).
+    await expect(page.locator("#admin-trash-heading")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("#filter-entity-type")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("#search-trash")).toBeVisible({ timeout: 5000 });
 
-      if (btnExists) {
-        // Get the item name from the table cell for later comparison
-        const firstItemCell = page.locator('tbody tr').first().locator('td').first();
-        const itemName = await firstItemCell.textContent({ timeout: 5000 });
-
-        await deleteBtn.click();
-
-        const modal = page.locator('dialog[open]');
-        await expect(modal).toBeVisible({ timeout: 5000 });
-
-        const input = modal.locator('input[type="text"]');
-        const confirmBtn = modal.locator('button[type="submit"]');
-
-        // Test that wrong name keeps button disabled
-        if (itemName) {
-          await input.fill('Wrong Name');
-          await expect(confirmBtn).toBeDisabled();
-
-          // Test that correct name enables button
-          await input.clear();
-          await input.fill(itemName);
-          // Note: button should now be enabled (but we don't click to avoid deleting)
-        }
-
-        // Cancel modal
-        const cancelBtn = modal.locator('button:has-text("Cancel")');
-        await cancelBtn.click();
-      }
-    }
-  });
-
-  test('SC3: Trash list UI renders properly', async ({
-    page,
-  }) => {
-    // Navigate to trash panel
-    await page.goto('/admin?tab=trash', { waitUntil: 'domcontentloaded' });
-
-    // Verify the trash panel exists — `toBeVisible` with timeout replaces the
-    // arbitrary 3s sleep (CI grep gate forbids `waitForTimeout`).
-    const trashPanel = page.locator('section[aria-labelledby="admin-trash-heading"]');
-    await expect(trashPanel).toBeVisible({ timeout: 10000 });
-
-    // Verify heading exists
-    const heading = page.locator('#admin-trash-heading');
-    await expect(heading).toBeVisible({ timeout: 5000 });
-
-    // Verify filters exist
-    const filterSelect = page.locator('#filter-entity-type');
-    await expect(filterSelect).toBeVisible({ timeout: 5000 });
-
-    // Verify search input exists
-    const searchInput = page.locator('#search-trash');
-    await expect(searchInput).toBeVisible({ timeout: 5000 });
+    // Filter interaction lock — selecting a filter must trigger the
+    // HTMX swap that re-renders the panel with the filter `selected`.
+    await page.locator("#filter-entity-type").selectOption("series");
+    await expect(page.locator("#filter-entity-type")).toHaveValue("series", {
+      timeout: 5000,
+    });
+    // Either the table has rows OR the empty-state appears — either is
+    // valid post-swap, but the page must not be in an in-flight state.
+    const swapped = page.locator("#admin-trash-panel");
+    await expect(swapped).toBeVisible();
   });
 });

--- a/tests/e2e/specs/journeys/admin-system-settings.spec.ts
+++ b/tests/e2e/specs/journeys/admin-system-settings.spec.ts
@@ -233,4 +233,111 @@ test.describe("Story 8-5 — Admin System Settings", () => {
     const location = resp.headers()["location"];
     expect(location).toMatch(/^\/login\?next=/);
   });
+
+  // CR #88 — Story 8-5 subtask 8.5 was prematurely checked off and
+  // reverted in code review; this E2E was never written. Validates
+  // **AC #6**: the partitioned optimistic-locking design (one `version`
+  // column PER settings row) means concurrent admin edits to DIFFERENT
+  // settings rows MUST NOT collide. A whole-table lock would have
+  // bounced one of them with 409 "modified by another admin"; a
+  // per-row lock lets both succeed.
+  test("cross-row concurrent edits to different settings don't collide (AC #6)", async ({
+    browser,
+  }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    const pageB = await ctxB.newPage();
+
+    try {
+      await loginAs(pageA, "admin");
+      await loginAs(pageB, "admin");
+
+      await pageA.goto("/admin?tab=system");
+      await pageB.goto("/admin?tab=system");
+
+      // Context A: queue the loans-form change (overdue threshold row)
+      const thresholdInput = pageA.locator(
+        'form#admin-system-loans-form input[name="overdue_threshold_days"]',
+      );
+      await expect(thresholdInput).toBeVisible();
+      await thresholdInput.fill("21");
+
+      // Context B: queue the providers-form change (Google Books key row)
+      const newKey = uniqueSlug("CR88_AAAA");
+      const gbInput = pageB.locator(
+        'form#admin-system-providers-form input[name="google_books_api_key"]',
+      );
+      await expect(gbInput).toBeVisible();
+      await gbInput.fill(newKey);
+
+      // Submit both nearly concurrently. Promise.all guarantees the two
+      // POSTs are dispatched before either resolves — a serialized
+      // whole-table lock would bounce one of them with 409.
+      await Promise.all([
+        pageA
+          .locator('form#admin-system-loans-form button[type="submit"]')
+          .click(),
+        pageB
+          .locator('form#admin-system-providers-form button[type="submit"]')
+          .click(),
+      ]);
+
+      // Both success feedbacks visible — proves neither was rejected
+      // with 409 / "modified by another admin".
+      await expect(
+        pageA
+          .locator("#feedback-list")
+          .getByText(/Loans settings saved|Préférences de prêt enregistrées/i),
+      ).toBeVisible({ timeout: 10000 });
+      await expect(
+        pageB
+          .locator("#feedback-list")
+          .getByText(/Google Books key saved|Clé Google Books enregistrée/i),
+      ).toBeVisible({ timeout: 10000 });
+
+      // Persistence proof — reload each context and verify the value
+      // (or mask, for the Google Books key) survived.
+      await pageA.goto("/admin?tab=system");
+      await expect(thresholdInput).toHaveValue("21");
+
+      await pageB.goto("/admin?tab=system");
+      const last4 = newKey.slice(-4);
+      await expect(
+        pageB
+          .locator("form#admin-system-providers-form")
+          .getByText(new RegExp(`••••${last4}`)),
+      ).toBeVisible();
+
+      // Reset both rows to keep cross-test isolation (loans → 30 days,
+      // Google Books key → cleared via the checkbox).
+      await thresholdInput.fill("30");
+      await pageA
+        .locator('form#admin-system-loans-form button[type="submit"]')
+        .click();
+      await expect(
+        pageA
+          .locator("#feedback-list")
+          .getByText(/Loans settings saved|Préférences de prêt enregistrées/i)
+          .last(),
+      ).toBeVisible({ timeout: 10000 });
+
+      await pageB
+        .locator(
+          'form#admin-system-providers-form input[name="_clear_google_books"]',
+        )
+        .check();
+      await pageB
+        .locator('form#admin-system-providers-form button[type="submit"]')
+        .click();
+      await expect(
+        pageB
+          .locator("#feedback-list")
+          .getByText(/Google Books key cleared|Clé Google Books effacée/i),
+      ).toBeVisible({ timeout: 10000 });
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
 });

--- a/tests/e2e/specs/journeys/admin-system-settings.spec.ts
+++ b/tests/e2e/specs/journeys/admin-system-settings.spec.ts
@@ -25,6 +25,16 @@ function uniqueSlug(prefix: string): string {
 }
 
 test.describe("Story 8-5 — Admin System Settings", () => {
+  // CR #88 + #89: tests in this describe mutate global K/V rows in the
+  // `settings` table (default_language, overdue_threshold_days, Google
+  // Books key). Running them in parallel produces cross-test
+  // interleaving where one test's "reset to default" happens between
+  // another test's "set value" and "verify value" steps — observed as
+  // intermittent flakes on the 3 default-language branches. Serializing
+  // the whole describe trades ~30 s of CI time for zero flake risk on
+  // shared-state mutators.
+  test.describe.configure({ mode: "serial" });
+
   test.beforeEach(async ({ page }) => {
     await page.context().clearCookies();
   });
@@ -232,6 +242,123 @@ test.describe("Story 8-5 — Admin System Settings", () => {
     expect(resp.status()).toBe(303);
     const location = resp.headers()["location"];
     expect(location).toMatch(/^\/login\?next=/);
+  });
+
+  // CR #89 — Story 8-5 subtask 8.6: the locale resolution chain (story
+  // 7-3) has FOUR branches. Only "no-match Accept-Language → default
+  // fallback" was covered (`default language change affects fresh
+  // anonymous visitor`). These two tests close branches 2 and 3:
+  //   2. Accept-Language match wins over default-language
+  //   3. Authenticated user's preferred_language wins over default
+  test("Accept-Language match wins over default-language for anonymous (AC #4)", async ({
+    page,
+    browser,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    // Set default to en — the test wants to confirm Accept-Language=fr
+    // STILL produces FR despite default being en.
+    await page
+      .locator(
+        'form#admin-system-language-form input[name="default_language"][value="en"]',
+      )
+      .check();
+    await page
+      .locator('form#admin-system-language-form button[type="submit"]')
+      .click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/Default language saved|Langue par défaut enregistrée/i),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Fresh context, no cookies, Accept-Language: fr
+    const ctx = await browser.newContext({ locale: "fr" });
+    const fresh = await ctx.newPage();
+    await fresh.goto("/");
+    const lang = await fresh.locator("html").getAttribute("lang");
+    expect(lang).toBe("fr");
+    await ctx.close();
+
+    // Reset default to fr for cross-test isolation.
+    await page.goto("/admin?tab=system");
+    await page
+      .locator(
+        'form#admin-system-language-form input[name="default_language"][value="fr"]',
+      )
+      .check();
+    await page
+      .locator('form#admin-system-language-form button[type="submit"]')
+      .click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/Default language saved|Langue par défaut enregistrée/i),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("authenticated user preferred_language wins over default (AC #4)", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+
+    // Step 1: persist admin's preferred_language = fr via POST /language.
+    // Mirrors what the nav-bar language <select> auto-submit does. Uses
+    // the page's CSRF token + cookie context — no DB direct access.
+    const csrf1 = await page
+      .locator('meta[name="csrf-token"]')
+      .getAttribute("content");
+    expect(csrf1).toBeTruthy();
+    const langResp = await page.request.post("/language", {
+      form: { _csrf_token: csrf1!, lang: "fr", next: "/" },
+      maxRedirects: 0,
+      failOnStatusCode: false,
+    });
+    // 303 to the redirect target on success (validated lang + CSRF)
+    expect(langResp.status()).toBe(303);
+
+    // Step 2: change default to en. User pref is fr; default is now en;
+    // the resolver must pick fr (user pref wins).
+    await page.goto("/admin?tab=system");
+    await page
+      .locator(
+        'form#admin-system-language-form input[name="default_language"][value="en"]',
+      )
+      .check();
+    await page
+      .locator('form#admin-system-language-form button[type="submit"]')
+      .click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/Default language saved|Langue par défaut enregistrée/i),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Step 3: navigate to / — html[lang] must reflect the user pref, not
+    // the new default. (Page reload re-runs the locale-resolution chain.)
+    await page.goto("/");
+    const lang = await page.locator("html").getAttribute("lang");
+    expect(lang).toBe("fr");
+
+    // Reset default to fr for cross-test isolation. (Admin's
+    // preferred_language stays = fr; future loginAs(admin) sessions will
+    // therefore resolve to fr, which matches the seed default behavior
+    // anyway, so no further test depends on it being NULL.)
+    await page.goto("/admin?tab=system");
+    await page
+      .locator(
+        'form#admin-system-language-form input[name="default_language"][value="fr"]',
+      )
+      .check();
+    await page
+      .locator('form#admin-system-language-form button[type="submit"]')
+      .click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/Default language saved|Langue par défaut enregistrée/i),
+    ).toBeVisible({ timeout: 10000 });
   });
 
   // CR #88 — Story 8-5 subtask 8.5 was prematurely checked off and

--- a/tests/e2e/specs/journeys/catalog-contributor.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-contributor.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
 import { specIsbn } from "../../helpers/isbn";
+import { captureEntityCounts } from "../../helpers/db-snapshot";
 
 const VALID_ISBN = specIsbn("CC", 1);
 
@@ -321,10 +322,21 @@ test.describe("Contributor Management", () => {
   // token POSTs with a 403 BEFORE the auth layer can issue its 303. The
   // end user still cannot mutate anything (DB snapshot unchanged) —
   // either outcome satisfies the original AC #1 + #3 assertion.
-  test("anonymous user cannot POST to contributor endpoints", async ({
+  //
+  // CR #43: the status-code assertion alone cannot catch a future
+  // regression where CSRF / auth silently passes through while the
+  // mutation also runs. The before/after `captureEntityCounts` snapshot
+  // PROVES the DB was untouched.
+  test("anonymous user cannot POST to contributor endpoints (DB unchanged)", async ({
     context,
     page,
-  }) => {
+  }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Snapshot key entity counts BEFORE — via a separate admin-authenticated
+    // APIRequestContext so the upcoming clearCookies() doesn't strip it.
+    const before = await captureEntityCounts(baseURL);
+
     await context.clearCookies();
     const resp = await page.request.post("/catalog/contributors/add", {
       form: { title_id: "1", contributor_name: "Anon", role_id: "1" },
@@ -338,6 +350,10 @@ test.describe("Contributor Management", () => {
     // a fully-rendered page rather than a bare feedback fragment. Either
     // outcome satisfies AC #1 + #3 — the request did not mutate anything.
     expect([303, 403]).toContain(resp.status());
+
+    // CR #43 DB-snapshot proof: counts unchanged after the rejected POST.
+    const after = await captureEntityCounts(baseURL);
+    expect(after).toEqual(before);
   });
 });
 

--- a/tests/e2e/specs/journeys/home.spec.ts
+++ b/tests/e2e/specs/journeys/home.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+import { scanTitleAndVolume } from "../../helpers/loans";
 
 test.describe("Home page", () => {
   test("should display mybibli title", async ({ page }) => {
@@ -181,18 +183,22 @@ test.describe("Home page — What needs attention / Unshelved indicator", () => 
     page,
   }) => {
     await loginAs(page, "librarian");
+
+    // CR #119 — seed an unshelved volume INSIDE the test (catalog scan
+    // creates a volume with NULL location_id, which IS unshelved by AC3
+    // definition). Without this seed, the original test silently
+    // no-op'd on a clean CI DB and a regression breaking the
+    // #unshelved-list rendering would NOT be caught (Foundation Rule
+    // #7 violation).
+    const isbn = specIsbn("UH", 1);
+    // 4-digit V-code unique per test run; helper expects `V` prefix.
+    const vcode = `V${(Date.now() % 9000 + 1000).toString()}`;
+    await scanTitleAndVolume(page, isbn, vcode);
+
     await page.goto("/");
 
     const section = page.locator("#what-needs-attention");
-    const sectionCount = await section.count();
-    if (sectionCount === 0) {
-      // Seed DB has zero unshelved volumes — section is hidden by AC3
-      // zero-count rule. Same defensive empty-DB short-circuit pattern
-      // as 9-2/9-3 E2E tests.
-      return;
-    }
-
-    await expect(section).toBeVisible();
+    await expect(section).toBeVisible({ timeout: 5000 });
     await expect(section.getByRole("heading", { level: 2 })).toContainText(
       /What needs attention|À traiter/i,
     );
@@ -243,15 +249,25 @@ test.describe("Home page — Overdue loans indicator", () => {
     await loginAs(page, "librarian");
     await page.goto("/");
 
-    // Conditional empty-DB short-circuit — same defensive pattern as
-    // the 9-4 unshelved smoke test. Seed DB may or may not contain
-    // overdue loans depending on fixture freshness.
+    // CR #119 — Foundation Rule #7 partial fix. The unshelved indicator
+    // (9-4) is now properly seeded above via scanTitleAndVolume. The
+    // overdue indicator requires backdating `loans.loaned_at` past the
+    // overdue threshold (default 30 days) — UI-only seeding cannot
+    // travel time, and the test DB does not expose port 3306 for
+    // direct SQL. Properly closing this gap needs either:
+    //   (a) a TEST_MODE-gated POST /debug/seed-overdue-loan endpoint, or
+    //   (b) port-exposing the test DB + a mysql2 npm dep.
+    // Both expand scope beyond the v1.7.7 test-rigor bundle; tracking
+    // separately as a follow-up. Until then, this test runs an
+    // assertion path only when seeded data happens to exist (skipped
+    // explicitly via test.skip on empty so the CI report shows the
+    // gap, not a silent green).
     const tag = page.locator("#filter-tag-overdue");
     const tagCount = await tag.count();
-    if (tagCount === 0) {
-      // No overdue loans seeded — AC3 zero-count rule hides the tag.
-      return;
-    }
+    test.skip(
+      tagCount === 0,
+      "Overdue-loan seeding requires TEST_MODE endpoint or DB exposure — tracked as follow-up to #119.",
+    );
 
     await expect(tag).toBeVisible();
     // Default state — href targets the indicator filter URL.

--- a/tests/e2e/specs/journeys/series.spec.ts
+++ b/tests/e2e/specs/journeys/series.spec.ts
@@ -326,6 +326,76 @@ test.describe("Series Assignment & Gap Detection (Story 5-4)", () => {
     await page.waitForURL(/\/title\/\d+/);
   });
 
+  // CR #336 — series-detail card layout: filled cells render as cards
+  // with cover (or fallback icon), "Vol. N" label, and title name.
+  // Empty positions also surface "Vol. N" alongside the missing marker.
+  test("series detail renders card grid with covers, Vol. N, and title", async ({
+    page,
+  }) => {
+    const SERIES_NAME = `SE-Cards-${Date.now()}`;
+    // seq=40 to avoid collision with positions used by the surrounding tests
+    const ISBN = specIsbn("SE", 40);
+
+    // Create closed series with total=3
+    await page.goto("/series/new");
+    await page.locator("#series-name").fill(SERIES_NAME);
+    await page.locator("#series-type").selectOption("closed");
+    await page.locator("#series-total").fill("3");
+    await page.locator('main button[type="submit"]').last().click();
+    await page.waitForURL(/\/series\/\d+/);
+    const seriesUrl = page.url();
+
+    // Create a title via scan
+    await page.goto("/catalog");
+    await page.locator("#scan-field").fill(ISBN);
+    await page.locator("#scan-field").press("Enter");
+    await expect(
+      page.locator(".feedback-entry, .feedback-skeleton"),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Navigate to the title via home search and assign to position 2
+    await page.goto(`/?q=${ISBN}`);
+    const titleLink = page
+      .locator(
+        "#browse-results table.browse-table tbody tr td a[href^='/title/']",
+      )
+      .first();
+    await expect(titleLink).toBeVisible({ timeout: 15000 });
+    const titleHref = (await titleLink.getAttribute("href"))!;
+    await page.goto(titleHref);
+    await page.waitForURL(/\/title\/\d+/);
+
+    await page.locator("#assign-series").selectOption({ label: SERIES_NAME });
+    await page.locator("#assign-position").fill("2");
+    await page.locator("#assign-series-submit").click();
+    await page.waitForURL(/\/title\/\d+/);
+
+    // Visit series detail and inspect the card grid
+    await page.goto(seriesUrl);
+    const grid = page.locator('[role="grid"]');
+    await expect(grid).toBeVisible({ timeout: 5000 });
+
+    // All 3 positions render as cells (preserves existing ARIA contract)
+    const cells = grid.locator('[role="gridcell"]');
+    await expect(cells).toHaveCount(3);
+
+    // The filled position (#2) is an <a> card and contains an <img>
+    // (either the downloaded cover or the media-type SVG fallback)
+    const filledCard = grid.locator("a[role='gridcell']");
+    await expect(filledCard).toHaveCount(1);
+    await expect(filledCard.locator("img")).toHaveCount(1);
+
+    // The card surfaces "Vol. 2" (EN+FR+IT) or "Bd. 2" (DE)
+    await expect(filledCard).toContainText(/Vol\.\s*2|Bd\.\s*2/);
+
+    // Gap cards (#1 and #3) also surface "Vol. 1" / "Vol. 3" so the
+    // collector can see which slots are missing at a glance
+    const gapCards = grid.locator("div[role='gridcell']");
+    await expect(gapCards).toHaveCount(2);
+    await expect(gapCards.nth(0)).toContainText(/Vol\.\s*1|Bd\.\s*1/);
+    await expect(gapCards.nth(1)).toContainText(/Vol\.\s*3|Bd\.\s*3/);
+  });
+
   // AC6: Omnibus covering 3 positions fills gap grid
   test("omnibus assignment fills multiple positions in gap grid", async ({
     page,

--- a/tests/setup_wizard.rs
+++ b/tests/setup_wizard.rs
@@ -255,6 +255,105 @@ async fn step_1_rejects_short_password(pool: DbPool) {
     assert_eq!(count.0, 0, "no active admin row after rejected Step 1");
 }
 
+/// CR #96 — AC13 concurrent first-launch race. Two browsers race
+/// through Step 1 with the SAME username; the in-tx COUNT-and-INSERT
+/// guard (defense-in-depth) AND the underlying `uq_users_username`
+/// constraint (the actual enforcement) together must produce exactly
+/// one admin row.
+///
+/// Different-username races (where both browsers happen to pick
+/// non-colliding names) are NOT covered here — under MariaDB
+/// REPEATABLE READ both COUNTs see the pre-INSERT snapshot, both
+/// INSERTs succeed on distinct usernames, and the COUNT guard is
+/// circumvented. That's a known scope limitation of the explicit
+/// guard; the underlying correctness comes from the UNIQUE
+/// constraint which only catches identical names.
+///
+/// `#[sqlx::test]` provisions a multi-connection pool (default 10),
+/// so `tokio::spawn` × 2 against `router.clone()` exercises true
+/// concurrent execution.
+#[sqlx::test(migrations = "./migrations")]
+async fn step_1_concurrent_same_username_produces_one_admin(pool: DbPool) {
+    ensure_no_admin(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+
+    // Each "browser" needs its own anonymous session + CSRF — the
+    // sessions are minted sequentially because session-resolve
+    // middleware writes to `sessions` and we want both rows landed
+    // before the race begins.
+    let (cookie_a, csrf_a) = anonymous_session(&router, &pool).await;
+    let (cookie_b, csrf_b) = anonymous_session(&router, &pool).await;
+    assert_ne!(cookie_a, cookie_b, "browsers must hold distinct sessions");
+
+    let body_a = format!(
+        "_csrf_token={csrf_a}&username=race_admin&password=race_pass_8chars&_back=0"
+    );
+    let body_b = format!(
+        "_csrf_token={csrf_b}&username=race_admin&password=race_pass_8chars&_back=0"
+    );
+
+    let router_a = router.clone();
+    let router_b = router.clone();
+    let handle_a = tokio::spawn(async move {
+        router_a
+            .oneshot(
+                Request::post("/setup/step-1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("cookie", &cookie_a)
+                    .body(Body::from(body_a))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    });
+    let handle_b = tokio::spawn(async move {
+        router_b
+            .oneshot(
+                Request::post("/setup/step-1")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("cookie", &cookie_b)
+                    .body(Body::from(body_b))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    });
+    let (res_a, res_b) = (handle_a.await.unwrap(), handle_b.await.unwrap());
+
+    // Exactly ONE 303 winner. The other is either:
+    //   - 409 from `username_taken` when both txs raced past the COUNT
+    //     and the UNIQUE caught the second INSERT, OR
+    //   - 303 from `admin_already_created` when the second tx began
+    //     AFTER the first committed (count = 1 → ROLLBACK + flash).
+    // We tolerate both loser shapes; what matters is the row count.
+    let statuses = [res_a.status(), res_b.status()];
+    let count_303 = statuses.iter().filter(|s| **s == StatusCode::SEE_OTHER).count();
+    let count_409 = statuses.iter().filter(|s| **s == StatusCode::CONFLICT).count();
+    assert!(
+        count_303 >= 1,
+        "at least one Step 1 POST must be the 303 winner; got {statuses:?}"
+    );
+    assert_eq!(
+        count_303 + count_409,
+        2,
+        "both responses must be 303 or 409; got {statuses:?}"
+    );
+
+    // The AC13 invariant: regardless of which loser shape fired,
+    // exactly ONE active admin row exists.
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM users \
+         WHERE role = 'admin' AND active = TRUE AND deleted_at IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        count.0, 1,
+        "AC13: exactly one admin row after concurrent Step 1 race"
+    );
+}
+
 /// AC8 — once `setup_completed_at` is written, GET /setup returns 404.
 #[sqlx::test(migrations = "./migrations")]
 async fn setup_returns_404_after_completion(pool: DbPool) {


### PR DESCRIPTION
## Summary

v1.7.7 patch bundle — 7 test-rigor code-review-findings + 1 user-visible CR.

## Issues addressed

### User-visible
- **#336** — Series detail card layout: cover + Vol. N + author for every position. Mobile-responsive (2-col on mobile scaling to 6-col on xl). Preserves the existing ARIA role="grid"/role="gridcell" contract so the 3 pre-existing E2E tests on series.spec.ts keep passing.

### Test rigor (Cat. 1, test-only changes, zero prod impact)
- **#43** — DB-snapshot helper + assertion on anonymous contributor POST. New captureEntityCounts(baseURL) helper proves the 403/303 rejection didn't mutate the DB.
- **#62** — Rewrite of 8-7 P9 spec: real seeded items + real assertions. Drops the silent `if (tableExists)` no-op pattern.
- **#88** — Cross-row concurrency E2E for admin system settings (AC #6 of story 8-5). Two browser.newContext() admin sessions race on different settings rows.
- **#89** — Backfill 2 missing locale-resolution-chain branches (AC #4 of story 8-5): Accept-Language wins over default, authenticated user pref wins over default. Serializes the spec describe to prevent shared-settings collisions.
- **#96** — AC13 concurrent first-launch race integration test (tests/setup_wizard.rs). Two tokio::spawn Step 1 POSTs with same username; asserts exactly one admin row.
- **#119** — Dashboard indicator E2E: unshelved fully seeded via scanTitleAndVolume; overdue gap explicitly tracked as follow-up #340 (requires TEST_MODE seed endpoint).
- **#120** — Template-layer lock for AC5 single-active-filter contract: two render unit tests assert that #browse-results carries no .browse-table / .title-card content when an indicator filter is active.

## Local validation

Per memory feedback-e2e-locally-before-push:
- cargo check clean
- cargo clippy --lib -- -D warnings clean
- cargo test --lib services::series:: — 19 pass (incl. new regression test)
- cargo test --lib templates_audit — 7 pass
- cargo test --test setup_wizard — 9 pass (incl. new #96 concurrency test)
- ./scripts/e2e-reset.sh && CI=true npx playwright test --workers=2 (5 affected specs) — **43 passed + 1 skipped** (overdue per design, see #340)

## Follow-up filed
- **#340** — Backfill overdue-loan seeding for home E2E (choice between TEST_MODE endpoint vs DB port exposure)

## Test plan

- [ ] CI gates all green
- [ ] After merge: visit /series/:id of a series with assigned titles → verify card grid with covers, Vol. N labels, and authors
- [ ] Verify gap cards still render with dashed border + Vol. N + "missing volume" marker
- [ ] Mobile viewport — verify 2-column layout (deviation from spec's 1-col, see #336 commit message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
