### PR TITLE
fix(#29): swap serde_yaml → serde_yaml_ng + lock locale HTML safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml",
+ "serde_yaml_ng",
  "sqlx",
  "subtle",
  "tempfile",
@@ -2936,6 +2936,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa 1.0.18",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa 1.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,12 @@ genpdf = "0.2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
-serde_yaml = "0.9"
+# #29 sub-item 3 — `serde_yaml` 0.9 is unmaintained (RUSTSEC-2024-0320).
+# `serde_yaml_ng` is the community fork that keeps shipping fixes against
+# the same 0.9 API surface, so the switch is one-line in code (the type
+# names live under `serde_yaml_ng::*` instead of `serde_yaml::*`).
+# Dev-dep only — used by i18n audit and the locale_parity integration test.
+serde_yaml_ng = "0.10"
 regex = "1"
 # Captures tracing events emitted during a test so we can assert on
 # security-audit warnings (story 8-2 §Ships 16 — CSRF-rejection warn log).

--- a/src/i18n/audit.rs
+++ b/src/i18n/audit.rs
@@ -117,12 +117,12 @@ mod tests {
 
     /// Check whether a dotted key (e.g. `nav.catalog`) resolves to a leaf in the
     /// YAML tree. Leaves are scalars; maps are rejected.
-    fn key_exists(value: &serde_yaml::Value, dotted: &str) -> bool {
+    fn key_exists(value: &serde_yaml_ng::Value, dotted: &str) -> bool {
         let mut current = value;
         for segment in dotted.split('.') {
             match current {
-                serde_yaml::Value::Mapping(map) => {
-                    let k = serde_yaml::Value::String(segment.to_string());
+                serde_yaml_ng::Value::Mapping(map) => {
+                    let k = serde_yaml_ng::Value::String(segment.to_string());
                     match map.get(&k) {
                         Some(v) => current = v,
                         None => return false,
@@ -131,7 +131,7 @@ mod tests {
                 _ => return false,
             }
         }
-        !matches!(current, serde_yaml::Value::Mapping(_))
+        !matches!(current, serde_yaml_ng::Value::Mapping(_))
     }
 
     fn project_root() -> PathBuf {
@@ -206,8 +206,8 @@ mod tests {
 
         let en_text = fs::read_to_string(root.join("locales/en.yml")).expect("read en.yml");
         let fr_text = fs::read_to_string(root.join("locales/fr.yml")).expect("read fr.yml");
-        let en: serde_yaml::Value = serde_yaml::from_str(&en_text).expect("parse en.yml");
-        let fr: serde_yaml::Value = serde_yaml::from_str(&fr_text).expect("parse fr.yml");
+        let en: serde_yaml_ng::Value = serde_yaml_ng::from_str(&en_text).expect("parse en.yml");
+        let fr: serde_yaml_ng::Value = serde_yaml_ng::from_str(&fr_text).expect("parse fr.yml");
 
         let mut missing_en = Vec::new();
         let mut missing_fr = Vec::new();
@@ -271,15 +271,15 @@ mod tests {
 
     #[test]
     fn key_exists_accepts_leaf() {
-        let v: serde_yaml::Value =
-            serde_yaml::from_str("nav:\n  catalog: Catalogue\n  loans: Prêts").unwrap();
+        let v: serde_yaml_ng::Value =
+            serde_yaml_ng::from_str("nav:\n  catalog: Catalogue\n  loans: Prêts").unwrap();
         assert!(key_exists(&v, "nav.catalog"));
         assert!(key_exists(&v, "nav.loans"));
     }
 
     #[test]
     fn key_exists_rejects_missing_path() {
-        let v: serde_yaml::Value = serde_yaml::from_str("nav:\n  catalog: Catalogue").unwrap();
+        let v: serde_yaml_ng::Value = serde_yaml_ng::from_str("nav:\n  catalog: Catalogue").unwrap();
         assert!(!key_exists(&v, "nav.missing"));
         assert!(!key_exists(&v, "other.foo"));
     }
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn key_exists_rejects_mapping_as_leaf() {
         // `nav` itself is a mapping, not a leaf string, so it must not match.
-        let v: serde_yaml::Value = serde_yaml::from_str("nav:\n  catalog: Catalogue").unwrap();
+        let v: serde_yaml_ng::Value = serde_yaml_ng::from_str("nav:\n  catalog: Catalogue").unwrap();
         assert!(!key_exists(&v, "nav"));
     }
 }

--- a/tests/locale_html_safety.rs
+++ b/tests/locale_html_safety.rs
@@ -1,0 +1,194 @@
+//! #29 sub-item 2 — defense-in-depth: locale values MUST NOT contain
+//! raw HTML tags.
+//!
+//! Several handlers interpolate `rust_i18n::t!()` output directly into
+//! `format!("…<h2>{}…", t!(...))` strings (catalog, titles, locations,
+//! etc.). The values come from translator-controlled YAML files
+//! committed to the repo, so the practical XSS surface today is zero —
+//! a malicious translator would need a commit + review + merge.
+//!
+//! This audit is the belt for that braces: every entry in every locale
+//! YAML is asserted to contain no HTML tag start. If a future
+//! translator (or an unwitting copy-paste from an HTML mockup) lands
+//! `<script>` or `<a href>` in a locale string, CI fails before the
+//! string ever reaches a production format!() context.
+//!
+//! Rule:
+//!   - `<` immediately followed by an ASCII letter, `/`, or `!` is a
+//!     tag start and is REJECTED.
+//!   - `&` followed by alpha/digit and a `;` later in the string is an
+//!     HTML entity reference and is REJECTED.
+//!   - Bare `<` / `>` / `&` are allowed (legitimate French apostrophes,
+//!     punctuation, percent placeholders like `%{name}`).
+//!
+//! `rust_i18n::t!(...)` placeholders (`%{name}`) are interpolated AT
+//! CALL TIME with caller-supplied values; this audit covers the static
+//! template strings only.
+
+use serde_yaml_ng::Value;
+use std::path::Path;
+
+const LOCALES: &[&str] = &["en", "fr", "de", "it"];
+
+/// Dotted YAML paths whose values are KNOWN to contain HTML / pseudo-
+/// HTML and have been audited as safe. The audit allows these specific
+/// paths through; every other path is rejected.
+///
+/// Adding a new entry here is a deliberate "yes, this string is HTML
+/// and the caller renders it raw" decision. Reviewers should require:
+///   1. The string only uses an inline-emphasis whitelist
+///      (`<em>`, `<strong>`, `<br>`, `<code>`, `<a>`), OR
+///   2. The `<…>` is documentation prose (e.g. `<key>` as a placeholder
+///      stand-in), AND
+///   3. The render path is documented to bypass HTML escaping
+///      intentionally.
+const ALLOWED_HTML_KEYS: &[&str] = &[
+    // feedback.volume_confirm.body — UX-DR8 modal body uses `<em>` for
+    // title emphasis. Rendered through `Html()` in the catalog handler
+    // so the `<em>` produces actual italic, not literal angle brackets.
+    "feedback.volume_confirm.body",
+    // admin.api_keys.tooltip_text — `<key>` is documentation prose
+    // (placeholder for the user's actual API key value). Rendered
+    // through Askama auto-escape so the `<` becomes `&lt;` and the
+    // user sees literal `<key>`.
+    "admin.api_keys.tooltip_text",
+];
+
+fn locales_root() -> &'static Path {
+    Path::new("./locales")
+}
+
+fn looks_like_html_tag_start(s: &str) -> Option<String> {
+    // `<` followed by ASCII letter / `/` / `!` — tag start, doctype,
+    // closing tag, or comment open. Refuse all of them.
+    let bytes = s.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] == b'<' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            if next.is_ascii_alphabetic() || next == b'/' || next == b'!' {
+                return Some(format!(
+                    "raw HTML tag start `<{}` at byte offset {}",
+                    next as char, i
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn looks_like_html_entity_ref(s: &str) -> Option<String> {
+    // `&` followed by [a-zA-Z0-9#] and a `;` within the next 8 chars
+    // matches `&amp;`, `&lt;`, `&#39;`, `&#x27;`, etc. Refuse so the
+    // translator writes literal `&` instead and the rendering layer
+    // (Askama auto-escape or `html_escape`) handles encoding.
+    let bytes = s.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] == b'&' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            let entity_lookahead = next.is_ascii_alphanumeric() || next == b'#';
+            if entity_lookahead {
+                let end = (i + 8).min(bytes.len());
+                for j in i + 2..end {
+                    if bytes[j] == b';' {
+                        let entity = std::str::from_utf8(&bytes[i..=j])
+                            .unwrap_or("<non-utf8>")
+                            .to_string();
+                        return Some(format!(
+                            "HTML entity reference `{entity}` at byte offset {i}"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn check_value(path: &str, value: &Value, violations: &mut Vec<String>) {
+    match value {
+        Value::String(s) => {
+            if ALLOWED_HTML_KEYS.contains(&path) {
+                return;
+            }
+            if let Some(reason) = looks_like_html_tag_start(s) {
+                violations.push(format!("{path}: {reason}: {s:?}"));
+            } else if let Some(reason) = looks_like_html_entity_ref(s) {
+                violations.push(format!("{path}: {reason}: {s:?}"));
+            }
+        }
+        Value::Mapping(map) => {
+            for (k, v) in map {
+                let key_str = k.as_str().unwrap_or("?").to_string();
+                let next_path = if path.is_empty() {
+                    key_str
+                } else {
+                    format!("{path}.{key_str}")
+                };
+                check_value(&next_path, v, violations);
+            }
+        }
+        Value::Sequence(seq) => {
+            for (i, v) in seq.iter().enumerate() {
+                let next_path = format!("{path}[{i}]");
+                check_value(&next_path, v, violations);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn no_locale_value_contains_raw_html_tags_or_entities() {
+    let mut all_violations: Vec<String> = Vec::new();
+
+    for locale in LOCALES {
+        let path = locales_root().join(format!("{locale}.yml"));
+        let raw =
+            std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+        let parsed: Value = serde_yaml_ng::from_str(&raw)
+            .unwrap_or_else(|e| panic!("parse {path:?}: {e}"));
+        let mut local: Vec<String> = Vec::new();
+        check_value("", &parsed, &mut local);
+        if !local.is_empty() {
+            all_violations.push(format!("\n=== {locale}.yml ==="));
+            all_violations.extend(local);
+        }
+    }
+
+    assert!(
+        all_violations.is_empty(),
+        "locale strings must not contain raw HTML tags or entity references — \
+         translators should write literal `<` / `&` / `>` and the rendering \
+         layer (Askama auto-escape or `crate::utils::html_escape`) encodes \
+         them. Violations:\n{}",
+        all_violations.join("\n"),
+    );
+}
+
+#[test]
+fn audit_logic_recognizes_tag_starts() {
+    // Self-tests for the audit predicates.
+    assert!(looks_like_html_tag_start("<a>link</a>").is_some());
+    assert!(looks_like_html_tag_start("<script>").is_some());
+    assert!(looks_like_html_tag_start("</p>").is_some());
+    assert!(looks_like_html_tag_start("<!DOCTYPE>").is_some());
+
+    // Bare `<` / `>` are allowed (math, French quotes, etc.).
+    assert!(looks_like_html_tag_start("a < b").is_none());
+    assert!(looks_like_html_tag_start("«hello»").is_none());
+
+    // Percent placeholders look like `%{name}` — must NOT be confused
+    // with a tag start.
+    assert!(looks_like_html_tag_start("Hello %{name}").is_none());
+}
+
+#[test]
+fn audit_logic_recognizes_entity_refs() {
+    assert!(looks_like_html_entity_ref("Tom &amp; Jerry").is_some());
+    assert!(looks_like_html_entity_ref("&#39;").is_some());
+    assert!(looks_like_html_entity_ref("&lt;").is_some());
+
+    // Bare `&` is allowed (Tom & Jerry, etc.).
+    assert!(looks_like_html_entity_ref("Tom & Jerry").is_none());
+    assert!(looks_like_html_entity_ref("R&D").is_none());
+}

--- a/tests/locale_parity.rs
+++ b/tests/locale_parity.rs
@@ -12,7 +12,7 @@
 //!
 //! New locales should be added to `LOCALES_TO_CHECK` as they ship.
 
-use serde_yaml::Value;
+use serde_yaml_ng::Value;
 use std::collections::BTreeSet;
 use std::fs;
 
@@ -50,7 +50,7 @@ fn load_keys(locale: &str) -> BTreeSet<String> {
     let path = format!("locales/{locale}.yml");
     let raw = fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("read {}: {}", path, e));
-    let parsed: Value = serde_yaml::from_str(&raw)
+    let parsed: Value = serde_yaml_ng::from_str(&raw)
         .unwrap_or_else(|e| panic!("parse {}: {}", path, e));
     let mut out = BTreeSet::new();
     flatten_keys("", &parsed, &mut out);
@@ -122,14 +122,14 @@ fn placeholder_set_matches_en_for_every_translation() {
     }
 
     let en_raw = fs::read_to_string("locales/en.yml").expect("read en.yml");
-    let en_parsed: Value = serde_yaml::from_str(&en_raw).expect("parse en.yml");
+    let en_parsed: Value = serde_yaml_ng::from_str(&en_raw).expect("parse en.yml");
     let mut en_strings = std::collections::BTreeMap::new();
     walk("", &en_parsed, &mut en_strings);
 
     for locale in LOCALES_TO_CHECK.iter().chain(std::iter::once(&"fr")) {
         let raw = fs::read_to_string(format!("locales/{locale}.yml"))
             .unwrap_or_else(|e| panic!("read {}.yml: {}", locale, e));
-        let parsed: Value = serde_yaml::from_str(&raw)
+        let parsed: Value = serde_yaml_ng::from_str(&raw)
             .unwrap_or_else(|e| panic!("parse {}.yml: {}", locale, e));
         let mut strings = std::collections::BTreeMap::new();
         walk("", &parsed, &mut strings);


### PR DESCRIPTION
## Summary

Closes 2 of 3 sub-items of #29 and files #386 for the JS↔YAML extraction track.

**Sub-item 3 — RUSTSEC-2024-0320 mitigation.** Replaced the unmaintained `serde_yaml 0.9` dev-dependency with `serde_yaml_ng 0.10`, the community fork that ships fixes against the same 0.9 API surface. Code sites in `src/i18n/audit.rs` + `tests/locale_parity.rs` get the mechanical `serde_yaml::` → `serde_yaml_ng::` swap; nothing else moves. Production dependency surface unchanged (dev-dep only).

**Sub-item 2 — defense-in-depth on `t!()` HTML safety.** New `tests/locale_html_safety.rs` integration test walks every leaf String in every locale YAML and refuses entries that look like HTML markup or entity references. Catches the pattern where a translator (or an unwitting copy-paste from an HTML mockup) lands `<script>` / `<a href>` / `&amp;` inside a locale string that handlers later interpolate raw into `format!(\"…<h2>{}…</h2>\", t!(…))`. The practical XSS surface today is zero (translator-controlled, reviewed); this is the belt for those braces — CI will fail before a regression ships.

Audit predicates:
- `<` followed by ASCII letter / `/` / `!` → tag-start, rejected.
- `&` followed by alphanumeric/`#` plus `;` within 8 chars → entity reference, rejected.
- Bare `<` / `>` / `&` are allowed (math, French quotes, Tom & Jerry, `%{placeholder}` braces).
- `ALLOWED_HTML_KEYS` whitelist for the two pre-existing legitimate HTML strings (`feedback.volume_confirm.body` uses `<em>` for title emphasis; `admin.api_keys.tooltip_text` uses `<key>` as documentation prose).

Two self-tests on the predicates lock the audit logic against future \"simplifications\" that would silently allow real tags through.

## Deferred to #386

Sub-item 1 (JS↔YAML extraction via `<script type=\"application/json\">` bundle) — pure tech debt that doesn't fix a bug today; sized as its own focused PR with design questions on per-page vs. document-wide bundles, JSON escaping inside the embed, and which of the 6 existing JS modules to migrate first as proof-of-concept.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib --no-fail-fast` against rust-test DB on :3307 — 1002 / 1002 green
- [x] 3 new tests in `tests/locale_html_safety.rs`:
  - `no_locale_value_contains_raw_html_tags_or_entities` — the audit
  - `audit_logic_recognizes_tag_starts` — predicate self-test
  - `audit_logic_recognizes_entity_refs` — predicate self-test
- [ ] CI green on the full matrix

Closes #29. Follow-up tracked in #386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)