### PR TITLE
patch(v1.7.10): protect manually uploaded covers from refetch overwrite

### DIFF
--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -382,7 +382,10 @@ async fn add_author_contributor(
 /// refetch path skips the UPDATE entirely — applies to BOTH success
 /// (`Some(path)`) and download-failure (`None`) paths, so a failed provider
 /// download cannot blank out a manually uploaded cover.
-async fn update_cover_image_url(
+///
+/// `pub` to allow the integration test in `tests/cover_manual_survives_refetch.rs`
+/// to call this directly (mirrors the `do_update` carve-out for `metadata_fetch_race.rs`).
+pub async fn update_cover_image_url(
     pool: &DbPool,
     title_id: u64,
     local_path: Option<&str>,

--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -376,11 +376,33 @@ async fn add_author_contributor(
 }
 
 /// Update cover_image_url for a title (set to local path or NULL).
+///
+/// Honors `manually_edited_fields`: if the user uploaded a cover manually
+/// (which inserts `"cover_image_url"` into the set, see #335 + #347), the
+/// refetch path skips the UPDATE entirely — applies to BOTH success
+/// (`Some(path)`) and download-failure (`None`) paths, so a failed provider
+/// download cannot blank out a manually uploaded cover.
 async fn update_cover_image_url(
     pool: &DbPool,
     title_id: u64,
     local_path: Option<&str>,
 ) -> Result<(), AppError> {
+    let snapshot = match TitleModel::find_by_id(pool, title_id).await? {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    if snapshot
+        .parsed_manually_edited_fields()
+        .iter()
+        .any(|f| f == "cover_image_url")
+    {
+        tracing::debug!(
+            title_id = title_id,
+            "cover_image_url is manually edited; skipping refetch update"
+        );
+        return Ok(());
+    }
+
     sqlx::query(
         "UPDATE titles SET cover_image_url = ?, updated_at = NOW() \
          WHERE id = ? AND deleted_at IS NULL",

--- a/tests/cover_manual_survives_refetch.rs
+++ b/tests/cover_manual_survives_refetch.rs
@@ -1,0 +1,139 @@
+//! Issue #347 — guard against per-title metadata refetch silently overwriting a
+//! manually uploaded cover.
+//!
+//! Verifies:
+//!   - A title with `"cover_image_url"` in `manually_edited_fields` is NOT
+//!     updated by `update_cover_image_url(Some(new_path))` (success path).
+//!   - Same title is NOT blanked to NULL by `update_cover_image_url(None)`
+//!     (download-failure path).
+//!   - A title WITHOUT the flag still receives the new path (regression guard
+//!     so the fix doesn't break the normal refetch happy path).
+//!
+//! Run locally:
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test cover_manual_survives_refetch
+
+use mybibli::tasks::metadata_fetch::update_cover_image_url;
+use sqlx::MySqlPool;
+use sqlx::Row;
+
+async fn seed_title_with_cover(
+    pool: &MySqlPool,
+    title: &str,
+    cover_path: Option<&str>,
+    manually_edited_fields: Option<&str>,
+) -> u64 {
+    let result = sqlx::query(
+        "INSERT INTO titles (title, language, media_type, genre_id, cover_image_url, manually_edited_fields) \
+         VALUES (?, 'fr', 'book', 1, ?, ?)",
+    )
+    .bind(title)
+    .bind(cover_path)
+    .bind(manually_edited_fields)
+    .execute(pool)
+    .await
+    .expect("insert title");
+    result.last_insert_id()
+}
+
+async fn read_cover(pool: &MySqlPool, id: u64) -> Option<String> {
+    let row = sqlx::query("SELECT cover_image_url FROM titles WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("select cover");
+    row.try_get::<Option<String>, _>("cover_image_url")
+        .expect("decode cover_image_url")
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn manual_cover_survives_refetch_success_path(pool: MySqlPool) {
+    let id = seed_title_with_cover(
+        &pool,
+        "Manual Cover Title",
+        Some("/covers/manual_upload.jpg"),
+        Some(r#"["cover_image_url"]"#),
+    )
+    .await;
+
+    update_cover_image_url(&pool, id, Some("/covers/provider_fetched.jpg"))
+        .await
+        .expect("guarded update should succeed (skip)");
+
+    assert_eq!(
+        read_cover(&pool, id).await,
+        Some("/covers/manual_upload.jpg".to_string()),
+        "manually uploaded cover must not be overwritten by provider refetch"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn manual_cover_survives_refetch_failure_path(pool: MySqlPool) {
+    let id = seed_title_with_cover(
+        &pool,
+        "Manual Cover Title (failure path)",
+        Some("/covers/manual_upload.jpg"),
+        Some(r#"["cover_image_url"]"#),
+    )
+    .await;
+
+    // Simulate a failed provider download: caller invokes update_cover_image_url(None)
+    // to clear the column. The guard must prevent the manual cover from being NULLed.
+    update_cover_image_url(&pool, id, None)
+        .await
+        .expect("guarded update should succeed (skip)");
+
+    assert_eq!(
+        read_cover(&pool, id).await,
+        Some("/covers/manual_upload.jpg".to_string()),
+        "failed provider download must not blank a manually uploaded cover"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn unguarded_cover_is_updated_normally(pool: MySqlPool) {
+    // Regression guard: a title WITHOUT cover_image_url in manually_edited_fields
+    // must still receive the new path — otherwise we'd have broken the happy path.
+    let id = seed_title_with_cover(
+        &pool,
+        "Auto-fetched Cover Title",
+        Some("/covers/old_provider.jpg"),
+        None,
+    )
+    .await;
+
+    update_cover_image_url(&pool, id, Some("/covers/new_provider.jpg"))
+        .await
+        .expect("update should succeed");
+
+    assert_eq!(
+        read_cover(&pool, id).await,
+        Some("/covers/new_provider.jpg".to_string()),
+        "non-guarded cover should be overwritten by a provider refetch"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn other_field_in_guard_set_does_not_block_cover_update(pool: MySqlPool) {
+    // Regression guard: only "cover_image_url" in the manual set should block.
+    // A title with e.g. ["title", "publisher"] but NOT "cover_image_url" must
+    // still see its cover refreshed normally.
+    let id = seed_title_with_cover(
+        &pool,
+        "Other Guards Only",
+        Some("/covers/old.jpg"),
+        Some(r#"["title","publisher"]"#),
+    )
+    .await;
+
+    update_cover_image_url(&pool, id, Some("/covers/new.jpg"))
+        .await
+        .expect("update should succeed");
+
+    assert_eq!(
+        read_cover(&pool, id).await,
+        Some("/covers/new.jpg".to_string()),
+        "guard on title/publisher must not bleed into cover protection"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #347 — `update_cover_image_url` in `src/tasks/metadata_fetch.rs` did an unconditional UPDATE that ignored `manually_edited_fields`, leaving manually uploaded covers vulnerable to silent overwrite.

## Scope analysis (precise post-fix)

The fix targets `update_cover_image_url`, used by the async metadata-fetch chain. After auditing all cover-touching code paths:

| Path | Status before | Status after |
|---|---|---|
| **Async fetch chain** (post-initial-scan background task) | Vulnerable to race with manual upload | **Fixed** (this PR) |
| **Bulk-refetch admin button** | Filtered by `list_missing_covers()` WHERE `cover_image_url IS NULL`, but a race between snapshot+upload was possible | **Fixed** (this PR — defense in depth) |
| **Per-title "Re-fetch metadata" button** | Already safe (when `manually_edited_fields` contains `cover_image_url`, the conflict-resolution branch is taken and never reaches `apply_metadata_to_title`'s inline cover UPDATE) | No change needed |

`apply_metadata_to_title` (`src/routes/titles.rs:1721`) has its own inline cover UPDATE without a guard, but is currently unreachable for the manual-cover scenario because its sole caller (`redownload_metadata`) gates it on `manually_edited_fields.is_empty()`. If future code adds another caller, that path will need a guard too. Not in scope for this patch.

## Implementation

`update_cover_image_url` now reads a fresh snapshot of the title row before the UPDATE, and skips if `cover_image_url` is in `parsed_manually_edited_fields()`. Fresh snapshot (not one passed down from `update_title_from_metadata`) because the cover-download phase runs after `do_update`, leaving a window where a manual upload would be missed by an upstream snapshot.

## Tests

Unit / integration (4 scenarios, `tests/cover_manual_survives_refetch.rs`):
- Success path: `update_cover_image_url(Some(new_path))` is a no-op when guarded
- Failure path: `update_cover_image_url(None)` does NOT blank a manual cover (critical — protects against provider download flakiness)
- Regression: title without the flag still receives the new path
- Specificity: `["title","publisher"]` in the set does not bleed into cover protection

All 976 lib unit tests + 5 `metadata_fetch_race` tests still green (no regression in the existing `manually_edited_fields` machinery).

E2E: not added. The user-facing per-title re-fetch button is protected by an upstream gate (conflict-resolution branch in `redownload_metadata`); an E2E exercising "upload + re-fetch" would pass with OR without this fix and add zero regression coverage. The race in the async chain is the actual scenario this fix protects, and it's not deterministically reproducible via E2E. Unit tests are the right level here.

## Local gate

- `SQLX_OFFLINE=true cargo check`
- `cargo clippy -- -D warnings`
- `cargo test --lib` → 976/976
- `cargo test --test cover_manual_survives_refetch --test metadata_fetch_race --test metadata_cache_force_refresh --test metadata_fetch_dewey` → 15/15

## Slot

v1.7.10 patch — small surgical fix (22 lines src + 139 lines test).
