### PR TITLE
feat(#350): make the manual cover-upload affordance visible

### DIFF
--- a/docs/manual/en/05-metadata-providers.tex
+++ b/docs/manual/en/05-metadata-providers.tex
@@ -51,6 +51,29 @@ when (a) the chain succeeded \emph{and} (b) the resolving provider
 gave no \texttt{cover\_url}, so a title for which no provider has a
 cover anywhere will land cover-less without retry storms.
 
+\subsection*{When no provider has a cover: upload your own}
+
+Some titles will never receive a cover from the automatic chain. In
+practice this is dominated by French, Swiss, and German trade and
+academic publishers (Dunod, Eyrolles, Slatkine, Mardaga, Kana,
+Casterman, and the like): Google Books returns nothing for their
+ISBNs and the Open Library Covers index does not hold them either.
+This is a structural gap in the free data sources, not a bug --- no
+amount of re-fetching will fill it.
+
+For those titles, \textbf{manual upload is the realistic path}. On a
+title's detail page a Librarian (or Admin) sees an \emph{Upload
+cover} button under the cover area; titles with no cover get a more
+prominent call-to-action and a one-line reminder of this gap.
+Accepted formats are JPG, PNG, WebP and GIF, up to 10\,MiB. The
+image is resized and stored locally, and a manually uploaded cover
+is protected from being overwritten by a later automatic re-fetch.
+
+To find the titles that still need a cover, use the \emph{Titles
+without cover} filter on the home page (Librarian and above), or
+follow the \emph{Review titles without a cover} link shown on the
+Admin page's Health tab after a bulk cover re-fetch.
+
 \section{API keys}
 
 Three providers require an API key:

--- a/docs/manual/fr/05-metadata-providers.tex
+++ b/docs/manual/fr/05-metadata-providers.tex
@@ -56,6 +56,33 @@ pas fourni de \texttt{cover\_url}, de sorte qu'un titre dont
 aucun fournisseur n'a la couverture finit sans image, sans rafale
 d'essais inutiles.
 
+\subsection*{Quand aucun fournisseur n'a la couverture : téléversez la vôtre}
+
+Certains titres ne recevront jamais de couverture par la chaîne
+automatique. En pratique, il s'agit surtout d'éditeurs français,
+suisses et allemands, grand public comme universitaires (Dunod,
+Eyrolles, Slatkine, Mardaga, Kana, Casterman, etc.) : Google Books
+ne renvoie rien pour leurs ISBN et l'index Open Library Covers ne
+les contient pas davantage. C'est une lacune structurelle des
+sources de données gratuites, pas un bogue --- aucune récupération
+répétée ne la comblera.
+
+Pour ces titres, \textbf{le téléversement manuel est la voie
+réaliste}. Sur la page de détail d'un titre, un bibliothécaire (ou
+administrateur) voit un bouton \emph{Téléverser une couverture} sous
+la zone de couverture ; les titres sans couverture reçoivent un
+appel à l'action plus visible et un rappel d'une ligne sur cette
+lacune. Les formats acceptés sont JPG, PNG, WebP et GIF, jusqu'à
+10\,Mio. L'image est redimensionnée et stockée localement, et une
+couverture téléversée manuellement est protégée contre tout
+écrasement par une récupération automatique ultérieure.
+
+Pour trouver les titres qui ont encore besoin d'une couverture,
+utilisez le filtre \emph{Titres sans couverture} sur la page
+d'accueil (bibliothécaire et plus), ou suivez le lien \emph{Voir les
+titres sans couverture} affiché sous l'onglet Santé de la page
+d'administration après une récupération en lot.
+
 \section{Clés d'API}
 
 Trois fournisseurs requièrent une clé d'API :

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -551,6 +551,7 @@ cover:
   alt_text: "Cover von %{title}"
   no_cover: "Kein Cover verfügbar"
   upload_button: "Cover hochladen"
+  upload_cta_explainer: "Viele Verlage sind nicht bei Google Books oder Open Library indexiert — laden Sie Ihr eigenes Cover hoch (JPG/PNG/WebP, max. 10 MiB)."
 cover_upload:
   heading: "Cover hochladen"
   intro: "Wählen Sie eine JPG / PNG / WebP / GIF-Datei als Cover für"
@@ -785,6 +786,7 @@ admin:
       started: "Massenhafter Cover-Nachzug für %{total} Titel gestartet. Fortschritt steht im Log; aktualisieren Sie das Panel für Updates."
       empty: "Keine Titel benötigen einen Cover-Nachzug — alles, was abrufbar war, ist abgerufen."
       already_running: "Ein Cover-Nachzug läuft bereits. Bitte warten Sie auf den Abschluss."
+      review_cta: "Titel ohne Cover ansehen"
   users:
     heading: Benutzerkonten
     empty_state: "Nur Sie hier! Erstellen Sie ein Bibliothekar-Konto für andere Haushaltsmitglieder."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -558,6 +558,7 @@ cover:
   alt_text: "Cover of %{title}"
   no_cover: "No cover available"
   upload_button: "Upload cover"
+  upload_cta_explainer: "Many publishers aren't indexed by Google Books or Open Library — upload your own (JPG/PNG/WebP, max 10 MiB)."
 cover_upload:
   heading: "Upload a cover image"
   intro: "Pick a JPG / PNG / WebP / GIF file to attach as the cover of"
@@ -796,6 +797,7 @@ admin:
       started: "Bulk cover-refetch started for %{total} titles. Progress is logged; refresh the panel to see updates."
       empty: "No titles need a cover refetch — everything that can be fetched has been."
       already_running: "A bulk cover-refetch is already in progress. Please wait for it to complete."
+      review_cta: "Review titles without a cover"
   users:
     heading: User accounts
     empty_state: "Only you here! Create a Librarian account for household members."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -554,6 +554,7 @@ cover:
   alt_text: "Couverture de %{title}"
   no_cover: "Pas de couverture disponible"
   upload_button: "Téléverser une couverture"
+  upload_cta_explainer: "Beaucoup d'éditeurs ne sont pas indexés par Google Books ni Open Library — téléversez la vôtre (JPG/PNG/WebP, max 10 Mio)."
 cover_upload:
   heading: "Téléverser une image de couverture"
   intro: "Choisissez un fichier JPG / PNG / WebP / GIF à attacher comme couverture de"
@@ -792,6 +793,7 @@ admin:
       started: "Récupération en lot lancée pour %{total} titres. La progression est journalisée ; rafraîchissez le panneau pour voir les mises à jour."
       empty: "Aucun titre n'a besoin d'être re-fetché — tout ce qui peut être récupéré l'a été."
       already_running: "Une récupération en lot est déjà en cours. Attendez sa fin."
+      review_cta: "Voir les titres sans couverture"
   users:
     heading: "Comptes utilisateurs"
     empty_state: "Vous êtes seul·e ! Créez un compte Bibliothécaire pour les membres du foyer."

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -541,6 +541,7 @@ cover:
   alt_text: "Copertina di %{title}"
   no_cover: "Copertina non disponibile"
   upload_button: "Carica una copertina"
+  upload_cta_explainer: "Molti editori non sono indicizzati da Google Books o Open Library — carica la tua copertina (JPG/PNG/WebP, max 10 MiB)."
 cover_upload:
   heading: "Carica un'immagine di copertina"
   intro: "Scegli un file JPG / PNG / WebP / GIF da allegare come copertina di"
@@ -773,6 +774,7 @@ admin:
       started: "Riscaricamento delle copertine avviato per %{total} titoli. Il progresso è registrato nei log; aggiorna il pannello per vedere gli aggiornamenti."
       empty: "Nessun titolo ha bisogno di un nuovo recupero copertina — tutto ciò che era recuperabile è stato recuperato."
       already_running: "Un riscaricamento delle copertine è già in corso. Attendi il suo completamento."
+      review_cta: "Vedi i titoli senza copertina"
   users:
     heading: Account utenti
     empty_state: "Solo tu qui! Crea un account Bibliotecario per i membri della famiglia."

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -221,6 +221,10 @@ struct AdminHealthPanel {
     bulk_cover_fetch_can_start: bool,
     bulk_cover_fetch_running: bool,
     bulk_cover_fetch_status_label: String,
+    // CR #350 — link to the home "no cover" filter (#355) so an admin whose
+    // bulk-refetch left titles uncovered (the FR/CH/DE publisher gap) has a
+    // direct path to the manual-upload review list. Shown when count > 0.
+    bulk_cover_fetch_review_cta: String,
 }
 
 struct ProviderHealthRow {
@@ -1753,6 +1757,11 @@ async fn render_health_panel(state: &AppState, loc: &'static str) -> Result<Stri
         bulk_cover_fetch_can_start: !bulk_status.running && missing_covers_count > 0,
         bulk_cover_fetch_running: bulk_status.running,
         bulk_cover_fetch_status_label,
+        bulk_cover_fetch_review_cta: rust_i18n::t!(
+            "admin.health.bulk_cover_fetch.review_cta",
+            locale = loc
+        )
+        .to_string(),
     };
 
     panel

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -79,6 +79,9 @@ pub struct TitleDetailTemplate {
     // Issue #335 — manual cover upload affordance below the cover image
     // (Librarian+ only). Modal HX-loaded into `#modal-slot`.
     pub label_upload_cover: String,
+    // CR #350 — one-line explainer shown under the prominent upload CTA when
+    // the title has no cover (honest about the FR/CH/DE publisher gap).
+    pub label_cover_gap_explainer: String,
     // CR #271 — Delete-title button shown only when volume_count == 0.
     pub label_delete_title: String,
     pub has_code: bool,
@@ -196,6 +199,7 @@ pub async fn title_detail(
             label_edit: rust_i18n::t!("metadata.edit_metadata", locale = loc).to_string(),
             label_redownload: rust_i18n::t!("metadata.redownload", locale = loc).to_string(),
             label_upload_cover: rust_i18n::t!("cover.upload_button", locale = loc).to_string(),
+            label_cover_gap_explainer: rust_i18n::t!("cover.upload_cta_explainer", locale = loc).to_string(),
             label_delete_title: rust_i18n::t!("title.delete_title_button", locale = loc).to_string(),
             has_code,
             series_assignments,
@@ -2039,6 +2043,7 @@ mod tests {
             label_edit: "Edit metadata".to_string(),
             label_redownload: "Re-download".to_string(),
             label_upload_cover: "Upload cover".to_string(),
+            label_cover_gap_explainer: "Upload your own cover".to_string(),
             label_delete_title: "Delete title".to_string(),
             has_code: true,
             series_assignments: vec![],
@@ -2075,6 +2080,130 @@ mod tests {
         assert!(
             !rendered.contains("aria-label=\"Similar titles\""),
             "Expected empty similar_titles to render NO <section> element"
+        );
+    }
+
+    // CR #350 — a Librarian viewing a title with NO cover gets the prominent
+    // upload CTA plus the FR-publisher-gap explainer; a title WITH a cover
+    // shows only the modest replace link (no explainer). Locks the cover-empty
+    // branch in title_detail.html.
+    #[test]
+    fn test_title_detail_coverless_shows_prominent_upload_cta() {
+        let title = TitleModel {
+            id: 1,
+            title: "Sans couverture".to_string(),
+            subtitle: None,
+            description: None,
+            language: "fr".to_string(),
+            media_type: "book".to_string(),
+            publication_date: None,
+            publisher: None,
+            isbn: Some("9782070360246".to_string()),
+            issn: None,
+            upc: None,
+            cover_image_url: None,
+            genre_id: 1,
+            dewey_code: None,
+            page_count: None,
+            track_count: None,
+            total_duration: None,
+            age_rating: None,
+            issue_number: None,
+            manually_edited_fields: None,
+            version: 1,
+        };
+        let mut template = TitleDetailTemplate {
+            lang: "en".to_string(),
+            role: "librarian".to_string(),
+            current_page: "title",
+            skip_label: "Skip".to_string(),
+            connection_status: crate::utils::ConnectionStatusContext::new("en"),
+            shortcuts_cheat_sheet: crate::utils::ShortcutsCheatSheetContext::new("en"),
+            session_timeout_secs: crate::config::AppSettings::default().session_timeout_secs,
+            csrf_token: "tok".to_string(),
+            nav_catalog: "Catalog".to_string(),
+            nav_loans: "Loans".to_string(),
+            nav_wishlist: "Wish list".to_string(),
+            nav_locations: "Locations".to_string(),
+            nav_series: "Series".to_string(),
+            nav_borrowers: "Borrowers".to_string(),
+            nav_admin: "Admin".to_string(),
+            nav_login: "Log in".to_string(),
+            nav_logout: "Log out".to_string(),
+            nav_menu_open: "Open menu".to_string(),
+            title,
+            genre_name: "Roman".to_string(),
+            volume_count: 0,
+            volumes: vec![],
+            can_edit: true,
+            label_volumes_heading: "Volumes of this title".to_string(),
+            label_volumes_empty: "No volumes yet.".to_string(),
+            label_volumes_empty_cta: "Scan".to_string(),
+            label_volumes_empty_cta_url: "/catalog".to_string(),
+            label_col_vcode: "V-code".to_string(),
+            label_col_location: "Location".to_string(),
+            label_col_condition: "Condition".to_string(),
+            label_col_actions: "Actions".to_string(),
+            label_action_edit: "Edit".to_string(),
+            label_action_delete: "Delete".to_string(),
+            label_placeholder_empty: "—".to_string(),
+            contributors: vec![],
+            label_contributors: "Contributors".to_string(),
+            label_contributor_add: "Add contributor".to_string(),
+            label_contributor_remove: "Remove".to_string(),
+            label_contributor_remove_aria: "Remove contributor".to_string(),
+            label_no_contributors: "No contributors yet.".to_string(),
+            label_vol: "Volumes".to_string(),
+            label_no_cover: "No cover available".to_string(),
+            label_edit: "Edit metadata".to_string(),
+            label_redownload: "Re-download".to_string(),
+            label_upload_cover: "Upload cover".to_string(),
+            label_cover_gap_explainer: "PUBLISHER-GAP-EXPLAINER".to_string(),
+            label_delete_title: "Delete title".to_string(),
+            has_code: true,
+            series_assignments: vec![],
+            all_series: vec![],
+            label_series: "Series".to_string(),
+            label_assign: "Add to series".to_string(),
+            label_position: "Position".to_string(),
+            label_unassign: "Remove".to_string(),
+            label_no_series: "Not assigned".to_string(),
+            label_select_series: "Select a series...".to_string(),
+            label_omnibus: "Omnibus".to_string(),
+            label_end_position: "End position".to_string(),
+            omnibus_help: crate::utils::TooltipData::with_icon(
+                "tip-series-omnibus",
+                "Help: omnibus",
+                "Check this if the book bundles multiple series volumes.",
+            ),
+            similar_titles: vec![],
+            label_similar_titles: "Similar titles".to_string(),
+            label_dewey_code: "Dewey code".to_string(),
+            current_url: "/title/1".to_string(),
+            lang_toggle_aria: "Change language".to_string(),
+        };
+
+        // No cover → prominent CTA branch: explainer + upload-modal trigger.
+        let no_cover = template.render().unwrap();
+        assert!(
+            no_cover.contains("PUBLISHER-GAP-EXPLAINER"),
+            "coverless title must surface the FR-publisher-gap explainer"
+        );
+        assert!(
+            no_cover.contains("/title/1/cover/upload-modal"),
+            "coverless title must surface the upload-modal trigger"
+        );
+
+        // With a cover → modest replace link only, no explainer.
+        template.title.cover_image_url = Some("/covers/1.jpg".to_string());
+        let with_cover = template.render().unwrap();
+        assert!(
+            !with_cover.contains("PUBLISHER-GAP-EXPLAINER"),
+            "title with a cover must NOT show the gap explainer"
+        );
+        assert!(
+            with_cover.contains("/title/1/cover/upload-modal"),
+            "title with a cover keeps the (modest) replace-cover trigger"
         );
     }
 
@@ -2168,6 +2297,7 @@ mod tests {
             label_edit: "Edit metadata".to_string(),
             label_redownload: "Re-download".to_string(),
             label_upload_cover: "Upload cover".to_string(),
+            label_cover_gap_explainer: "Upload your own cover".to_string(),
             label_delete_title: "Delete title".to_string(),
             has_code: false,
             series_assignments: vec![],

--- a/templates/fragments/admin_health_panel.html
+++ b/templates/fragments/admin_health_panel.html
@@ -74,6 +74,13 @@
         <p class="text-sm {% if bulk_cover_fetch_running %}text-amber-700 dark:text-amber-300{% else %}text-stone-500 dark:text-stone-400{% endif %}">
             {{ bulk_cover_fetch_status_label }}
         </p>
+        {# CR #350 — when titles remain without a cover, point the admin at the
+           home "no cover" filter (#355) to upload manually. #}
+        {% if missing_covers_count > 0 %}
+        <p class="mt-2 text-sm">
+            <a href="/?filter=no_cover" class="text-indigo-600 dark:text-indigo-400 hover:underline">{{ bulk_cover_fetch_review_cta }}</a>
+        </p>
+        {% endif %}
     </div>
 
     <div id="admin-panel-feedback" class="mt-4" aria-live="polite"></div>

--- a/templates/pages/title_detail.html
+++ b/templates/pages/title_detail.html
@@ -13,8 +13,22 @@
         <div class="flex flex-col items-center gap-2">
             {% call cover::cover(title.cover_image_url.as_deref().unwrap_or_default(), title.title, title.media_type, "w-[200px] h-[300px]", "eager", label_no_cover) %}{% endcall %}
             {# Issue #335 — manual cover upload (Librarian+). Pulls the modal
-               fragment into the global `#modal-slot` mounted by base.html. #}
+               fragment into the global `#modal-slot` mounted by base.html.
+               CR #350 — when the title has NO cover, surface a prominent CTA
+               plus an honest one-line explainer (many FR/CH/DE publishers are
+               not indexed by Google Books / Open Library, so manual upload is
+               the realistic path). With a cover, keep the modest replace link. #}
             {% if role == "librarian" || role == "admin" %}
+            {% if title.cover_image_url.as_deref().unwrap_or_default().is_empty() %}
+            <button type="button"
+                    hx-get="/title/{{ title.id }}/cover/upload-modal"
+                    hx-target="#modal-slot"
+                    hx-swap="innerHTML"
+                    class="mt-1 inline-flex items-center gap-1 px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                {{ label_upload_cover }}
+            </button>
+            <p class="mt-1 max-w-[200px] text-xs text-stone-500 dark:text-stone-400 text-center">{{ label_cover_gap_explainer }}</p>
+            {% else %}
             <button type="button"
                     hx-get="/title/{{ title.id }}/cover/upload-modal"
                     hx-target="#modal-slot"
@@ -22,6 +36,7 @@
                     class="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">
                 {{ label_upload_cover }}
             </button>
+            {% endif %}
             {% endif %}
         </div>
         <div class="flex-1">

--- a/tests/e2e/specs/journeys/title-cover-upload-cta.spec.ts
+++ b/tests/e2e/specs/journeys/title-cover-upload-cta.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+import { scanTitleAndVolume } from "../../helpers/loans";
+
+// CR #350 — make the manual cover-upload affordance more visible (FR/CH/DE
+// publisher gap pivot). A title scanned with a generated ISBN resolves to
+// synthetic BnF metadata with NO cover (and the Open Library cover fallback
+// 404s), so it is deterministically cover-less even after the async fetch.
+
+const UPLOAD_BTN = /Upload cover|Téléverser une couverture|Cover hochladen|Carica una copertina/i;
+const EXPLAINER = /Many publishers|Beaucoup d'éditeurs|Viele Verlage|Molti editori/i;
+const REVIEW_CTA = /Review titles without a cover|Voir les titres sans couverture|Titel ohne Cover ansehen|Vedi i titoli senza copertina/i;
+
+test.describe("Cover-upload affordance (#350)", () => {
+  test("librarian: cover-less title detail shows prominent CTA + explainer; click opens modal", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+    const isbn = specIsbn("UC", 1);
+    await scanTitleAndVolume(page, isbn, "V0350");
+
+    // ISBN search returns the single matching title in #browse-results. Read
+    // its detail href and navigate directly — the card markup carries a
+    // desktop + md:hidden mobile twin, so clicking ".first()" can hit the
+    // hidden copy. getAttribute works regardless of visibility.
+    await page.goto("/?q=" + isbn);
+    const detailHref = await page
+      .locator('#browse-results a[href^="/title/"]')
+      .first()
+      .getAttribute("href");
+    expect(detailHref).toBeTruthy();
+    await page.goto(detailHref!);
+
+    // Cover-less → prominent upload button + honest gap explainer.
+    const uploadBtn = page.getByRole("button", { name: UPLOAD_BTN });
+    await expect(uploadBtn).toBeVisible();
+    await expect(page.getByText(EXPLAINER)).toBeVisible();
+
+    // Clicking the CTA loads the upload modal into #modal-slot (file input).
+    await uploadBtn.click();
+    await expect(page.locator('#modal-slot input[type="file"]')).toBeVisible();
+  });
+
+  test("admin: Health tab links to the no-cover review list when titles remain uncovered", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    // A cover-less title WITH an identifier counts toward the bulk-refetch
+    // "missing covers" total, so the review CTA renders.
+    const isbn = specIsbn("UC", 2);
+    await scanTitleAndVolume(page, isbn, "V0351");
+
+    await page.goto("/admin?tab=health");
+    const reviewLink = page.getByRole("link", { name: REVIEW_CTA });
+    await expect(reviewLink).toBeVisible();
+    await expect(reviewLink).toHaveAttribute("href", "/?filter=no_cover");
+  });
+});


### PR DESCRIPTION
## Summary

Pivot for the structural FR/CH/DE publisher cover gap (#333 closed wontfix): manual upload (#335) is the only realistic safety net for those titles, so make it discoverable and honest about the gap.

**Scope = parts 2-4.** The in-card clickable placeholder (part 1) is deliberately out of scope: the card cover sits inside the `<a href="/title/:id">` detail link and cards render for anonymous, so an in-card modal trigger conflicts with navigation + role-gating. Combined with the #355 chip, parts 2-4 already form a complete discover → upload flow.

- **`/title/:id` detail:** when the title has NO cover, the upload affordance becomes a prominent CTA + a one-line explainer about the gap; with a cover it stays a modest "replace" link. Librarian+ only.
- **Admin → Health:** when titles remain without a cover after a bulk re-fetch (`count > 0`), a "Review titles without a cover" link points at `/?filter=no_cover` (#355).
- **User manual (EN + FR, ch. 5):** new subsection documenting the publisher gap honestly + the manual-upload workaround. **PDFs are rebuilt at the v1.8.0 release cut** (Rule #19), not in this PR.
- i18n `cover.upload_cta_explainer` + `admin.health.bulk_cover_fetch.review_cta` added to en/fr/de/it (locale parity preserved).

## Validation (local)

- `cargo clippy --all-targets -- -D warnings` — clean; `tsc --noEmit` — clean
- Unit: render test locks the coverless-CTA branch (explainer present without a cover, absent with one); `templates_audit` (CSP) + `locale_parity` green
- E2E (`title-cover-upload-cta.spec.ts`): librarian detail CTA → upload modal opens; admin Health review link → `/?filter=no_cover`. Ran title/admin/catalog specs (80 tests) at `CI=true --workers=2` — green (1 pre-existing flaky in `catalog-title`, unrelated, passed on retry).

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)