### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/_gates.yml
+++ b/.github/workflows/_gates.yml
@@ -41,7 +41,7 @@ jobs:
       DATABASE_URL: mysql://root:root_test@127.0.0.1:3307/mybibli_rust_test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -95,7 +95,7 @@ jobs:
       DATABASE_URL: mysql://root:root_test@127.0.0.1:3307/mybibli_rust_test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload MariaDB logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mariadb-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/mariadb.log
@@ -133,17 +133,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: tests/e2e/package-lock.json
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
@@ -218,7 +218,7 @@ jobs:
 
       - name: Upload compose logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: compose-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/compose-logs.txt
@@ -237,17 +237,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: tests/e2e/package-lock.json
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-wizard-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
@@ -326,7 +326,7 @@ jobs:
 
       - name: Upload compose logs on failure
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wizard-compose-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/wizard-compose-logs.txt

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,9 +26,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
         with:
           enablement: true
 
@@ -49,9 +49,9 @@ jobs:
       - name: Mirror screenshots into website/
         run: cp -r docs/screenshots website/screenshots || true
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./website
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check tag vs Cargo.toml
         id: check
@@ -57,7 +57,7 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -84,17 +84,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: gcorbaz/mybibli
           tags: |
@@ -102,7 +102,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.is-highest.outputs.is_highest == 'true' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -121,7 +121,7 @@ jobs:
       # Foundation Rule #19).
       - name: Sync Docker Hub overview
         if: steps.is-highest.outputs.is_highest == 'true'
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub forces Node 20 actions to Node 24 on **2026-06-02** and removes the Node 20 runner on **2026-09-16**. Bumps every JS action to its latest major. All inputs we use (`name`/`path`/`key`/`node-version`/`images`/`tags`/`context`/`file`/`push`) are unchanged across these majors.

| Action | From → To |
|---|---|
| actions/checkout | v4 → v6 |
| actions/cache | v4 → v5 |
| actions/setup-node | v4 → v6 |
| actions/upload-artifact | v4 → v7 |
| actions/configure-pages | v5 → v6 |
| actions/upload-pages-artifact | v3 → v5 |
| actions/deploy-pages | v4 → v5 |
| docker/setup-buildx-action | v3 → v4 |
| docker/login-action | v3 → v4 |
| docker/metadata-action | v5 → v6 |
| docker/build-push-action | v5 → v7 |
| peter-evans/dockerhub-description | v4 → v5 |

**Left unchanged (intentional):** `Swatinem/rust-cache@v2` (latest major, already Node 24 — not flagged by the deprecation annotation) and `dtolnay/rust-toolchain@stable` (composite action, no Node runtime). The `setup-node` `node-version: "20"` input is the Playwright test runtime, independent of the action runtime.

## Validation

- All four workflow files pass `yaml.safe_load`.
- Version tags verified as the current latest releases via the GitHub API.
- **`_gates.yml`** bumps are exercised by this PR's CI (checkout, rust-cache, upload-artifact, setup-node, cache).
- **`pages.yml`** is exercised on the post-merge `main` push — `.github/workflows/pages.yml` is in its own path filter.
- **`release.yml`** (docker/* + checkout) is only exercised at the next tagged release; inputs are unchanged so risk is low, but it is not validated by this PR.

Closes #360

## Test plan

- [ ] PR CI green (gates: Rust + clippy + sqlx, DB integration, Playwright E2E + wizard) with no Node 20 deprecation annotation
- [ ] Post-merge Pages deploy green
- [ ] Next release build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)