### PR TITLE
refactor(#354): migrate LoginTemplate to base_context() + regression guard

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -10,7 +10,6 @@ use crate::error::{AppError, is_safe_next};
 use crate::middleware::auth::{Role, Session};
 use crate::middleware::htmx::HxRequest;
 use crate::middleware::locale::Locale;
-use crate::utils::current_url;
 
 // ─── Login form template ─────────────────────────────────────────
 
@@ -50,35 +49,40 @@ impl LoginTemplate {
     fn new(
         error_message: &str,
         next: &str,
+        session: &Session,
         loc: &str,
-        current_url_value: String,
-        csrf_token: String,
+        uri: &axum::http::Uri,
     ) -> Self {
         let next = if is_safe_next(next) {
             next.to_string()
         } else {
             String::new()
         };
+        // CR #354: build the 20 shared full-page fields via base_context()
+        // instead of inline t!() calls — the last page handler still doing so.
+        // Login is always anonymous (authenticated users are redirected before
+        // render), so session_timeout_secs is irrelevant (guarded in base.html)
+        // — pass 0. role + csrf_token come off the (anonymous) session.
+        let base = crate::utils::base_context(session, loc, "login", uri, 0);
         LoginTemplate {
-            lang: loc.to_string(),
-            role: "anonymous".to_string(),
-            current_page: "login",
-            skip_label: rust_i18n::t!("nav.skip_to_content", locale = loc).to_string(),
-            connection_status: crate::utils::ConnectionStatusContext::new(loc),
-            shortcuts_cheat_sheet: crate::utils::ShortcutsCheatSheetContext::new(loc),
-            // Login page is anonymous — value is not rendered (guarded in base.html).
-            session_timeout_secs: 0,
-            csrf_token,
-            nav_catalog: rust_i18n::t!("nav.catalog", locale = loc).to_string(),
-            nav_loans: rust_i18n::t!("nav.loans", locale = loc).to_string(),
-            nav_wishlist: rust_i18n::t!("nav.wishlist", locale = loc).to_string(),
-            nav_locations: rust_i18n::t!("nav.locations", locale = loc).to_string(),
-            nav_series: rust_i18n::t!("nav.series", locale = loc).to_string(),
-            nav_borrowers: rust_i18n::t!("nav.borrowers", locale = loc).to_string(),
-            nav_admin: rust_i18n::t!("nav.admin", locale = loc).to_string(),
-            nav_login: rust_i18n::t!("nav.login", locale = loc).to_string(),
-            nav_logout: rust_i18n::t!("nav.logout", locale = loc).to_string(),
-            nav_menu_open: rust_i18n::t!("nav.menu_open", locale = loc).to_string(),
+            lang: base.lang,
+            role: base.role,
+            current_page: base.current_page,
+            skip_label: base.skip_label,
+            connection_status: base.connection_status,
+            shortcuts_cheat_sheet: base.shortcuts_cheat_sheet,
+            session_timeout_secs: base.session_timeout_secs,
+            csrf_token: base.csrf_token,
+            nav_catalog: base.nav_catalog,
+            nav_loans: base.nav_loans,
+            nav_wishlist: base.nav_wishlist,
+            nav_locations: base.nav_locations,
+            nav_series: base.nav_series,
+            nav_borrowers: base.nav_borrowers,
+            nav_admin: base.nav_admin,
+            nav_login: base.nav_login,
+            nav_logout: base.nav_logout,
+            nav_menu_open: base.nav_menu_open,
             login_title: rust_i18n::t!("login.title", locale = loc).to_string(),
             username_label: rust_i18n::t!("login.username_label", locale = loc).to_string(),
             password_label: rust_i18n::t!("login.password_label", locale = loc).to_string(),
@@ -86,8 +90,8 @@ impl LoginTemplate {
             back_to_home: rust_i18n::t!("login.back_to_home", locale = loc).to_string(),
             error_message: error_message.to_string(),
             next,
-            current_url: current_url_value,
-            lang_toggle_aria: rust_i18n::t!("nav.language_toggle_aria", locale = loc).to_string(),
+            current_url: base.current_url,
+            lang_toggle_aria: base.lang_toggle_aria,
         }
     }
 }
@@ -117,13 +121,7 @@ pub async fn login_page(
         return Ok(Redirect::to(target).into_response());
     }
 
-    let template = LoginTemplate::new(
-        "",
-        &query.next,
-        locale.0,
-        current_url(&uri),
-        session.csrf_token.clone(),
-    );
+    let template = LoginTemplate::new("", &query.next, &session, locale.0, &uri);
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
         Err(e) => {
@@ -154,7 +152,6 @@ pub async fn login(
     let pool = &state.pool;
     let username = form.username.trim();
     let password = form.password.as_str();
-    let url_for_toggle = current_url(&uri);
 
     // Look up user (widened to read preferred_language for cookie sync — AC 5, 15).
     // Issue #68: explicitly restrict to the two human-login roles. The
@@ -172,25 +169,13 @@ pub async fn login(
 
     let Some((user_id, password_hash, role, preferred_language)) = user_row else {
         tracing::info!(username = %username, "Login failed: user not found");
-        return render_login_error(
-            jar,
-            &form.next,
-            locale.0,
-            url_for_toggle,
-            session.csrf_token.clone(),
-        );
+        return render_login_error(jar, &form.next, &session, locale.0, &uri);
     };
 
     // Verify password with Argon2
     if !crate::services::password::verify_password(password, &password_hash) {
         tracing::info!(username = %username, "Login failed: invalid password");
-        return render_login_error(
-            jar,
-            &form.next,
-            locale.0,
-            url_for_toggle,
-            session.csrf_token.clone(),
-        );
+        return render_login_error(jar, &form.next, &session, locale.0, &uri);
     }
 
     // Generate session + CSRF tokens. Story 8-2: CSRF token rotates on
@@ -268,12 +253,12 @@ pub async fn login(
 fn render_login_error(
     jar: CookieJar,
     next: &str,
+    session: &Session,
     loc: &str,
-    current_url_value: String,
-    csrf_token: String,
+    uri: &axum::http::Uri,
 ) -> Result<(CookieJar, axum::response::Response), AppError> {
     let error_msg = rust_i18n::t!("login.error_invalid", locale = loc).to_string();
-    let template = LoginTemplate::new(&error_msg, next, loc, current_url_value, csrf_token);
+    let template = LoginTemplate::new(&error_msg, next, session, loc, uri);
     match template.render() {
         Ok(html) => Ok((jar, Html(html).into_response())),
         Err(e) => {
@@ -529,7 +514,9 @@ mod tests {
 
     #[test]
     fn test_login_template_renders() {
-        let template = LoginTemplate::new("", "", "en", "/login".to_string(), "tok".to_string());
+        let session = Session::anonymous_with_token("tok".to_string());
+        let uri: axum::http::Uri = "/login".parse().unwrap();
+        let template = LoginTemplate::new("", "", &session, "en", &uri);
         let result = template.render();
         assert!(result.is_ok());
         let html = result.unwrap();
@@ -540,20 +527,18 @@ mod tests {
 
     #[test]
     fn test_login_template_with_error() {
-        let template = LoginTemplate::new(
-            "Invalid credentials",
-            "",
-            "en",
-            "/login".to_string(),
-            "tok".to_string(),
-        );
+        let session = Session::anonymous_with_token("tok".to_string());
+        let uri: axum::http::Uri = "/login".parse().unwrap();
+        let template = LoginTemplate::new("Invalid credentials", "", &session, "en", &uri);
         let html = template.render().unwrap();
         assert!(html.contains("Invalid credentials"));
     }
 
     #[test]
     fn test_login_template_renders_next_hidden_field() {
-        let template = LoginTemplate::new("", "/loans", "en", "/login".to_string(), "tok".to_string());
+        let session = Session::anonymous_with_token("tok".to_string());
+        let uri: axum::http::Uri = "/login".parse().unwrap();
+        let template = LoginTemplate::new("", "/loans", &session, "en", &uri);
         let html = template.render().unwrap();
         assert!(html.contains(r#"name="next""#));
         assert!(html.contains(r#"value="/loans""#));
@@ -561,14 +546,10 @@ mod tests {
 
     #[test]
     fn test_login_template_drops_unsafe_next() {
+        let session = Session::anonymous_with_token("tok".to_string());
+        let uri: axum::http::Uri = "/login".parse().unwrap();
         let template =
-            LoginTemplate::new(
-                "",
-                "https://evil.example.com/",
-                "en",
-                "/login".to_string(),
-                "tok".to_string(),
-            );
+            LoginTemplate::new("", "https://evil.example.com/", &session, "en", &uri);
         let html = template.render().unwrap();
         // The unsafe value must be gone…
         assert!(!html.contains("evil.example.com"));

--- a/src/templates_audit.rs
+++ b/src/templates_audit.rs
@@ -445,6 +445,56 @@ fn hx_confirm_in_rust_strings_matches_allowlist() {
     }
 }
 
+/// CR #354 — every full-page handler in `src/routes/` must build the 20 shared
+/// base fields (lang, role, csrf_token, nav_*, current_url, …) via
+/// `crate::utils::base_context()`, never inline. The tell of an inline builder
+/// is a template-struct literal assigning `nav_catalog: rust_i18n::t!(...)`
+/// directly. After the migration that pattern lives ONLY in `base_context()`
+/// itself (`src/utils.rs`, outside this walk), so any match under `src/routes/`
+/// is a regression — a new page handler hand-rolling the shared fields.
+#[test]
+fn routes_build_base_context_via_helper() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let routes = root.join("src").join("routes");
+    assert!(
+        routes.is_dir(),
+        "src/routes directory not found at {}",
+        routes.display()
+    );
+
+    let mut offenders: Vec<String> = Vec::new();
+    visit(&routes, &mut |path| {
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            return;
+        }
+        let raw = match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let n = raw.matches("nav_catalog: rust_i18n::t!").count();
+        if n == 0 {
+            return;
+        }
+        let rel = path.strip_prefix(&root).unwrap_or(path);
+        offenders.push(format!(
+            "  {}: {} inline base-field builder(s)",
+            rel.to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/"),
+            n
+        ));
+    });
+
+    if !offenders.is_empty() {
+        panic!(
+            "CR #354 — inline base-context builder(s) found under src/routes/.\n\
+             A full-page handler is hand-rolling the 20 shared fields instead of \
+             calling crate::utils::base_context(). Build them via base_context() \
+             and spread `base.*` into the template struct.\n{}",
+            offenders.join("\n")
+        );
+    }
+}
+
 // ─── Story 8-2 — CSRF audit guards ─────────────────────────────────
 //
 // Two gates, one per audit target:


### PR DESCRIPTION
## Summary

PR #356 (v1.8.0) already migrated 22/23 full-page handlers to the shared `base_context()` helper. **`LoginTemplate` (`auth.rs`) was the last one** still building the 20 shared fields inline — this PR finishes the migration.

- `LoginTemplate::new` now takes `&Session` + `&Uri` and spreads `base_context(session, loc, "login", uri, 0)`. **Behavior is identical** — login is always anonymous (authenticated users redirect before render), so `role="anonymous"`, `session_timeout_secs=0`, and `csrf_token` come off the (anonymous) session exactly as before. `render_login_error` + `login_page` thread `&session`/`&uri`; the now-unused `current_url` import + `url_for_toggle` local are dropped.
- **New regression guard** (`templates_audit::routes_build_base_context_via_helper`): fails if any `src/routes/*.rs` builds `nav_catalog: rust_i18n::t!(...)` inline. After this migration that pattern lives only in `base_context()` itself (`src/utils.rs`), so the guard locks the invariant — no future page handler can hand-roll the shared fields again.
- The 3 deferred sub-items of #354 (dedup `generate_session_token`, the `anonymous_with_token` empty-token fallback, the login ephemeral-token path) are unblocked by this migration and will be filed as separate follow-up issues.

## Validation (local)

- `cargo clippy --all-targets -- -D warnings` — clean
- Unit: 4 `LoginTemplate` render tests updated to the new signature; guard test green; 53 auth lib tests green
- Integration: `auth_service` (3) + `csrf_integration` (17) green
- E2E: `login-smoke` + `security/csrf` + role/admin/librarian smoke (19 tests) green at `CI=true --workers=2`. No new spec — the migration is behavior-preserving and the whole suite logs in via the real login page, exercising the migrated render end-to-end.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)