### PR TITLE
fix(#20): windowed pagination on home /

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -107,6 +107,64 @@ impl<T> PaginatedList<T> {
     pub fn has_next(&self) -> bool {
         self.page < self.total_pages
     }
+
+    /// #20 — Windowed pagination entries (First | … | window | … | Last).
+    ///
+    /// Pre-fix the home template walked `1..=total_pages` and emitted one
+    /// `<a>` per page. A 10 000-title catalog → 400 pages → 400 `<a>` in
+    /// the DOM (slow render, poor UX, ridiculous tab order). A
+    /// `?page=999999` in the URL would render an even bigger block.
+    ///
+    /// This helper returns at most `2 * (WINDOW_RADIUS=3) + 1` pages
+    /// around the current page plus first / last anchors, with
+    /// `Ellipsis` markers wherever a gap larger than one page exists.
+    /// Bounded output: 11 entries max regardless of `total_pages`.
+    /// Template iterates over the returned `Vec<PageEntry>` and emits an
+    /// anchor for `Page(n)` or a literal `…` span for `Ellipsis`.
+    pub fn windowed_pages(&self) -> Vec<PageEntry> {
+        use std::collections::BTreeSet;
+        const WINDOW_RADIUS: u32 = 3;
+        let total = self.total_pages;
+        if total == 0 {
+            return Vec::new();
+        }
+        let current = self.page.clamp(1, total);
+
+        // Always include first, last, and current ± radius. BTreeSet
+        // both dedups and orders for the gap-detection sweep below.
+        let mut pages = BTreeSet::new();
+        pages.insert(1);
+        pages.insert(total);
+        let start = current.saturating_sub(WINDOW_RADIUS).max(1);
+        let end = current.saturating_add(WINDOW_RADIUS).min(total);
+        for p in start..=end {
+            pages.insert(p);
+        }
+
+        let mut out = Vec::with_capacity(pages.len() + 2);
+        let mut prev: Option<u32> = None;
+        for p in &pages {
+            if let Some(prev_p) = prev
+                && *p > prev_p + 1
+            {
+                out.push(PageEntry::Ellipsis);
+            }
+            out.push(PageEntry::Page(*p));
+            prev = Some(*p);
+        }
+        out
+    }
+}
+
+/// #20 — one entry in the windowed pagination output.
+///
+/// `Page(n)` renders as an anchor in the template; `Ellipsis` renders as
+/// a non-interactive `<span aria-hidden="true">…</span>` so screen
+/// readers don't announce a gap as a clickable page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageEntry {
+    Page(u32),
+    Ellipsis,
 }
 
 #[cfg(test)]
@@ -171,5 +229,138 @@ mod tests {
     fn test_paginated_list_26_items() {
         let list: PaginatedList<u32> = PaginatedList::new(vec![1; 25], 1, 26, None, None, None);
         assert_eq!(list.total_pages, 2);
+    }
+
+    // ─── #20 — windowed pagination coverage ─────────────────────────
+
+    /// Sub-7 page sets emit no ellipsis — the contiguous range fits.
+    #[test]
+    fn windowed_pages_small_total_is_contiguous() {
+        let list: PaginatedList<u32> = PaginatedList::new(vec![], 3, 6 * 25, None, None, None);
+        // 150 items / 25 per page = 6 pages, current = 3.
+        assert_eq!(list.total_pages, 6);
+        let pages = list.windowed_pages();
+        assert_eq!(
+            pages,
+            vec![
+                PageEntry::Page(1),
+                PageEntry::Page(2),
+                PageEntry::Page(3),
+                PageEntry::Page(4),
+                PageEntry::Page(5),
+                PageEntry::Page(6),
+            ],
+        );
+    }
+
+    /// Large total with current in the middle: First | … | window | … | Last.
+    /// Locks the bound: at most 11 entries (2 anchors + 7 window + 2
+    /// ellipses).
+    #[test]
+    fn windowed_pages_large_total_emits_bounded_window() {
+        // 10_000 items / 25 per page = 400 pages — the issue scenario.
+        let list: PaginatedList<u32> =
+            PaginatedList::new(vec![], 10, 10_000, None, None, None);
+        assert_eq!(list.total_pages, 400);
+        let pages = list.windowed_pages();
+        assert_eq!(
+            pages,
+            vec![
+                PageEntry::Page(1),
+                PageEntry::Ellipsis,
+                PageEntry::Page(7),
+                PageEntry::Page(8),
+                PageEntry::Page(9),
+                PageEntry::Page(10),
+                PageEntry::Page(11),
+                PageEntry::Page(12),
+                PageEntry::Page(13),
+                PageEntry::Ellipsis,
+                PageEntry::Page(400),
+            ],
+        );
+        assert!(
+            pages.len() <= 11,
+            "windowed pagination must stay bounded; got {}",
+            pages.len()
+        );
+    }
+
+    /// Current near the start — the leading ellipsis is suppressed
+    /// because the window touches page 1.
+    #[test]
+    fn windowed_pages_current_near_start() {
+        let list: PaginatedList<u32> =
+            PaginatedList::new(vec![], 2, 10_000, None, None, None);
+        let pages = list.windowed_pages();
+        // Pages 1..=5 contiguous, then ellipsis, then 400.
+        assert_eq!(
+            pages,
+            vec![
+                PageEntry::Page(1),
+                PageEntry::Page(2),
+                PageEntry::Page(3),
+                PageEntry::Page(4),
+                PageEntry::Page(5),
+                PageEntry::Ellipsis,
+                PageEntry::Page(400),
+            ],
+        );
+    }
+
+    /// Current near the end — trailing ellipsis suppressed for the same
+    /// reason on the other side.
+    #[test]
+    fn windowed_pages_current_near_end() {
+        let list: PaginatedList<u32> =
+            PaginatedList::new(vec![], 399, 10_000, None, None, None);
+        let pages = list.windowed_pages();
+        assert_eq!(
+            pages,
+            vec![
+                PageEntry::Page(1),
+                PageEntry::Ellipsis,
+                PageEntry::Page(396),
+                PageEntry::Page(397),
+                PageEntry::Page(398),
+                PageEntry::Page(399),
+                PageEntry::Page(400),
+            ],
+        );
+    }
+
+    /// `?page=999999` (way out of range) — the issue's second sub-item.
+    /// The window must still be bounded. `current` is clamped to
+    /// `total_pages`, so the result is the same as "current = last".
+    #[test]
+    fn windowed_pages_out_of_range_current_is_clamped() {
+        let list: PaginatedList<u32> =
+            PaginatedList::new(vec![], 999_999, 10_000, None, None, None);
+        let pages = list.windowed_pages();
+        assert_eq!(
+            pages,
+            vec![
+                PageEntry::Page(1),
+                PageEntry::Ellipsis,
+                PageEntry::Page(397),
+                PageEntry::Page(398),
+                PageEntry::Page(399),
+                PageEntry::Page(400),
+            ],
+        );
+        assert!(
+            pages.len() <= 11,
+            "out-of-range current must still produce a bounded window; got {}",
+            pages.len()
+        );
+    }
+
+    /// total_pages == 0 (edge case: empty list with current = 1) — return
+    /// an empty Vec so the template skips the nav entirely.
+    #[test]
+    fn windowed_pages_zero_total_returns_empty() {
+        let mut list: PaginatedList<u32> = PaginatedList::new(vec![], 1, 0, None, None, None);
+        list.total_pages = 0; // force the zero case the constructor avoids
+        assert_eq!(list.windowed_pages(), Vec::<PageEntry>::new());
     }
 }

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -439,15 +439,23 @@
                        hx-target="#browse-results" hx-swap="innerHTML" hx-push-url="true"
                        class="px-3 py-1 rounded border border-stone-300 dark:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800 text-sm">&laquo; {{ pagination_previous }}</a>
                     {% endif %}
-                    {% for p in 1..=paginated.total_pages %}
-                        {% if p == paginated.page %}
-                        <span class="px-3 py-1 rounded bg-indigo-600 text-white text-sm" aria-current="page">{{ p }}</span>
-                        {% else %}
-                        <a href="/?q={{ query_encoded }}&amp;page={{ p }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}"
-                           hx-get="/?q={{ query_encoded }}&amp;page={{ p }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}"
-                           hx-target="#browse-results" hx-swap="innerHTML" hx-push-url="true"
-                           class="px-3 py-1 rounded border border-stone-300 dark:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800 text-sm">{{ p }}</a>
-                        {% endif %}
+                    {# #20 — windowed pagination: First | … | window | … | Last,
+                       capped at ≤11 entries so a 10 000-title catalog (400 pages)
+                       does NOT render 400 anchors. See PaginatedList::windowed_pages. #}
+                    {% for entry in paginated.windowed_pages() %}
+                        {% match entry %}
+                        {% when crate::models::PageEntry::Page with (p) %}
+                            {% if *p == paginated.page %}
+                            <span class="px-3 py-1 rounded bg-indigo-600 text-white text-sm" aria-current="page">{{ p }}</span>
+                            {% else %}
+                            <a href="/?q={{ query_encoded }}&amp;page={{ p }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}"
+                               hx-get="/?q={{ query_encoded }}&amp;page={{ p }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}"
+                               hx-target="#browse-results" hx-swap="innerHTML" hx-push-url="true"
+                               class="px-3 py-1 rounded border border-stone-300 dark:border-stone-600 hover:bg-stone-100 dark:hover:bg-stone-800 text-sm">{{ p }}</a>
+                            {% endif %}
+                        {% when crate::models::PageEntry::Ellipsis %}
+                            <span class="px-3 py-1 text-stone-500 dark:text-stone-400 text-sm" aria-hidden="true">…</span>
+                        {% endmatch %}
                     {% endfor %}
                     {% if paginated.has_next() %}
                     <a href="/?q={{ query_encoded }}&amp;page={{ paginated.page + 1 }}&amp;sort={{ current_sort }}&amp;dir={{ current_dir }}{% if !active_filter.is_empty() %}&amp;filter={{ active_filter }}{% endif %}"


### PR DESCRIPTION
## Summary

Pre-fix the home template walked `1..=total_pages` and rendered one `<a>` per page. At 10 000 titles (400 pages at the default 25/page), that's 400 anchors in the DOM — slow render, awful tab order, and a URL like `?page=999999` would render an even bigger block.

## Fix

New `PaginatedList::windowed_pages()` returns a `Vec<PageEntry>` capped at ≤11 entries:
- always first + last
- current page ± 3
- `PageEntry::Ellipsis` markers for any gap larger than one page

Out-of-range `?page=N` is clamped to `[1, total_pages]` before the window is computed.

Template change in `templates/pages/home.html`:

```askama
{% for entry in paginated.windowed_pages() %}
    {% match entry %}
    {% when crate::models::PageEntry::Page with (p) %}
        {% if *p == paginated.page %}…current…{% else %}…<a>…</a>{% endif %}
    {% when crate::models::PageEntry::Ellipsis %}
        <span aria-hidden="true">…</span>
    {% endmatch %}
{% endfor %}
```

Ellipsis renders as a non-interactive `<span aria-hidden="true">…</span>` so screen readers don't announce a gap as a clickable page.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib --no-fail-fast` against rust-test DB on :3307 — 998 / 998 green
- [x] 6 new unit tests on `PaginatedList::windowed_pages`:
  - `windowed_pages_small_total_is_contiguous` — sub-7 totals stay contiguous, no ellipsis
  - `windowed_pages_large_total_emits_bounded_window` — 10 000 items → bounded [1, …, 7..13, …, 400]
  - `windowed_pages_current_near_start` — leading ellipsis suppressed
  - `windowed_pages_current_near_end` — trailing ellipsis suppressed
  - `windowed_pages_out_of_range_current_is_clamped` — `?page=999999` clamped
  - `windowed_pages_zero_total_returns_empty` — edge case
- [ ] CI green on the full matrix

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)