### PR TITLE
fix(#365): centralize token generators + drop empty-CSRF extractor fallback

### DIFF
--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -99,24 +99,6 @@ impl Session {
     }
 }
 
-/// Generate a URL-safe base64-encoded 32-byte CSRF token. Co-located with
-/// the auth middleware so the session resolver can mint anonymous-session
-/// tokens without pulling in the CSRF-middleware module (which would
-/// create a circular dependency).
-pub fn generate_csrf_token() -> String {
-    use base64::Engine;
-    let bytes: [u8; 32] = rand::random();
-    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
-}
-
-/// Generate a session token matching the 44-char base64 format used by
-/// `src/routes/auth.rs::generate_session_token`.
-fn generate_session_token() -> String {
-    use base64::Engine;
-    let bytes: [u8; 32] = rand::random();
-    base64::engine::general_purpose::STANDARD.encode(bytes)
-}
-
 /// Session resolver middleware. Runs on every request. Reads the
 /// `session` cookie, resolves the session row (authenticated OR
 /// anonymous) via `SessionModel::find_resolved`, and mints a fresh
@@ -279,8 +261,8 @@ async fn resolve_or_mint(
     // down, unique-collision, etc.) fall back to an in-memory session
     // so the request still completes; the client gets a fresh token on
     // the next request.
-    let new_session_token = generate_session_token();
-    let new_csrf_token = generate_csrf_token();
+    let new_session_token = crate::utils::generate_session_token();
+    let new_csrf_token = crate::utils::generate_csrf_token();
     match SessionModel::insert_anonymous(&state.pool, &new_session_token, &new_csrf_token).await {
         Ok(()) => (
             Session {
@@ -366,12 +348,25 @@ impl FromRequestParts<crate::AppState> for Session {
         // middleware still need a Session. Read the cookie and look up
         // the authenticated session (anonymous-DB-row minting is
         // middleware-only; the extractor never writes cookies).
+        //
+        // #365: when the fallback returns an anonymous session, mint a
+        // fresh ephemeral CSRF token instead of the historic
+        // `String::new()` placeholder. The empty-string fallback was a
+        // latent footgun — two anonymous sessions both carrying `""`
+        // would treat the empty form-input as a valid CSRF match in the
+        // constant-time compare. Production never reaches this path (the
+        // resolver middleware always runs first and populates the
+        // Extension), but tests that exercise CSRF-protected POSTs
+        // without wiring the resolver would otherwise observe the
+        // empty-matches-empty surprise.
         let jar = CookieJar::from_request_parts(parts, state)
             .await
             .unwrap_or_default();
 
         let Some(cookie) = jar.get("session") else {
-            return Ok(Session::anonymous_with_token(String::new()));
+            return Ok(Session::anonymous_with_token(
+                crate::utils::generate_csrf_token(),
+            ));
         };
 
         let token = cookie.value();
@@ -395,7 +390,9 @@ impl FromRequestParts<crate::AppState> for Session {
                     preferred_language: row.preferred_language,
                 })
             }
-            _ => Ok(Session::anonymous_with_token(String::new())),
+            _ => Ok(Session::anonymous_with_token(
+                crate::utils::generate_csrf_token(),
+            )),
         }
     }
 }
@@ -667,25 +664,9 @@ mod tests {
         assert!(session.require_role(Role::Librarian, "fr").is_ok());
     }
 
-    #[test]
-    fn test_generate_csrf_token_length_and_charset() {
-        let tok = generate_csrf_token();
-        // URL-safe base64 of 32 bytes, no padding = 43 chars.
-        assert_eq!(tok.len(), 43);
-        for c in tok.chars() {
-            assert!(
-                c.is_ascii_alphanumeric() || c == '-' || c == '_',
-                "unexpected char {c:?} in CSRF token"
-            );
-        }
-    }
-
-    #[test]
-    fn test_generate_csrf_token_unique() {
-        let a = generate_csrf_token();
-        let b = generate_csrf_token();
-        assert_ne!(a, b, "token generator must produce distinct values");
-    }
+    // generate_csrf_token / generate_session_token live in src/utils.rs
+    // post-#365 and carry their own length / charset / uniqueness tests
+    // there. No duplicated coverage here.
 
     #[test]
     fn test_anonymous_with_token_preserves_token() {

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -67,13 +67,6 @@ pub const CSRF_EXEMPT_ROUTES: &[(&str, &str)] = &[("POST", "/login")];
 /// does not pay for reading megabytes before rejecting.
 const MAX_CSRF_BODY_BYTES: usize = 1024 * 1024;
 
-/// URL-safe base64 32-byte token, re-exported so callers outside the
-/// middleware (login handler, session resolver) can mint matching
-/// tokens from one place.
-pub fn generate_csrf_token() -> String {
-    crate::middleware::auth::generate_csrf_token()
-}
-
 /// Normalize a request path for exempt-route comparison so that URI variants
 /// Axum's router would dispatch to the same handler (trailing `/`, repeated
 /// `/`) also bypass CSRF.
@@ -608,15 +601,8 @@ mod tests {
         assert!(!ct_eq(stored, b""));
     }
 
-    #[test]
-    fn test_generate_csrf_token_is_43_chars() {
-        assert_eq!(generate_csrf_token().len(), 43);
-    }
-
-    #[test]
-    fn test_generate_csrf_token_is_unique() {
-        assert_ne!(generate_csrf_token(), generate_csrf_token());
-    }
+    // generate_csrf_token moved to src/utils.rs post-#365 — length and
+    // uniqueness coverage now lives there.
 
     #[sqlx::test(migrations = "./migrations")]
     async fn get_requests_bypass_csrf(pool: crate::db::DbPool) {

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -181,8 +181,8 @@ pub async fn login(
     // Generate session + CSRF tokens. Story 8-2: CSRF token rotates on
     // every login so a pre-login anonymous token cannot be replayed
     // against the authenticated session.
-    let token = generate_session_token();
-    let csrf_token = crate::middleware::csrf::generate_csrf_token();
+    let token = crate::utils::generate_session_token();
+    let csrf_token = crate::utils::generate_csrf_token();
 
     // Insert session into database. Explicitly UTC_TIMESTAMP so the
     // expiry check (Rust-side `Utc::now()`) cannot drift vs a server
@@ -440,49 +440,14 @@ pub async fn logout(
     Ok((jar.remove(cookie), Redirect::to("/").into_response()))
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────
-
-pub fn generate_session_token() -> String {
-    use base64::Engine;
-    let bytes: [u8; 32] = rand::random();
-    base64::engine::general_purpose::STANDARD.encode(bytes)
-}
-
 // ─── Tests ───────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_generate_session_token_length() {
-        let token = generate_session_token();
-        assert_eq!(
-            token.len(),
-            44,
-            "Token should be 44 chars (32 bytes base64)"
-        );
-    }
-
-    #[test]
-    fn test_generate_session_token_is_base64() {
-        use base64::Engine;
-        let token = generate_session_token();
-        let decoded = base64::engine::general_purpose::STANDARD.decode(&token);
-        assert!(decoded.is_ok(), "Token should be valid base64");
-        assert_eq!(
-            decoded.unwrap().len(),
-            32,
-            "Decoded token should be 32 bytes"
-        );
-    }
-
-    #[test]
-    fn test_generate_session_token_unique() {
-        let t1 = generate_session_token();
-        let t2 = generate_session_token();
-        assert_ne!(t1, t2, "Tokens should be unique");
-    }
+    // generate_session_token moved to src/utils.rs post-#365; length /
+    // base64 / uniqueness coverage now lives there.
 
     #[test]
     fn test_verify_password_valid() {
@@ -542,6 +507,35 @@ mod tests {
         let html = template.render().unwrap();
         assert!(html.contains(r#"name="next""#));
         assert!(html.contains(r#"value="/loans""#));
+    }
+
+    /// #365 sub-item 3 — confirm the login GET page rendered through
+    /// `LoginTemplate::new` carries the session's CSRF token into the
+    /// form's hidden `_csrf_token` input. In production the session comes
+    /// off `session_resolve_middleware` and therefore always carries a
+    /// DB-backed token; this test locks the contract on the template
+    /// layer so a future refactor that loses the wiring (e.g. drops
+    /// `base_context`) trips here instead of failing at the next POST
+    /// /login round-trip with a 403.
+    #[test]
+    fn login_template_emits_session_csrf_token_in_form() {
+        let session = Session::anonymous_with_token("real-csrf-abc123".to_string());
+        let uri: axum::http::Uri = "/login".parse().unwrap();
+        let template = LoginTemplate::new("", "", &session, "en", &uri);
+        let html = template.render().unwrap();
+        assert!(
+            html.contains(r#"name="_csrf_token""#)
+                && html.contains(r#"value="real-csrf-abc123""#),
+            "login form must echo the session CSRF token as a hidden input \
+             — the next POST /login depends on it",
+        );
+        // The meta tag also has to carry the token so HTMX-mediated POSTs
+        // from any page rendered under base.html (e.g. lang toggle, nav
+        // logout) can populate `X-CSRF-Token`.
+        assert!(
+            html.contains(r#"<meta name="csrf-token" content="real-csrf-abc123""#),
+            "base layout must inject the same token via <meta csrf-token>",
+        );
     }
 
     #[test]

--- a/src/services/auth.rs
+++ b/src/services/auth.rs
@@ -18,21 +18,7 @@
 
 use crate::db::DbPool;
 use crate::error::AppError;
-use crate::middleware::auth::generate_csrf_token;
-
-/// 32-byte STANDARD base64 token (44 chars w/ padding, matches the
-/// existing `routes/auth.rs::generate_session_token` and the project
-/// convention for session tokens — CSRF tokens use `URL_SAFE_NO_PAD`,
-/// session tokens use `STANDARD`; the `+/=` chars get percent-encoded
-/// in cookie values and decoded by the session resolver). Kept here
-/// (rather than re-exporting from `routes/auth.rs`) so the `services`
-/// layer never depends on `routes`. Story 8-8 review P15 corrected the
-/// previous "URL-safe" doc-comment.
-fn generate_session_token() -> String {
-    use base64::Engine;
-    let bytes: [u8; 32] = rand::random();
-    base64::engine::general_purpose::STANDARD.encode(bytes)
-}
+use crate::utils::{generate_csrf_token, generate_session_token};
 
 /// Mint a fresh authenticated session for `user_id`. Returns
 /// `(session_token, csrf_token)` so the caller can set the cookie and
@@ -94,19 +80,5 @@ pub async fn authenticate_session(
     Ok((session_token, csrf_token))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn generate_session_token_length_is_44() {
-        // Match the existing `routes/auth.rs::generate_session_token`
-        // contract — base64 of 32 bytes with padding.
-        assert_eq!(generate_session_token().len(), 44);
-    }
-
-    #[test]
-    fn generate_session_token_is_unique() {
-        assert_ne!(generate_session_token(), generate_session_token());
-    }
-}
+// generate_session_token + generate_csrf_token now live in src/utils.rs
+// (#365) and own their length/charset/uniqueness coverage there.

--- a/src/services/setup.rs
+++ b/src/services/setup.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use crate::AppState;
 use crate::db::DbPool;
 use crate::error::AppError;
-use crate::middleware::auth::generate_csrf_token;
+use crate::utils::generate_csrf_token;
 use crate::models::user::UserModel;
 use crate::services::admin_system::{
     KEY_DEFAULT_LANGUAGE, KEY_GOOGLE_BOOKS, KEY_OMDB, KEY_SETUP_COMPLETED_AT,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,33 @@
+/// Generate a STANDARD-base64-encoded 32-byte session token (44 chars
+/// w/ padding). Canonical implementation for `sessions.token`. Earlier
+/// versions of the codebase duplicated this function across
+/// `routes/auth.rs`, `services/auth.rs`, and `middleware/auth.rs`; the
+/// three copies drifted with comments and contracts. Centralized here
+/// (the `utils` layer depends on nothing else inside the crate, so no
+/// module dependency cycle is introduced).
+///
+/// STANDARD (not URL-safe) base64 matches the historic on-disk format;
+/// the `+`/`/`/`=` chars get percent-encoded inside `Set-Cookie` values
+/// and decoded by the session resolver on the way back in. CSRF tokens
+/// use URL_SAFE_NO_PAD — see `generate_csrf_token` below.
+pub fn generate_session_token() -> String {
+    use base64::Engine;
+    let bytes: [u8; 32] = rand::random();
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Generate a URL_SAFE_NO_PAD-base64-encoded 32-byte CSRF token (43
+/// chars). Canonical implementation for `sessions.csrf_token`. Previously
+/// duplicated across `middleware/auth.rs` (canonical) and re-exported
+/// from `middleware/csrf.rs`; centralizing in `utils` lets callers
+/// (`services/auth.rs`, `services/setup.rs`, `routes/auth.rs`) import
+/// directly instead of routing through middleware modules.
+pub fn generate_csrf_token() -> String {
+    use base64::Engine;
+    let bytes: [u8; 32] = rand::random();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
 /// Return `/path` or `/path?query` from an `axum::http::Uri`, stripping the
 /// scheme, host, and fragment. Used to populate the `current_url` hidden
 /// field on the language-toggle form (story 7-3 AC 8) so clicking FR/EN
@@ -257,6 +287,47 @@ pub fn base_context(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn generate_session_token_length_is_44() {
+        // 32 bytes → STANDARD base64 with padding → 44 chars. Locks the
+        // wire format expected by the `sessions.token` schema (VARCHAR(64))
+        // and by `tasks/anonymous_session_purge.rs` (which assumes 44-char
+        // tokens when crafting LIKE patterns).
+        assert_eq!(generate_session_token().len(), 44);
+    }
+
+    #[test]
+    fn generate_session_token_is_unique() {
+        assert_ne!(generate_session_token(), generate_session_token());
+    }
+
+    #[test]
+    fn generate_csrf_token_length_is_43() {
+        // 32 bytes → URL_SAFE_NO_PAD base64 → 43 chars (no `=` padding).
+        // Matches the existing CSRF wire format read by
+        // `templates/layouts/base.html` (the `<meta name="csrf-token">`
+        // value) and `static/js/csrf.js` (the `X-CSRF-Token` header).
+        assert_eq!(generate_csrf_token().len(), 43);
+    }
+
+    #[test]
+    fn generate_csrf_token_is_unique() {
+        assert_ne!(generate_csrf_token(), generate_csrf_token());
+    }
+
+    #[test]
+    fn generate_csrf_token_is_url_safe_charset() {
+        // Sanity: URL_SAFE base64 uses `[A-Za-z0-9_-]` only — no `+`/`/`/`=`.
+        // A regression that swapped to STANDARD here would silently break
+        // the `X-CSRF-Token` header on Set-Cookie + Cookie round-trips.
+        let tok = generate_csrf_token();
+        assert!(
+            tok.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "CSRF token must use URL-safe charset: {tok:?}"
+        );
+    }
 
     #[test]
     fn test_current_url_path_only() {


### PR DESCRIPTION
## Summary

Three things, all in the auth surface, all unblocked by #354 (`base_context()` now flows `session.csrf_token` through every page handler uniformly).

1. **Dedup `generate_session_token`.** Previously defined in three places:
   - `src/routes/auth.rs:445` (`pub`)
   - `src/services/auth.rs:31` (private, used by `authenticate_session`)
   - `src/middleware/auth.rs:114` (private, used by the session resolver)

   The three copies had drifting doc-comments and an identical contract. Collapsed to a single canonical implementation in `src/utils.rs` (no internal-crate dependencies, so no module cycle introduced). Same move for `generate_csrf_token` — previously in `middleware/auth.rs:106` + re-exported via `middleware/csrf.rs:73`. Call sites updated: login + `authenticate_session` + setup Step 1 + `resolve_or_mint`. The 5 duplicated length/uniqueness tests collapsed into one set in `utils.rs`.

2. **Drop the empty-CSRF fallback in the `Session` extractor** (lines 356 and 380 of `middleware/auth.rs`). The historic `Session::anonymous_with_token(String::new())` returned a session whose `csrf_token` was the empty string. Production never reaches this branch (the resolver middleware always populates the Extension first), so it's a tests-only path. But it was a latent footgun — two anonymous sessions both carrying `\"\"` would treat the empty form-input as a valid CSRF match in the constant-time compare. Both fallbacks now mint a fresh ephemeral csrf_token via `crate::utils::generate_csrf_token()`.

3. **Lock the login render token path.** Post-#354 the login GET handler builds its template via `base_context()`, which reads `session.csrf_token` straight from the resolver-populated session. Added `login_template_emits_session_csrf_token_in_form` — asserts the token reaches both the form's hidden `_csrf_token` input and the `<meta name=\"csrf-token\">` tag in `base.html`. A future refactor that loses the wiring trips here instead of failing at the next POST /login round-trip with a 403.

Net diff: 6 files, +132 / −128 lines. Token contracts identical (44-char STANDARD base64 sessions, 43-char URL-safe-no-pad CSRF).

Closes #365

## Test plan

- [x] `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib --no-fail-fast` against rust-test DB on :3307 — 987 / 987 green
- [x] New regression test `routes::auth::tests::login_template_emits_session_csrf_token_in_form` green
- [ ] CI must stay green on the full job matrix (sqlx-offline cache, db-integration, e2e, locale-parity, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)