### PR TITLE
fix(#300): phantom-volume guard — confirm modal on stale current_title_id

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -211,6 +211,11 @@ feedback:
   volume_created_suggestion: "L-Code scannen zum Einsortieren, oder weiteren V-Code scannen."
   volume_duplicate: "Etikett %{label} ist bereits %{title} zugeordnet. Bitte ein anderes Etikett scannen."
   volume_no_title: "Kein Titel ausgewählt. Scannen Sie zuerst eine ISBN, um einen Titelkontext aufzubauen."
+  volume_confirm:
+    title: "Weiteres Exemplar hinzufügen?"
+    body: "<em>%{title}</em> hat bereits %{count} Exemplar(e). Weiteres Exemplar dieses Titels hinzufügen, oder zuerst die ISBN des neuen Buchs scannen?"
+    confirm: "Exemplar hinzufügen"
+    cancel: "Abbrechen"
   volume_shelved: "Exemplar %{label} am Standort %{path} eingestellt."
   vcode_invalid: "Ungültiges V-Code-Format. Erwartet wird V gefolgt von 4 Ziffern (z. B. V0042)."
   lcode_not_found: "Standort %{label} nicht gefunden."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -211,6 +211,11 @@ feedback:
   volume_created_suggestion: "Scan L-code to shelve, or scan another V-code."
   volume_duplicate: "Label %{label} is already assigned to %{title}. Scan a different label."
   volume_no_title: "No title selected. Scan an ISBN first to establish a title context."
+  volume_confirm:
+    title: "Add another copy?"
+    body: "<em>%{title}</em> already has %{count} volume(s) attached. Add another copy of this title, or scan the new book's ISBN first?"
+    confirm: "Add another copy"
+    cancel: "Cancel"
   volume_shelved: "Volume %{label} shelved at %{path}."
   vcode_invalid: "Invalid volume code format. Expected V followed by 4 digits (e.g., V0042)."
   lcode_not_found: "Location %{label} not found."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -212,6 +212,11 @@ feedback:
   volume_created_suggestion: "Scannez un code L pour ranger, ou scannez un autre code V."
   volume_duplicate: "Le label %{label} est déjà assigné à %{title}. Scannez un autre label."
   volume_no_title: "Aucun titre sélectionné. Scannez d'abord un ISBN pour établir un contexte."
+  volume_confirm:
+    title: "Ajouter un autre exemplaire ?"
+    body: "<em>%{title}</em> a déjà %{count} exemplaire(s) attaché(s). Ajouter un autre exemplaire de ce titre, ou scanner d'abord l'ISBN du nouveau livre ?"
+    confirm: "Ajouter un exemplaire"
+    cancel: "Annuler"
   volume_shelved: "Volume %{label} rangé à %{path}."
   vcode_invalid: "Format de code volume invalide. Attendu : V suivi de 4 chiffres (ex. V0042)."
   lcode_not_found: "Emplacement %{label} introuvable."

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -207,6 +207,11 @@ feedback:
   volume_created_suggestion: "Scansiona un codice L per collocare, oppure un altro codice V."
   volume_duplicate: "L'etichetta %{label} è già assegnata a %{title}. Scansiona un'etichetta diversa."
   volume_no_title: "Nessun titolo selezionato. Scansiona prima un ISBN per stabilire un titolo di contesto."
+  volume_confirm:
+    title: "Aggiungere un'altra copia?"
+    body: "<em>%{title}</em> ha già %{count} esemplare/i. Aggiungere un'altra copia di questo titolo, o scansionare prima l'ISBN del nuovo libro?"
+    confirm: "Aggiungi una copia"
+    cancel: "Annulla"
   volume_shelved: "Esemplare %{label} collocato in %{path}."
   vcode_invalid: "Formato codice V non valido. Atteso V seguito da 4 cifre (es. V0042)."
   lcode_not_found: "Ubicazione %{label} non trovata."

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -356,6 +356,13 @@ pub async fn catalog_page(
 #[derive(Deserialize)]
 pub struct ScanForm {
     pub code: String,
+    /// CR #300: librarian explicitly confirmed adding another copy to a title
+    /// that already has ≥1 volume. Set by the volume-confirm modal's Confirm
+    /// button — bypasses the phantom-volume guard. Absent in the normal scan
+    /// path, in which case the V-code branch returns the modal instead of
+    /// silently creating a volume on a possibly-stale `current_title_id`.
+    #[serde(default)]
+    pub confirmed: bool,
 }
 
 /// Result of barcode prefix detection.
@@ -592,7 +599,9 @@ pub async fn handle_scan(
                 }
 
                 // If volume already exists and batch location is active, shelve it
-                if let Some(existing_vol) = VolumeModel::find_by_label(pool, &code).await? {
+                let existing_vol_lookup = VolumeModel::find_by_label(pool, &code).await?;
+                let existing_vol_was_some = existing_vol_lookup.is_some();
+                if let Some(existing_vol) = existing_vol_lookup {
                     let active_loc = match &session.token {
                         Some(token) => SessionModel::get_active_location(pool, token)
                             .await
@@ -662,6 +671,76 @@ pub async fn handle_scan(
                     let message = rust_i18n::t!("feedback.volume_no_title").to_string();
                     return Ok(Html(feedback_html("warning", &message, "")).into_response());
                 };
+
+                // CR #300: phantom-volume guard. `current_title_id` is sticky
+                // (set on ISBN scan, never cleared) — scanning a fresh V-code
+                // for ANOTHER physical book without re-scanning its ISBN would
+                // silently attach a new volume to the previous title. When the
+                // active title already has volumes and the librarian hasn't
+                // explicitly confirmed via the modal, return the UX-DR8
+                // confirmation modal instead of creating blind. Multi-copy
+                // titles (legitimate N volumes under one ISBN) just click
+                // Confirm; accidental stale-title attaches click Cancel.
+                // Only fires when the V-code is genuinely NEW (a re-scan of an
+                // existing V-code keeps its DUPLICATE_LABEL error path).
+                if !existing_vol_was_some && !form.confirmed {
+                    let already_has =
+                        VolumeModel::count_by_title(pool, title_id).await.unwrap_or(0);
+                    if already_has >= 1 {
+                        let title_name = crate::models::title::TitleModel::find_by_id(
+                            pool, title_id,
+                        )
+                        .await?
+                        .map(|t| t.title)
+                        .unwrap_or_else(|| "?".to_string());
+                        let escaped_title = crate::utils::html_escape(&title_name);
+                        let escaped_code = crate::utils::html_escape(&code);
+                        let body_html = rust_i18n::t!(
+                            "feedback.volume_confirm.body",
+                            locale = loc,
+                            title = &escaped_title,
+                            count = &already_has.to_string()
+                        )
+                        .to_string();
+                        let inner_form_html = format!(
+                            r#"<input type="hidden" name="code" value="{escaped_code}"><input type="hidden" name="confirmed" value="true">"#
+                        );
+                        let modal = VolumeConfirmAddModalTemplate {
+                            title: rust_i18n::t!(
+                                "feedback.volume_confirm.title",
+                                locale = loc
+                            )
+                            .to_string(),
+                            body_html,
+                            confirm_label: rust_i18n::t!(
+                                "feedback.volume_confirm.confirm",
+                                locale = loc
+                            )
+                            .to_string(),
+                            cancel_label: rust_i18n::t!(
+                                "feedback.volume_confirm.cancel",
+                                locale = loc
+                            )
+                            .to_string(),
+                            csrf_token: session.csrf_token.clone(),
+                            inner_form_html,
+                        };
+                        let html = modal.render().map_err(|_| {
+                            AppError::Internal(
+                                "volume confirm modal render failed".to_string(),
+                            )
+                        })?;
+                        return Ok((
+                            axum::http::StatusCode::OK,
+                            [
+                                ("HX-Retarget", "#modal-slot"),
+                                ("HX-Reswap", "innerHTML"),
+                            ],
+                            Html(html),
+                        )
+                            .into_response());
+                    }
+                }
 
                 match VolumeService::create_volume(pool, &code, title_id).await {
                     Ok(volume) => {
@@ -810,7 +889,13 @@ pub async fn handle_scan(
                                     },
                                 ],
                             };
-                            return Ok(resp.into_response());
+                            // CR #300: when the create was confirmed via the
+                            // phantom-volume modal, close the modal on success.
+                            return Ok(if form.confirmed {
+                                resp.into_response_with_hx_trigger("modal-close")
+                            } else {
+                                resp.into_response()
+                            });
                         }
                         // Unreachable: session.token is always present for authenticated users
                         // (require_role(Librarian) already validated the session)
@@ -2052,6 +2137,22 @@ pub struct VolumeDeleteModalTemplate {
     pub csrf_token: String,
 }
 
+/// CR #300 — confirmation modal returned by the V-code scan when the active
+/// title already has ≥1 volume. The librarian explicitly confirms before a
+/// new volume is attached, defeating the phantom-volume mechanism (a stale
+/// `current_title_id` silently accumulating volumes from other physical
+/// books during a shelve batch).
+#[derive(Template)]
+#[template(path = "fragments/volume_confirm_add_modal.html")]
+pub struct VolumeConfirmAddModalTemplate {
+    pub title: String,
+    pub body_html: String,
+    pub confirm_label: String,
+    pub cancel_label: String,
+    pub csrf_token: String,
+    pub inner_form_html: String,
+}
+
 /// `GET /volume/:id/delete-modal` — returns the UX-DR8 destructive
 /// modal for the per-volume table's Delete button (CR #209). Mirrors
 /// the series-delete-modal pattern (story 9-13). Librarian-gated,
@@ -2616,6 +2717,35 @@ pub async fn debug_set_session_timeout(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// CR #300 — the phantom-volume confirmation modal renders, surfaces the
+    /// title + count + locale labels, and embeds the bypass hidden inputs
+    /// (`code` + `confirmed=true`) that re-POST `/catalog/scan` on Confirm.
+    #[test]
+    fn test_volume_confirm_add_modal_renders() {
+        let modal = VolumeConfirmAddModalTemplate {
+            title: "Add another copy?".to_string(),
+            body_html: "<em>L'\u{00c9}tranger</em> already has 2 volume(s) attached.".to_string(),
+            confirm_label: "Add another copy".to_string(),
+            cancel_label: "Cancel".to_string(),
+            csrf_token: "tok123".to_string(),
+            inner_form_html: r#"<input type="hidden" name="code" value="V0099"><input type="hidden" name="confirmed" value="true">"#.to_string(),
+        };
+        let html = modal.render().expect("modal must render");
+        // Title + labels surfaced
+        assert!(html.contains("Add another copy?"), "title missing");
+        assert!(html.contains("Add another copy"), "confirm label missing");
+        assert!(html.contains("Cancel"), "cancel label missing");
+        // Body rendered as HTML (the <em> survives the |safe pipe)
+        assert!(html.contains("<em>L'\u{00c9}tranger</em>"), "body html not preserved");
+        // Bypass inputs present so Confirm re-POSTs with confirmed=true
+        assert!(html.contains(r#"name="confirmed" value="true""#), "confirmed bypass input missing");
+        assert!(html.contains(r#"name="code" value="V0099""#), "code input missing");
+        // POSTs to /catalog/scan (the canonical scan endpoint)
+        assert!(html.contains("/catalog/scan"), "action URL missing");
+        // CSRF token threaded through
+        assert!(html.contains("tok123"), "csrf token missing");
+    }
 
     #[test]
     fn test_detect_code_type_isbn_978() {

--- a/templates/fragments/volume_confirm_add_modal.html
+++ b/templates/fragments/volume_confirm_add_modal.html
@@ -1,0 +1,22 @@
+{# CR #300 — confirmation modal returned by the V-code scan when the active
+   current_title_id already has ≥1 volume. The librarian explicitly confirms
+   before a new volume is attached, defeating the phantom-volume mechanism
+   (a stale current_title_id silently accumulating volumes from other
+   physical books during a shelve batch). Inner hidden inputs re-POST
+   /catalog/scan with the same code and confirmed=true to bypass the guard.
+   CSP-clean. #}
+{% import "components/modal.html" as modal %}
+{% call modal::modal(
+    "warning",
+    title,
+    body_html,
+    confirm_label,
+    cancel_label,
+    "/catalog/scan",
+    "POST",
+    csrf_token,
+    "#feedback-list",
+    "innerHTML",
+    0,
+    inner_form_html,
+) %}{% endcall %}

--- a/tests/e2e/helpers/loans.ts
+++ b/tests/e2e/helpers/loans.ts
@@ -49,6 +49,19 @@ export async function scanTitleAndVolume(
   });
   await scanField.fill(volumeLabel);
   await scanField.press("Enter");
+  // CR #300: many specs share an ISBN across multiple tests, so by the 2nd
+  // test the title already has ≥1 volume and the V-code scan returns the
+  // phantom-volume confirmation modal. The helper documents the "attach
+  // this volume to this title" intent — Confirm and proceed. No-op when no
+  // modal is open (typical first-test or unique-ISBN-per-test case).
+  const phantomConfirm = page
+    .locator("#modal-slot dialog[open]")
+    .getByRole("button", {
+      name: /Add another copy|Ajouter un exemplaire|Exemplar hinzufügen|Aggiungi una copia/i,
+    });
+  if (await phantomConfirm.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await phantomConfirm.click();
+  }
   // Volume scan is synchronous; wait for a feedback entry containing the
   // exact volume label. Filter first, then assert visibility — do not use
   // `.first()` on the unfiltered list, which can lock onto a stale ISBN

--- a/tests/e2e/specs/journeys/borrower-loans.spec.ts
+++ b/tests/e2e/specs/journeys/borrower-loans.spec.ts
@@ -8,7 +8,8 @@ import {
   scanTitleAndVolume,
 } from "../../helpers/loans";
 
-const VALID_ISBN = specIsbn("BL", 1);
+// CR #300: per-test unique ISBNs so the V-code scan never hits the
+// phantom-volume confirmation modal (each test gets a fresh title).
 
 test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
   test.beforeEach(async ({ page }) => {
@@ -39,7 +40,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
   // AC2: Loan details shown on borrower page
   test("borrower with loan shows loan details", async ({ page }) => {
     await createBorrower(page, "BL-Loan Detail Borrower");
-    await scanTitleAndVolume(page, VALID_ISBN, "V0080");
+    await scanTitleAndVolume(page, specIsbn("BL", 3), "V0080");
     await createLoan(page, "V0080", "BL-Loan Detail Borrower");
 
     // Navigate to borrower detail
@@ -63,7 +64,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
   // AC3: Return loan from borrower detail
   test("return loan from borrower detail → loan disappears", async ({ page }) => {
     await createBorrower(page, "BL-Return Detail Borrower");
-    await scanTitleAndVolume(page, VALID_ISBN, "V0081");
+    await scanTitleAndVolume(page, specIsbn("BL", 4), "V0081");
     await createLoan(page, "V0081", "BL-Return Detail Borrower");
 
     // Navigate to borrower detail
@@ -98,7 +99,7 @@ test.describe("Borrower Detail & Loan History (Story 4-4)", () => {
 
     // Create borrower + title + volume + loan
     await createBorrower(page, "BL-Smoke Detail Borrower");
-    await scanTitleAndVolume(page, VALID_ISBN, "V0082");
+    await scanTitleAndVolume(page, specIsbn("BL", 5), "V0082");
     await createLoan(page, "V0082", "BL-Smoke Detail Borrower");
 
     // Navigate to borrower detail — should see loan

--- a/tests/e2e/specs/journeys/catalog-metadata.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-metadata.spec.ts
@@ -92,11 +92,14 @@ test.describe("Scan Feedback & Async Metadata (Story 1-7)", () => {
   test("already assigned V-code shows error with title name", async ({
     page,
   }) => {
+    // CR #300: unique ISBN so the title has no prior volumes and the V0055
+    // scan path doesn't hit the phantom-volume confirmation modal.
+    const isbn = specIsbn("CM", 3);
     await page.goto("/catalog");
     const scanField = page.locator("#scan-field");
 
     // First: create a title
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(isbn);
     await scanField.press("Enter");
     await expect(page.locator("#feedback-list .feedback-skeleton, #feedback-list .feedback-entry").first()).toBeVisible({ timeout: 5000 });
 

--- a/tests/e2e/specs/journeys/catalog-phantom-volume-confirm.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-phantom-volume-confirm.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+import { scanTitleAndVolume } from "../../helpers/loans";
+
+// CR #300 — phantom-volume guard. `current_title_id` is sticky in the session
+// (set on ISBN scan, never cleared). Scanning a fresh V-code without
+// re-scanning the new book's ISBN would silently attach a volume to the
+// previous title. The fix: when the active title already has ≥1 volume, the
+// V-code scan returns a UX-DR8 confirmation modal instead of creating blind.
+// Confirm = bypass the guard (multi-copy titles), Cancel = no creation.
+
+const MODAL_TITLE = /Add another copy\?|Ajouter un autre exemplaire|Weiteres Exemplar hinzuf|Aggiungere un'altra copia/i;
+const CONFIRM_LABEL = /Add another copy|Ajouter un exemplaire|Exemplar hinzufügen|Aggiungi una copia/i;
+
+test.describe("Catalog — phantom-volume guard on V-code scan (#300)", () => {
+  test("scanning a 2nd V-code on a title that already has 1 volume opens the confirmation modal; confirm creates the volume", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+    const isbn = specIsbn("PV", 1);
+
+    // Scan ISBN + first V-code — count goes 0 → 1, guard does NOT trigger
+    // (the helper waits for the 1st volume's feedback).
+    await scanTitleAndVolume(page, isbn, "V0300");
+
+    // Scan a 2nd V-code via the catalog form. The guard fires because the
+    // active title now has 1 volume — the response is the modal markup
+    // retargeted to #modal-slot, NOT a new volume.
+    await page.goto("/catalog");
+    await page.locator("#scan-field").fill("V0301");
+    await page.locator("#scan-field").press("Enter");
+
+    // Modal appears with title + confirm label localized.
+    const modal = page.locator("#modal-slot dialog[open]");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(MODAL_TITLE);
+    const confirmBtn = modal.getByRole("button", { name: CONFIRM_LABEL });
+    await expect(confirmBtn).toBeVisible();
+
+    // Click Confirm → re-POSTs /catalog/scan with confirmed=true → creates the
+    // 2nd volume (feedback contains the V-code label) and closes the modal.
+    await confirmBtn.click();
+    await expect(
+      page.locator(".feedback-entry").filter({ hasText: /V0301/i }).first(),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("#modal-slot dialog[open]")).toHaveCount(0);
+  });
+
+  test("modal Cancel closes without creating a volume", async ({ page }) => {
+    await loginAs(page, "librarian");
+    const isbn = specIsbn("PV", 2);
+    await scanTitleAndVolume(page, isbn, "V0302");
+
+    await page.goto("/catalog");
+    await page.locator("#scan-field").fill("V0303");
+    await page.locator("#scan-field").press("Enter");
+
+    const modal = page.locator("#modal-slot dialog[open]");
+    await expect(modal).toBeVisible();
+
+    // UX-DR8 invariant: Cancel button has data-modal-cancel.
+    await modal.locator("[data-modal-cancel]").click();
+    await expect(page.locator("#modal-slot dialog[open]")).toHaveCount(0);
+
+    // No feedback entry mentions V0303 — Cancel did not create the volume.
+    await expect(
+      page.locator(".feedback-entry").filter({ hasText: /V0303/i }),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/specs/journeys/catalog-volume.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-volume.spec.ts
@@ -1,10 +1,24 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
 import { specIsbn } from "../../helpers/isbn";
 import { createLocation } from "../../helpers/locations";
 
-const VALID_ISBN = specIsbn("CV", 1);
 const COUNTER_ISBN = specIsbn("CV", 2);
+
+// CR #300: when a test intentionally adds a second volume to the same title,
+// the V-code scan returns the phantom-volume confirmation modal. Click
+// Confirm to bypass the guard (the multi-copy flow). No-op if no modal is
+// open — only the "two V-codes" test below needs it.
+async function dismissPhantomConfirm(page: Page) {
+  const confirm = page
+    .locator("#modal-slot dialog[open]")
+    .getByRole("button", {
+      name: /Add another copy|Ajouter un exemplaire|Exemplar hinzufügen|Aggiungi una copia/i,
+    });
+  if (await confirm.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await confirm.click();
+  }
+}
 
 test.describe("Volume Management", () => {
   test.beforeEach(async ({ page }) => {
@@ -15,11 +29,12 @@ test.describe("Volume Management", () => {
   test("scan ISBN then V-code creates volume with success feedback", async ({
     page,
   }) => {
+    const isbn = specIsbn("CV", 3);
     await page.goto("/catalog");
     const scanField = page.locator("#scan-field");
 
     // First scan ISBN to set current title
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(isbn);
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry");
 
@@ -39,10 +54,11 @@ test.describe("Volume Management", () => {
 
   // AC2: Reject duplicate V-code
   test("scan same V-code again shows error feedback", async ({ page }) => {
+    const isbn = specIsbn("CV", 4);
     await page.goto("/catalog");
     const scanField = page.locator("#scan-field");
 
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(isbn);
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry");
 
@@ -117,14 +133,16 @@ test.describe("Volume Management", () => {
     expect(serverCalled).toBe(false);
   });
 
-  // AC5: Volume count in banner
+  // AC5: Volume count in banner — legitimately adds 2 volumes to one title,
+  // so the 2nd scan hits the CR #300 confirmation modal that we Confirm.
   test("scan ISBN then two V-codes shows banner with 2 vol", async ({
     page,
   }) => {
+    const isbn = specIsbn("CV", 5);
     await page.goto("/catalog");
     const scanField = page.locator("#scan-field");
 
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(isbn);
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry");
 
@@ -136,6 +154,8 @@ test.describe("Volume Management", () => {
 
     await scanField.fill("V0045");
     await scanField.press("Enter");
+    // 2nd volume on a title that already has V0044 → confirm modal opens.
+    await dismissPhantomConfirm(page);
 
     const banner = page.locator("#context-banner");
     await expect(banner).toContainText("vol", { timeout: 5000 });
@@ -162,6 +182,7 @@ test.describe("Volume Management", () => {
 
   // AC6: L-code assigns location (needs location data in DB)
   test("scan V-code then L-code shelves volume", async ({ page }) => {
+    const isbn = specIsbn("CV", 6);
     // Create a location and capture its L-code dynamically
     const lcode = await createLocation(page, "CV-ShelveLoc", "L3001");
 
@@ -169,7 +190,7 @@ test.describe("Volume Management", () => {
     const scanField = page.locator("#scan-field");
 
     // Set up title and volume
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(isbn);
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry");
 
@@ -230,10 +251,11 @@ test.describe("Volume accessibility", () => {
       return;
     }
 
+    const isbn = specIsbn("CV", 7);
     await page.goto("/catalog");
     const scanField = page.locator("#scan-field");
 
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(isbn);
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry");
 

--- a/tests/e2e/specs/journeys/loan-returns.spec.ts
+++ b/tests/e2e/specs/journeys/loan-returns.spec.ts
@@ -9,7 +9,8 @@ import {
 } from "../../helpers/loans";
 import { simulateScan } from "../../helpers/scanner";
 
-const VALID_ISBN = specIsbn("LR", 1);
+// CR #300: per-test unique ISBNs — each test gets a fresh title so the
+// V-code scan never hits the phantom-volume confirmation modal.
 
 test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
   test.beforeEach(async ({ page }) => {
@@ -17,15 +18,20 @@ test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
   });
 
   // Helper: create the full title+volume+borrower+loan chain for a single test
-  async function setupLoan(page: any, volumeLabel: string, borrowerName: string) {
-    await scanTitleAndVolume(page, VALID_ISBN, volumeLabel);
+  async function setupLoan(
+    page: any,
+    isbn: string,
+    volumeLabel: string,
+    borrowerName: string,
+  ) {
+    await scanTitleAndVolume(page, isbn, volumeLabel);
     await createBorrower(page, borrowerName);
     await createLoan(page, volumeLabel, borrowerName);
   }
 
   // AC1: Return a loan
   test("return a loan → loan disappears from list", async ({ page }) => {
-    await setupLoan(page, "V0070", "LR-Return Borrower");
+    await setupLoan(page, specIsbn("LR", 3), "V0070", "LR-Return Borrower");
 
     // Loan is already visible in /loans (createLoan leaves us on the loans page
     // with the row asserted). Perform the return via the canonical helper.
@@ -40,7 +46,7 @@ test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
 
   // AC4: Volume deletion guard
   test("try to delete volume on loan → blocked with error", async ({ page }) => {
-    await setupLoan(page, "V0071", "LR-Delete Guard Borrower");
+    await setupLoan(page, specIsbn("LR", 4), "V0071", "LR-Delete Guard Borrower");
 
     // Verify loan is live
     await page.goto("/loans");
@@ -86,7 +92,7 @@ test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
 
   // AC3: Overdue highlighting (styling check for a fresh loan — no threshold change)
   test("overdue loan shows red styling and badge", async ({ page }) => {
-    await setupLoan(page, "V0074", "LR-Overdue Borrower");
+    await setupLoan(page, specIsbn("LR", 5), "V0074", "LR-Overdue Borrower");
 
     // Brand-new loan (0 days) should NOT be overdue with the default threshold
     await page.goto("/loans");
@@ -118,7 +124,7 @@ test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
 
   // AC6: Scan V-code → return from scan result card
   test("scan V-code → return from scan result", async ({ page }) => {
-    await setupLoan(page, "V0072", "LR-Scan Return Borrower");
+    await setupLoan(page, specIsbn("LR", 6), "V0072", "LR-Scan Return Borrower");
 
     await page.goto("/loans");
     const scanField = page.locator("#loan-scan-field");
@@ -164,7 +170,7 @@ test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
   // burst against `body` MUST NOT leak Enter through to Cancel (which would
   // close the modal). Mirror of the 9-10 PR #129 fix pattern.
   test("scanner-guard suppresses scanner burst while modal open", async ({ page }) => {
-    await setupLoan(page, "V0075", "LR-Scanner Guard Borrower");
+    await setupLoan(page, specIsbn("LR", 7), "V0075", "LR-Scanner Guard Borrower");
 
     await page.goto("/loans");
     const loanRow = page
@@ -204,7 +210,7 @@ test.describe("Loan Return & Location Restoration (Story 4-3)", () => {
     await loginAs(page);
 
     // Create title + volume + borrower + loan via canonical helpers
-    await scanTitleAndVolume(page, VALID_ISBN, "V0073");
+    await scanTitleAndVolume(page, specIsbn("LR", 8), "V0073");
     await createBorrower(page, "LR-Smoke Return Borrower");
     await createLoan(page, "V0073", "LR-Smoke Return Borrower");
 

--- a/tests/e2e/specs/journeys/loans.spec.ts
+++ b/tests/e2e/specs/journeys/loans.spec.ts
@@ -7,7 +7,8 @@ import {
   scanTitleAndVolume,
 } from "../../helpers/loans";
 
-const VALID_ISBN = specIsbn("LN", 1);
+// CR #300: per-test unique ISBNs — each test gets a fresh title so the
+// V-code scan never hits the phantom-volume confirmation modal.
 
 test.describe("Loan Registration & Validation (Story 4-2)", () => {
   test.beforeEach(async ({ page }) => {
@@ -29,7 +30,7 @@ test.describe("Loan Registration & Validation (Story 4-2)", () => {
 
   // AC2: Register a loan
   test("register a loan → verify loan appears in list", async ({ page }) => {
-    await scanTitleAndVolume(page, VALID_ISBN, "V0060");
+    await scanTitleAndVolume(page, specIsbn("LN", 3), "V0060");
     await createBorrower(page, "LN-Loan Test Borrower");
     await createLoan(page, "V0060", "LN-Loan Test Borrower");
 
@@ -42,7 +43,7 @@ test.describe("Loan Registration & Validation (Story 4-2)", () => {
 
   // AC3: Prevent loan of non-loanable volume
   test("attempt to lend non-loanable volume → verify error", async ({ page }) => {
-    await scanTitleAndVolume(page, VALID_ISBN, "V0063");
+    await scanTitleAndVolume(page, specIsbn("LN", 4), "V0063");
 
     // Find the volume ID by scanning volume detail pages for label V0063.
     // The range is bounded by the number of volumes seeded in this test run.
@@ -109,7 +110,7 @@ test.describe("Loan Registration & Validation (Story 4-2)", () => {
 
   // AC4: Prevent double loan
   test("attempt to lend volume already on loan → verify error", async ({ page }) => {
-    await scanTitleAndVolume(page, VALID_ISBN, "V0061");
+    await scanTitleAndVolume(page, specIsbn("LN", 5), "V0061");
     await createBorrower(page, "LN-Double Loan Borrower");
 
     // Register first loan (idempotent — may already be on loan from a prior
@@ -195,7 +196,7 @@ test.describe("Loan Registration & Validation (Story 4-2)", () => {
     await loginAs(page);
 
     // Create the loan chain via canonical helpers
-    await scanTitleAndVolume(page, VALID_ISBN, "V0062");
+    await scanTitleAndVolume(page, specIsbn("LN", 6), "V0062");
     await createBorrower(page, "LN-Smoke Loan Borrower");
     await createLoan(page, "V0062", "LN-Smoke Loan Borrower");
 
@@ -209,7 +210,7 @@ test.describe("Loan Registration & Validation (Story 4-2)", () => {
   // Bug: dynamic sqlx::query() could not decode MariaDB TIMESTAMP into NaiveDateTime.
   // Fix: CAST(loaned_at AS DATETIME) in all dynamic loan queries.
   test("regression: loans page renders with active loan (TIMESTAMP fix)", async ({ page }) => {
-    await scanTitleAndVolume(page, VALID_ISBN, "V0090");
+    await scanTitleAndVolume(page, specIsbn("LN", 7), "V0090");
     await createBorrower(page, "LN-TIMESTAMP Borrower");
     await createLoan(page, "V0090", "LN-TIMESTAMP Borrower");
 

--- a/tests/e2e/specs/journeys/shelving.spec.ts
+++ b/tests/e2e/specs/journeys/shelving.spec.ts
@@ -3,7 +3,10 @@ import { loginAs } from "../../helpers/auth";
 import { specIsbn } from "../../helpers/isbn";
 import { createLocation } from "../../helpers/locations";
 
-const VALID_ISBN = specIsbn("SH", 1);
+// CR #300: VALID_ISBN was shared across 4 tests, leaving each one's title
+// with prior volumes → the V-code scan returned the phantom-volume modal.
+// Per-test unique ISBNs (specIsbn("SH", 4..7)) restore independence. The
+// _2 / _3 constants are kept since they only ever sourced a single test.
 const VALID_ISBN_2 = specIsbn("SH", 2);
 const VALID_ISBN_3 = specIsbn("SH", 3);
 
@@ -18,7 +21,7 @@ test.describe("Shelving by Scan (Story 2-2 + batch fix)", () => {
     const scanField = page.locator("#scan-field");
 
     // Create a title first
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(specIsbn("SH", 4));
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 5000 });
 
@@ -52,7 +55,7 @@ test.describe("Shelving by Scan (Story 2-2 + batch fix)", () => {
     const scanField = page.locator("#scan-field");
 
     // Book 1: ISBN → V-code
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(specIsbn("SH", 5));
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 5000 });
 
@@ -109,7 +112,7 @@ test.describe("Shelving by Scan (Story 2-2 + batch fix)", () => {
     await expect(page.locator(".feedback-entry").first()).toBeVisible({ timeout: 5000 });
 
     // Clear last_volume_label by scanning another ISBN
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(specIsbn("SH", 6));
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 5000 });
 
@@ -151,7 +154,7 @@ test.describe("Shelving by Scan (Story 2-2 + batch fix)", () => {
     const scanField = page.locator("#scan-field");
 
     // Create title + volume
-    await scanField.fill(VALID_ISBN);
+    await scanField.fill(specIsbn("SH", 7));
     await scanField.press("Enter");
     await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 5000 });
 

--- a/tests/e2e/specs/journeys/title-detail-volumes.spec.ts
+++ b/tests/e2e/specs/journeys/title-detail-volumes.spec.ts
@@ -43,6 +43,17 @@ test.describe("CR #209 — per-volume table on /title/:id", () => {
     ).toBeVisible({ timeout: 10000 });
     await scanField.fill(V_DROP);
     await scanField.press("Enter");
+    // CR #300: the title now has 1 volume → the V-code scan returns the
+    // phantom-volume confirmation modal. This test documents the legitimate
+    // multi-volume flow, so Confirm to bypass the guard.
+    const phantomConfirm = page
+      .locator("#modal-slot dialog[open]")
+      .getByRole("button", {
+        name: /Add another copy|Ajouter un exemplaire|Exemplar hinzufügen|Aggiungi una copia/i,
+      });
+    if (await phantomConfirm.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await phantomConfirm.click();
+    }
     await expect(
       page.locator(".feedback-entry").filter({ hasText: V_DROP }),
     ).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Summary

**Root cause:** `current_title_id` is set on every ISBN scan (`catalog.rs:469` etc.) but **never cleared** — no `clear_current_title` helper exists. Scanning a fresh V-code for ANOTHER physical book without re-scanning its ISBN silently attaches a new volume to the previously-scanned title. The user's report matches exactly: "3 volumes for a title, I only own 1, the others were lost" — phantoms accumulate on the last-scanned title during a shelve batch.

**Fix:** in the V-code create path (around `catalog.rs:666`), before creating, check if the active title already has ≥1 volume. If yes AND the scan wasn't explicitly confirmed, return the UX-DR8 "warning" modal: *"Add another copy of '\<title\>'?"*. Confirm re-POSTs `/catalog/scan` with `confirmed=true` to bypass the guard; Cancel = no creation. **Only fires for genuinely new V-codes** — re-scanning an existing V-code keeps its `DUPLICATE_LABEL` error path.

Multi-copy titles (legitimate N volumes under one ISBN) just click Confirm; accidental stale-title attaches click Cancel.

## What's in the change

- `ScanForm.confirmed: bool` with `#[serde(default)]`.
- New `VolumeConfirmAddModalTemplate` + `templates/fragments/volume_confirm_add_modal.html` (uses the UX-DR8 modal macro).
- i18n keys `feedback.volume_confirm.{title,body,confirm,cancel}` in en/fr/de/it (locale parity preserved).
- On a confirmed scan's success response, emit `HX-Trigger: modal-close`.

## Validation (local)

- `cargo clippy --all-targets -- -D warnings` — clean; `cargo check` — clean.
- Unit test locks the modal render: localized labels, bypass hidden inputs (`code` + `confirmed=true`), CSRF token threaded.
- E2E `catalog-phantom-volume-confirm.spec.ts`: scanning a 2nd V-code opens the modal, Confirm creates + closes, Cancel closes without creating.
- E2E regression on **fresh DB** (per Rule #13 step 3): 19/19 pass for catalog-volume + catalog-metadata + the new spec.

## Companion test refactor

`catalog-volume.spec.ts` previously shared `VALID_ISBN` across 7 tests, accumulating volumes on the same title — pre-existing parallel-state pollution that this PR's guard exposes loudly. Per-test unique ISBNs (`specIsbn("CV", N)`) restore independence. The kept `dismissPhantomConfirm` helper is invoked only in the AC5 "two V-codes" test where adding a 2nd volume to the same title is the documented flow. Same fix on the one affected `catalog-metadata.spec.ts` test (:92).

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)