### PR TITLE
feat(#355): home filter chip "titles without cover"

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -137,6 +137,7 @@ home:
   filter:
     uncategorized: "Ohne Kategorie"
     no_volumes: "Titel ohne Exemplar"
+    no_cover: "Titel ohne Cover"
   genre_filter_no_longer_exists: "Dieses Genre existiert nicht mehr — alle Titel werden angezeigt."
 catalog:
   title: Katalog

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -137,6 +137,7 @@ home:
   filter:
     uncategorized: "Uncategorized"
     no_volumes: "Titles without volumes"
+    no_cover: "Titles without cover"
   genre_filter_no_longer_exists: "This genre no longer exists — showing all titles."
 catalog:
   title: Catalog

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -138,6 +138,7 @@ home:
   filter:
     uncategorized: "Sans genre"
     no_volumes: "Titres sans exemplaire"
+    no_cover: "Titres sans couverture"
   genre_filter_no_longer_exists: "Ce genre n'existe plus — affichage de tous les titres."
 catalog:
   title: Catalogue

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -134,6 +134,7 @@ home:
   filter:
     uncategorized: "Senza categoria"
     no_volumes: "Titoli senza esemplari"
+    no_cover: "Titoli senza copertina"
   genre_filter_no_longer_exists: "Questo genere non esiste più — vengono mostrati tutti i titoli."
 catalog:
   title: Catalogo

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -952,6 +952,11 @@ impl TitleModel {
         // which collides with the DISTINCT shape the data query
         // already needs.
         no_volumes_only: bool,
+        // CR #355 — when `true`, restrict to titles with no cover image.
+        // Same predicate the bulk cover-refetch uses (#214), minus the
+        // identifier clause: titles WITHOUT an ISBN/ISSN/UPC can never be
+        // auto-fetched, so they most need the manual-upload safety net.
+        no_cover_only: bool,
     ) -> Result<PaginatedList<SearchResult>, AppError> {
         let sort_col = validated_sort(sort);
         let sort_dir = validated_dir(dir);
@@ -1022,6 +1027,12 @@ impl TitleModel {
                  AND v_no.deleted_at IS NULL)"
                     .to_string(),
             );
+        }
+
+        if no_cover_only {
+            // CR #355 — title with no cover image (NULL or empty string).
+            // No bind value: self-contained predicate on the titles table.
+            conditions.push("(t.cover_image_url IS NULL OR t.cover_image_url = '')".to_string());
         }
 
         if let Some(ref state_name) = volume_state {

--- a/src/routes/api_v1.rs
+++ b/src/routes/api_v1.rs
@@ -91,6 +91,7 @@ pub async fn list_titles(
         &None,
         page,
         false, // no_volumes_only — not exposed via API in v1
+        false, // no_cover_only — not exposed via API in v1
     )
     .await?;
 

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -188,6 +188,13 @@ pub struct HomeTemplate {
     pub show_no_volumes_chip: bool,
     pub no_volumes_filter_active: bool,
     pub label_no_volumes: String,
+    // CR #355 — "Titles without a cover" filter chip. Librarian+ only
+    // (discovery path to the manual-upload safety net for the FR/CH/DE
+    // tech-publisher titles no free provider indexes). Same shape as the
+    // no_volumes chip.
+    pub show_no_cover_chip: bool,
+    pub no_cover_filter_active: bool,
+    pub label_no_cover_filter: String,
 }
 
 /// One row of the "By genre" dashboard section.
@@ -340,7 +347,13 @@ pub async fn home(
     // Librarian+ — Anonymous shouldn't see catalog-cleanup affordances.
     let no_volumes_filter_active = params.filter.as_deref() == Some("no_volumes")
         && session.role >= crate::middleware::auth::Role::Librarian;
-    let (genre_id, volume_state) = if parsed_indicator.is_some() || no_volumes_filter_active {
+    // CR #355 — `?filter=no_cover` short-circuit, same shape as no_volumes.
+    let no_cover_filter_active = params.filter.as_deref() == Some("no_cover")
+        && session.role >= crate::middleware::auth::Role::Librarian;
+    let (genre_id, volume_state) = if parsed_indicator.is_some()
+        || no_volumes_filter_active
+        || no_cover_filter_active
+    {
         (None, None)
     } else if params.filter.as_deref() == Some("uncategorized") {
         let default_genre_id = TitleService::find_default_genre_id(pool).await?;
@@ -390,6 +403,7 @@ pub async fn home(
             &params.dir,
             page,
             no_volumes_filter_active,
+            no_cover_filter_active,
         )
         .await?;
 
@@ -911,6 +925,9 @@ pub async fn home(
         show_no_volumes_chip: session.role >= crate::middleware::auth::Role::Librarian,
         no_volumes_filter_active,
         label_no_volumes: rust_i18n::t!("home.filter.no_volumes", locale = loc).to_string(),
+        show_no_cover_chip: session.role >= crate::middleware::auth::Role::Librarian,
+        no_cover_filter_active,
+        label_no_cover_filter: rust_i18n::t!("home.filter.no_cover", locale = loc).to_string(),
     };
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
@@ -1378,6 +1395,9 @@ pub(crate) mod tests {
             show_no_volumes_chip: false,
             no_volumes_filter_active: false,
             label_no_volumes: "Titles without volumes".to_string(),
+            show_no_cover_chip: false,
+            no_cover_filter_active: false,
+            label_no_cover_filter: "Titles without cover".to_string(),
         }
     }
 

--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -81,12 +81,19 @@ impl SearchService {
         page: u32,
         // CR #279 — title without any active volume.
         no_volumes_only: bool,
+        // CR #355 — title without a cover image.
+        no_cover_only: bool,
     ) -> Result<SearchOutcome, AppError> {
         let trimmed = query.trim();
         // Browse-without-query path: empty query + no filter → no results.
         // Empty query WITH a genre/state filter falls through to `fulltext_search`
         // (pill-driven browse, e.g. clicking "BD" on the home page).
-        if trimmed.is_empty() && genre_id.is_none() && volume_state.is_none() && !no_volumes_only {
+        if trimmed.is_empty()
+            && genre_id.is_none()
+            && volume_state.is_none()
+            && !no_volumes_only
+            && !no_cover_only
+        {
             return Ok(SearchOutcome::Results(PaginatedList::new(
                 vec![],
                 1,
@@ -108,6 +115,7 @@ impl SearchService {
                 dir,
                 page,
                 no_volumes_only,
+                no_cover_only,
             )
             .await;
         }
@@ -139,6 +147,7 @@ impl SearchService {
                             dir,
                             page,
                             no_volumes_only,
+                            no_cover_only,
                         )
                         .await
                     }
@@ -160,6 +169,7 @@ impl SearchService {
                             dir,
                             page,
                             no_volumes_only,
+                            no_cover_only,
                         )
                         .await
                     }
@@ -190,6 +200,7 @@ impl SearchService {
                             dir,
                             page,
                             no_volumes_only,
+                            no_cover_only,
                         )
                         .await
                     }
@@ -205,6 +216,7 @@ impl SearchService {
                     dir,
                     page,
                     no_volumes_only,
+                    no_cover_only,
                 )
                 .await
             }
@@ -221,6 +233,7 @@ impl SearchService {
         dir: &Option<String>,
         page: u32,
         no_volumes_only: bool,
+        no_cover_only: bool,
     ) -> Result<SearchOutcome, AppError> {
         let results = TitleModel::active_search(
             pool,
@@ -231,6 +244,7 @@ impl SearchService {
             dir,
             page,
             no_volumes_only,
+            no_cover_only,
         )
         .await?;
         Ok(SearchOutcome::Results(results))

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -143,6 +143,33 @@
         {% endif %}
         {% endif %}
 
+        {# CR #355 — "Titles without a cover" filter chip. Librarian+ only
+           (discovery path to the manual-upload safety net). Same shape as
+           the no_volumes chip above; distinct sky color. #}
+        {% if show_no_cover_chip %}
+        {% if no_cover_filter_active %}
+        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-sky-100 dark:bg-sky-900/40 text-sky-800 dark:text-sky-200 text-sm" role="status" aria-label="Active filter: {{ label_no_cover_filter }}. Press to remove filter">
+            {{ label_no_cover_filter }}
+            <button type="button"
+                    hx-get="/?q={{ query_encoded }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+                    hx-target="#browse-results"
+                    hx-swap="innerHTML"
+                    hx-push-url="true"
+                    class="ml-1 text-sky-600 hover:text-sky-800"
+                    aria-label="{{ remove_filter_aria }}">&times;</button>
+        </span>
+        {% else %}
+        <a href="/?q={{ query_encoded }}&amp;filter=no_cover&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+           hx-get="/?q={{ query_encoded }}&amp;filter=no_cover&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}"
+           hx-target="#browse-results"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           class="px-3 py-1 rounded-full bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 text-sm hover:bg-stone-200 dark:hover:bg-stone-700"
+           role="link"
+           aria-label="Filter by: {{ label_no_cover_filter }}">{{ label_no_cover_filter }}</a>
+        {% endif %}
+        {% endif %}
+
         <input type="hidden" name="filter" id="filter-hidden" value="{{ active_filter }}">
         <input type="hidden" name="sort" value="{{ current_sort }}">
         <input type="hidden" name="dir" value="{{ current_dir }}">

--- a/tests/e2e/specs/journeys/home-no-cover-filter.spec.ts
+++ b/tests/e2e/specs/journeys/home-no-cover-filter.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+// CR #355 — "Titles without cover" home filter chip. Discovery path to the
+// manual-upload safety net for the FR/CH/DE tech-publisher titles no free
+// provider indexes. Librarian+ only. Mirrors the no_volumes / uncategorized
+// chip pattern. The SQL filtering correctness is locked by the integration
+// tests in tests/search_filter_browse.rs; this spec covers the user-facing
+// affordance: chip visible, navigates, active-state clears, hidden for anon.
+
+const LABEL = /Titles without cover|Titres sans couverture|Titel ohne Cover|Titoli senza copertina/i;
+const REMOVE = /Remove filter|Retirer le filtre|Filter entfernen|Rimuovi filtro/i;
+
+test.describe("Home — no-cover filter chip (#355)", () => {
+  test("librarian: chip visible, navigates to ?filter=no_cover, active state clears", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+    await page.goto("/");
+
+    // Inactive chip is a link labelled with the localized text.
+    const chip = page.getByRole("link", { name: LABEL });
+    await expect(chip).toBeVisible();
+
+    // Clicking it applies the filter and pushes ?filter=no_cover into the URL
+    // (HTMX swaps #browse-results; the chip bar itself lives outside the swap
+    // target, same as every other home chip).
+    await chip.click();
+    await page.waitForURL(/[?&]filter=no_cover/);
+
+    // A full load of the filtered URL renders the chip in its active state:
+    // a status pill carrying a "remove filter" (×) control.
+    await page.goto("/?filter=no_cover");
+    const active = page.getByRole("status", { name: LABEL });
+    await expect(active).toBeVisible();
+    const clear = active.getByRole("button", { name: REMOVE });
+    await expect(clear).toBeVisible();
+
+    // Clearing removes the filter from the URL.
+    await clear.click();
+    await expect(page).not.toHaveURL(/[?&]filter=no_cover/);
+  });
+
+  test("anonymous: chip not rendered and ?filter=no_cover is ignored", async ({
+    page,
+  }) => {
+    // Fresh context is anonymous — no login.
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: LABEL })).toHaveCount(0);
+
+    // Direct navigation to the filtered URL must not render the chip as active
+    // (the filter is Librarian+ only; Anonymous gets no catalog-cleanup chip).
+    await page.goto("/?filter=no_cover");
+    await expect(page.getByRole("status", { name: LABEL })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: LABEL })).toHaveCount(0);
+  });
+});

--- a/tests/search_filter_browse.rs
+++ b/tests/search_filter_browse.rs
@@ -63,7 +63,7 @@ async fn empty_query_with_genre_filter_returns_filtered_titles(pool: MySqlPool) 
     let _ = seed_title(&pool, "Matching Two", genre_a).await;
     let _ = seed_title(&pool, "Other genre", genre_b).await;
 
-    let outcome = SearchService::search(&pool, "", Some(genre_a), None, &None, &None, 1, false)
+    let outcome = SearchService::search(&pool, "", Some(genre_a), None, &None, &None, 1, false, false)
         .await
         .expect("search must succeed");
 
@@ -92,7 +92,7 @@ async fn empty_query_without_filter_returns_empty(pool: MySqlPool) {
     let genre_a = first_genre_id(&pool).await;
     let _ = seed_title(&pool, "Something", genre_a).await;
 
-    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, false)
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, false, false)
         .await
         .expect("search must succeed");
 
@@ -114,7 +114,7 @@ async fn whitespace_query_with_filter_is_treated_as_filter_only_browse(pool: MyS
     let genre_a = first_genre_id(&pool).await;
     let _ = seed_title(&pool, "Matching", genre_a).await;
 
-    let outcome = SearchService::search(&pool, "   ", Some(genre_a), None, &None, &None, 1, false)
+    let outcome = SearchService::search(&pool, "   ", Some(genre_a), None, &None, &None, 1, false, false)
         .await
         .expect("search must succeed");
 
@@ -159,7 +159,7 @@ async fn no_volumes_only_filters_titles_with_active_volumes(pool: MySqlPool) {
         .await
         .expect("insert soft-deleted volume");
 
-    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, true)
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, true, false)
         .await
         .expect("search must succeed");
 
@@ -194,7 +194,7 @@ async fn no_volumes_only_disables_empty_query_short_circuit(pool: MySqlPool) {
     let genre = first_genre_id(&pool).await;
     let _ = seed_title(&pool, "Bare", genre).await;
 
-    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, true)
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, true, false)
         .await
         .expect("search must succeed");
 
@@ -203,6 +203,79 @@ async fn no_volumes_only_disables_empty_query_short_circuit(pool: MySqlPool) {
             assert!(
                 paginated.total_items >= 1,
                 "no_volumes filter must override the empty-query short-circuit"
+            );
+        }
+        SearchOutcome::Redirect(_) => panic!("unexpected redirect"),
+    }
+}
+
+/// CR #355 — the `no_cover_only` flag restricts results to titles whose
+/// `cover_image_url` is NULL or empty string. Seeds 3 titles: one with a
+/// real cover URL, one left NULL, one set to empty string. The NULL and
+/// empty-string titles must surface; the title with a cover must NOT.
+#[sqlx::test(migrations = "./migrations")]
+async fn no_cover_only_filters_titles_with_cover(pool: MySqlPool) {
+    let genre = first_genre_id(&pool).await;
+
+    let with_cover = seed_title(&pool, "Has Cover", genre).await;
+    let _null_cover = seed_title(&pool, "Null Cover", genre).await; // cover defaults to NULL
+    let empty_cover = seed_title(&pool, "Empty Cover", genre).await;
+
+    sqlx::query("UPDATE titles SET cover_image_url = '/covers/has-cover.jpg' WHERE id = ?")
+        .bind(with_cover)
+        .execute(&pool)
+        .await
+        .expect("set cover url");
+    sqlx::query("UPDATE titles SET cover_image_url = '' WHERE id = ?")
+        .bind(empty_cover)
+        .execute(&pool)
+        .await
+        .expect("set empty cover");
+
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, false, true)
+        .await
+        .expect("search must succeed");
+
+    match outcome {
+        SearchOutcome::Results(paginated) => {
+            let titles: Vec<&str> = paginated.items.iter().map(|i| i.title.as_str()).collect();
+            assert!(
+                titles.contains(&"Null Cover"),
+                "NULL-cover title must surface, got {:?}",
+                titles
+            );
+            assert!(
+                titles.contains(&"Empty Cover"),
+                "empty-string-cover title must surface, got {:?}",
+                titles
+            );
+            assert!(
+                !titles.contains(&"Has Cover"),
+                "title with a cover must NOT surface, got {:?}",
+                titles
+            );
+        }
+        SearchOutcome::Redirect(_) => panic!("unexpected redirect for no_cover browse"),
+    }
+}
+
+/// CR #355 — when `no_cover_only` is `true`, the empty-query short-circuit
+/// must NOT fire (mirror of the no_volumes case). `?filter=no_cover` lands
+/// with no query and no genre filter set.
+#[sqlx::test(migrations = "./migrations")]
+async fn no_cover_only_disables_empty_query_short_circuit(pool: MySqlPool) {
+    let genre = first_genre_id(&pool).await;
+    let _ = seed_title(&pool, "Coverless", genre).await; // cover defaults to NULL
+
+    let outcome = SearchService::search(&pool, "", None, None, &None, &None, 1, false, true)
+        .await
+        .expect("search must succeed");
+
+    match outcome {
+        SearchOutcome::Results(paginated) => {
+            assert!(
+                paginated.total_items >= 1,
+                "no_cover filter must override the empty-query short-circuit"
             );
         }
         SearchOutcome::Redirect(_) => panic!("unexpected redirect"),


### PR DESCRIPTION
## Summary

Adds a **Librarian+ home filter chip** that lists titles with no cover image (`cover_image_url IS NULL OR ''`) — the discovery path to the manual-upload safety net for the FR/CH/DE tech-publisher titles no free provider indexes (#333 closed wontfix). Mirrors the `no_volumes` (#279) / `uncategorized` (#205) chip pattern.

- Handler short-circuit on `?filter=no_cover`; a `no_cover_only` flag threaded through `SearchService::search` → `TitleModel::active_search`. No schema, no migration.
- Self-contained SQL predicate. **Unlike the bulk-refetch predicate (#214) this omits the `isbn/issn/upc` clause on purpose** — titles without an identifier can never be auto-fetched, so they most need the manual path.
- Librarian+ only; Anonymous never sees the chip and `?filter=no_cover` is ignored.
- 3-way mutual exclusion with the other indicator/legacy filters holds.
- i18n `home.filter.no_cover` added to en/fr/de/it (locale parity preserved).

## Validation (local)

- `cargo clippy --all-targets -- -D warnings` — clean
- Integration tests (`search_filter_browse`): NULL + empty-string covers surface, with-cover excluded, empty-query short-circuit overridden by the filter — 7 passed
- Home unit tests — 47 passed
- E2E (`home-no-cover-filter.spec.ts`): chip visible to librarian, navigates to `?filter=no_cover`, active-state clears, hidden for anon. Ran the full home+search E2E set (33 tests) at `CI=true --workers=2` — green, no regressions.

Closes #355

## Test plan

- [ ] CI green (clippy, integration, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)