### PR TITLE
test(ci): run all integration tests + fix 3 latent DB-backed failures

### DIFF
--- a/.github/workflows/_gates.yml
+++ b/.github/workflows/_gates.yml
@@ -104,18 +104,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run DB-backed integration tests
-        run: |
-          cargo test \
-            --test admin_audit_fk_set_null \
-            --test find_similar \
-            --test find_by_location_dewey \
-            --test metadata_fetch_dewey \
-            --test metadata_fetch_race \
-            --test seed_gate \
-            --test seeded_users \
-            --test setup_wizard \
-            --test system_user \
-            --test users_in_allowed_tables
+        # Auto-discover ALL integration test binaries (`--tests`) instead of a
+        # hardcoded `--test X` allowlist — a stale allowlist silently skipped 36
+        # of 46 tests/*.rs files, hiding real failures (see issue #357).
+        # --no-fail-fast so one red binary doesn't mask failures in later ones.
+        run: cargo test --tests --no-fail-fast
 
       - name: Collect MariaDB logs on failure
         if: failure() || cancelled()

--- a/tests/api_v1_auth.rs
+++ b/tests/api_v1_auth.rs
@@ -75,7 +75,7 @@ async fn seed_title(pool: &DbPool, title: &str) -> u64 {
     // default "Other" / "Roman" — but `migrations/` also runs a fresh
     // sequence per sqlx::test. Pick any active genre id by SELECT MIN.
     let (genre_id,): (i64,) = sqlx::query_as(
-        "SELECT MIN(id) FROM genres WHERE deleted_at IS NULL",
+        "SELECT CAST(MIN(id) AS SIGNED) FROM genres WHERE deleted_at IS NULL",
     )
     .fetch_one(pool)
     .await

--- a/tests/api_v1_patch_titles.rs
+++ b/tests/api_v1_patch_titles.rs
@@ -59,7 +59,7 @@ async fn seed_write_key(pool: &DbPool) -> String {
 
 async fn first_genre_id(pool: &DbPool) -> i64 {
     let (g,): (i64,) =
-        sqlx::query_as("SELECT MIN(id) FROM genres WHERE deleted_at IS NULL")
+        sqlx::query_as("SELECT CAST(MIN(id) AS SIGNED) FROM genres WHERE deleted_at IS NULL")
             .fetch_one(pool)
             .await
             .unwrap();
@@ -110,7 +110,7 @@ async fn patch_single_field_bumps_version_and_audits(pool: DbPool) {
         &router,
         &key,
         id,
-        serde_json::json!({"version": 0, "dewey_code": "813.54"}),
+        serde_json::json!({"version": 1, "dewey_code": "813.54"}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -118,7 +118,7 @@ async fn patch_single_field_bumps_version_and_audits(pool: DbPool) {
     let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024).await.unwrap();
     let dto: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(dto["dewey_code"], "813.54");
-    assert_eq!(dto["version"], 1, "version must bump from 0 → 1");
+    assert_eq!(dto["version"], 2, "version must bump from 1 → 2");
 
     // Audit row recorded.
     let (n,): (i64,) = sqlx::query_as(
@@ -147,7 +147,7 @@ async fn patch_explicit_null_clears_nullable_field(pool: DbPool) {
         &router,
         &key,
         id,
-        serde_json::json!({"version": 0, "subtitle": null}),
+        serde_json::json!({"version": 1, "subtitle": null}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -172,7 +172,7 @@ async fn patch_omitted_field_untouched(pool: DbPool) {
         &router,
         &key,
         id,
-        serde_json::json!({"version": 0, "dewey_code": "100"}),
+        serde_json::json!({"version": 1, "dewey_code": "100"}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -199,7 +199,7 @@ async fn patch_version_mismatch_returns_409(pool: DbPool) {
     let bytes = axum::body::to_bytes(res.into_body(), 4096).await.unwrap();
     let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(body["error"], "version_mismatch");
-    assert_eq!(body["expected"], 0);
+    assert_eq!(body["expected"], 1);
     assert_eq!(body["supplied"], 99);
 }
 
@@ -213,7 +213,7 @@ async fn patch_invalid_genre_returns_400(pool: DbPool) {
         &router,
         &key,
         id,
-        serde_json::json!({"version": 0, "genre_id": 999_999}),
+        serde_json::json!({"version": 1, "genre_id": 999_999}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -232,7 +232,7 @@ async fn patch_invalid_dewey_returns_400(pool: DbPool) {
         &router,
         &key,
         id,
-        serde_json::json!({"version": 0, "dewey_code": "abc; DROP TABLE titles"}),
+        serde_json::json!({"version": 1, "dewey_code": "abc; DROP TABLE titles"}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -250,7 +250,7 @@ async fn patch_missing_title_returns_404(pool: DbPool) {
         &router,
         &key,
         999_999_999,
-        serde_json::json!({"version": 0, "dewey_code": "100"}),
+        serde_json::json!({"version": 1, "dewey_code": "100"}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
@@ -267,7 +267,7 @@ async fn patch_no_changes_is_idempotent(pool: DbPool) {
         &router,
         &key,
         id,
-        serde_json::json!({"version": 0}),
+        serde_json::json!({"version": 1}),
     )
     .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -278,7 +278,7 @@ async fn patch_no_changes_is_idempotent(pool: DbPool) {
         .fetch_one(&pool)
         .await
         .unwrap();
-    assert_eq!(version, 0, "no-op PATCH must not bump version");
+    assert_eq!(version, 1, "no-op PATCH must not bump version");
 
     let (n,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM admin_audit WHERE action = 'api_patch_title' AND entity_id = ?",

--- a/tests/navbar_role_visibility.rs
+++ b/tests/navbar_role_visibility.rs
@@ -110,13 +110,17 @@ fn extract_desktop_nav(html: &str) -> String {
     // Walk PAST the opening `<nav` (4 bytes) so the depth-1 starting state
     // correctly accounts for the strip's own opening tag.
     let tail = &html[start + 4..];
+    // Scan over bytes — the nav HTML contains multi-byte UTF-8 (e.g. the `—`
+    // em-dash in "mybibli — home"), so byte-indexed `&str` slicing would panic
+    // on a non-char-boundary. All markers are ASCII, so byte comparison is exact.
+    let bytes = tail.as_bytes();
     let mut depth: i32 = 1;
     let mut pos = 0;
-    while pos < tail.len() {
-        if tail[pos..].starts_with("<nav") {
+    while pos < bytes.len() {
+        if bytes[pos..].starts_with(b"<nav") {
             depth += 1;
             pos += 4;
-        } else if tail[pos..].starts_with("</nav>") {
+        } else if bytes[pos..].starts_with(b"</nav>") {
             depth -= 1;
             pos += "</nav>".len();
             if depth == 0 {
@@ -141,13 +145,16 @@ fn extract_mobile_panel(html: &str) -> String {
         .find(start_marker)
         .expect("rendered HTML must contain the mobile-nav panel id");
     let tail = &html[start..];
+    // Byte-indexed scan — see extract_desktop_nav: multi-byte UTF-8 in the
+    // panel would make `&str` slicing panic on a non-char-boundary.
+    let bytes = tail.as_bytes();
     let mut depth: i32 = 1;
     let mut pos = 0;
-    while pos < tail.len() {
-        if tail[pos..].starts_with("<div") {
+    while pos < bytes.len() {
+        if bytes[pos..].starts_with(b"<div") {
             depth += 1;
             pos += 4;
-        } else if tail[pos..].starts_with("</div>") {
+        } else if bytes[pos..].starts_with(b"</div>") {
             depth -= 1;
             pos += "</div>".len();
             if depth == 0 {


### PR DESCRIPTION
## Summary

- **CI coverage gap fixed:** the `db-integration` job ran a hardcoded `--test X` allowlist (10 of 46 `tests/*.rs` files). The other 36 never ran in CI, so integration regressions could not turn CI red. Switched to `cargo test --tests --no-fail-fast` so every present and future integration binary runs.
- **3 latent failures this surfaced** (all on MariaDB 10.11.x, never caught because the files weren't in the allowlist):
  - `api_v1_auth` + `api_v1_patch_titles`: `SELECT MIN(genres.id)` decoded into `i64` fails on `BIGINT UNSIGNED` → wrapped in `CAST(... AS SIGNED)` (CLAUDE.md MariaDB gotcha #2).
  - `api_v1_patch_titles`: tests assumed a fresh title starts at `version 0`, but `titles.version` DEFAULTs to `1` (matches the whole app + the PATCH handler's `expected: existing.version` / `version + 1`). Send version 1, expect the `1 → 2` bump and `expected: 1` on mismatch.
  - `navbar_role_visibility`: `extract_desktop_nav` / `extract_mobile_panel` sliced HTML by byte index and panicked inside the `—` em-dash of `"mybibli — home"`. Now scans over bytes (ASCII markers) to stay char-boundary-safe.

## Validation (local)

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --tests --no-fail-fast` against MariaDB 10.11 (the broadened CI command) — all green
- Playwright E2E `CI=true --workers=2` — 275 passed, 2 flaky (pass on retry), 2 skipped

Closes #357
Closes #358

## Test plan

- [ ] CI `db-integration` job now runs all integration binaries and is green
- [ ] CI fails if any integration test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)