### PR TITLE
fix(#18): aria-sort on the 5 sortable home-table column headers

### DIFF
--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -351,7 +351,7 @@
                                 <thead class="text-xs text-stone-500 dark:text-stone-400 uppercase border-b border-stone-200 dark:border-stone-700">
                                     <tr>
                                         <th class="px-3 py-2 w-10" aria-hidden="true"></th>
-                                        <th class="px-3 py-2">
+                                        <th class="px-3 py-2" aria-sort="{% if current_sort == "title" %}{% if current_dir == "asc" %}ascending{% else %}descending{% endif %}{% else %}none{% endif %}">
                                             <a href="/?q={{ query_encoded }}&amp;sort=title&amp;dir={% if current_sort == "title" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-get="/?q={{ query_encoded }}&amp;sort=title&amp;dir={% if current_sort == "title" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-target="#browse-results"
@@ -361,7 +361,7 @@
                                                 {{ col_title }} {% if current_sort == "title" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
                                             </a>
                                         </th>
-                                        <th class="px-3 py-2">
+                                        <th class="px-3 py-2" aria-sort="{% if current_sort == "primary_contributor" %}{% if current_dir == "asc" %}ascending{% else %}descending{% endif %}{% else %}none{% endif %}">
                                             <a href="/?q={{ query_encoded }}&amp;sort=primary_contributor&amp;dir={% if current_sort == "primary_contributor" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-get="/?q={{ query_encoded }}&amp;sort=primary_contributor&amp;dir={% if current_sort == "primary_contributor" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-target="#browse-results"
@@ -371,7 +371,7 @@
                                                 {{ col_contributor }} {% if current_sort == "primary_contributor" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
                                             </a>
                                         </th>
-                                        <th class="px-3 py-2">
+                                        <th class="px-3 py-2" aria-sort="{% if current_sort == "genre_name" %}{% if current_dir == "asc" %}ascending{% else %}descending{% endif %}{% else %}none{% endif %}">
                                             <a href="/?q={{ query_encoded }}&amp;sort=genre_name&amp;dir={% if current_sort == "genre_name" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-get="/?q={{ query_encoded }}&amp;sort=genre_name&amp;dir={% if current_sort == "genre_name" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-target="#browse-results"
@@ -381,7 +381,7 @@
                                                 {{ col_genre }} {% if current_sort == "genre_name" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
                                             </a>
                                         </th>
-                                        <th class="px-3 py-2">
+                                        <th class="px-3 py-2" aria-sort="{% if current_sort == "dewey_code" %}{% if current_dir == "asc" %}ascending{% else %}descending{% endif %}{% else %}none{% endif %}">
                                             <a href="/?q={{ query_encoded }}&amp;sort=dewey_code&amp;dir={% if current_sort == "dewey_code" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-get="/?q={{ query_encoded }}&amp;sort=dewey_code&amp;dir={% if current_sort == "dewey_code" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-target="#browse-results"
@@ -391,7 +391,7 @@
                                                 {{ col_dewey }} {% if current_sort == "dewey_code" %}{% if current_dir == "asc" %}▲{% else %}▼{% endif %}{% endif %}
                                             </a>
                                         </th>
-                                        <th class="px-3 py-2 text-right">
+                                        <th class="px-3 py-2 text-right" aria-sort="{% if current_sort == "volume_count" %}{% if current_dir == "asc" %}ascending{% else %}descending{% endif %}{% else %}none{% endif %}">
                                             <a href="/?q={{ query_encoded }}&amp;sort=volume_count&amp;dir={% if current_sort == "volume_count" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-get="/?q={{ query_encoded }}&amp;sort=volume_count&amp;dir={% if current_sort == "volume_count" && current_dir == "asc" %}desc{% else %}asc{% endif %}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}&amp;page=1"
                                                hx-target="#browse-results"


### PR DESCRIPTION
## Summary

Added `aria-sort` to each of the 5 sortable `<th>` elements on the home browse-table (title / primary_contributor / genre_name / dewey_code / volume_count), emitting `ascending` / `descending` / `none` based on the current `sort` + `dir` query params. Screen-reader users now hear which column is sorted and in which direction.

## Scope note for #18

This PR closes the **aria-sort sub-item** only. The two remaining sub-items of #18 are tracked as a follow-up issue:

- i18n the hardcoded `aria-label="Active filter: ..."` / `aria-label="Filter by: ..."` strings on the home filter chips.
- Re-enable the `@axe-core/playwright` `color-contrast` rule currently `disableRules`'d in `catalog-title.spec.ts:299`, `catalog-volume.spec.ts:269`, `catalog-contributor.spec.ts:457` (requires bumping the placeholder-input contrast first).

## Validation

- `cargo check` — clean (Askama templates compile via proc-macro).

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)