### PR TITLE
fix(#151): align UX spec + Epic 9.18 nav tables with shipped impl

### DIFF
--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1518,7 +1518,7 @@ The dashboard shows actionable indicators with counts. Every page has encouragin
 **UX-DRs:** UX-DR6 (role visibility polish — completion of Epic 1's basic nav)
 
 **Acceptance Criteria:**
-- Given the nav bar (desktop or hamburger), when rendered for an anonymous user, then the visible links are exactly: Home (/), Catalog (read-only — clicking takes them to `/login` per existing gate), Sign in (/login), Theme toggle, Language toggle — NO Loans, NO Borrowers, NO Admin, NO Sign out
+- Given the nav bar (desktop or hamburger), when rendered for an anonymous user, then the visible links are exactly: Home (/), Catalog (read-only), Locations (read-only), Series (read-only), Sign in (/login), Theme toggle, Language toggle — NO Loans, NO Borrowers, NO Admin, NO Sign out
 - Given the nav bar, when rendered for a librarian, then the visible links are: Home, Catalog, Loans, Borrowers, Theme, Language, Sign out — NO Admin
 - Given the nav bar, when rendered for an admin, then the visible links are: Home, Catalog, Loans, Borrowers, Admin, Theme, Language, Sign out (all links)
 - Given a role downgrade (e.g., admin demoted to librarian by another admin via 8-3), when the next page is rendered, then the nav reflects the new role on the very next request — no stale "Admin" link from a cached template

--- a/_bmad-output/planning-artifacts/ux-design-specification.md
+++ b/_bmad-output/planning-artifacts/ux-design-specification.md
@@ -1769,7 +1769,7 @@ Before specifying individual components, behavioral analysis identified 5 groups
 | Link | Anonymous | Librarian | Admin |
 |------|-----------|-----------|-------|
 | Home (/) | ✅ (logo) | ✅ (logo) | ✅ (logo) |
-| Catalog (/catalog) | — | ✅ | ✅ |
+| Catalog (/catalog) | ✅ (read-only) | ✅ | ✅ |
 | Loans (/loans) | — | ✅ | ✅ |
 | Series (/series) | ✅ | ✅ | ✅ |
 | Locations (/locations) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
## Summary

Doc-only alignment of three sources that disagreed on the anonymous nav-link set. Story 9-18 already shipped Option A (current impl); this PR brings the planning docs in line so future readers don't reopen the debate.

- **UX spec table** (`_bmad-output/planning-artifacts/ux-design-specification.md:1772`): Catalog row for Anonymous flips from `—` to `✅ (read-only)`. Now matches Locations + Series, which were already ✅.
- **Epic 9.18 spec** (`_bmad-output/planning-artifacts/epics.md:1521`): drops the factually wrong parenthetical *"Catalog (read-only — clicking takes them to /login per existing gate)"* and adds the missing Locations + Series links. The shipped impl + the test `anonymous_gets_200_on_catalog` prove /catalog is anonymous-readable.

Implementation in `templates/components/nav_bar.html` is unchanged and remains the single source of truth (locked by `tests/navbar_role_visibility.rs::anonymous_nav_link_set_exact`).

Closes #151

## Test plan

- [x] Re-read both edited tables to confirm consistency with `nav_bar.html`
- No code changed, no test changes required; CI runs the standard locale-parity / clippy / sqlx gates which are unaffected by spec-doc edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)