### PR TITLE
fix(#21): DB hardening — pool timeouts + /health DB ping + FK doc

### DIFF
--- a/migrations/20260602000000_document_pending_session_token_fk_absence.sql
+++ b/migrations/20260602000000_document_pending_session_token_fk_absence.sql
@@ -1,0 +1,23 @@
+-- #21 (DB hardening): document why `pending_metadata_updates.session_token`
+-- intentionally has NO foreign key to `sessions.token`.
+--
+-- Rationale (single-tenant lifecycle decoupling):
+--   * pending_metadata_updates rows are ephemeral — created when a scan
+--     kicks off an async metadata fetch and resolved (resolved_at set)
+--     within seconds, then soft-deleted and auto-purged.
+--   * sessions rows — anonymous ones especially — are hard-purged after
+--     7 days of inactivity by tasks::anonymous_session_purge, on a cadence
+--     entirely independent of pending-update resolution.
+--   * An FK with ON DELETE RESTRICT would let a stale pending row block a
+--     session purge; ON DELETE CASCADE would couple two independently
+--     managed lifecycles for no integrity gain. The PendingUpdates
+--     middleware already treats a token with no matching session as a
+--     benign no-op (it simply delivers no OOB update), so a dangling token
+--     is not a data-integrity hazard.
+--
+-- We record the decision as a column COMMENT so it stays visible in
+-- `SHOW CREATE TABLE pending_metadata_updates` rather than living only in
+-- a closed GitHub issue.
+ALTER TABLE pending_metadata_updates
+    MODIFY session_token VARCHAR(44) NOT NULL
+    COMMENT 'No FK to sessions.token by design (#21): ephemeral pending row vs independently-purged session; a dangling token is a no-op in the PendingUpdates middleware.';

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use sqlx::Executor;
 use sqlx::mysql::{MySqlPool, MySqlPoolOptions};
 
@@ -32,6 +34,21 @@ pub async fn create_pool(database_url: &str) -> Result<DbPool, sqlx::Error> {
         // The matching MariaDB-side floor is `max_connections=151` in
         // MariaDB 10.x default, well above our ceiling.
         .max_connections(20)
+        // #21 (DB hardening): make the acquire + idle timeouts explicit
+        // rather than silently inheriting sqlx defaults, so the pool's
+        // failure and recycling behaviour is documented at the call site.
+        //   * acquire_timeout(30s): a handler waiting on a saturated pool
+        //     fails fast with a clear pool-timeout error instead of hanging
+        //     the request indefinitely. 30s deliberately matches the prior
+        //     sqlx default, so fix #312's max_connections bump stays the
+        //     load lever — this change is documentation, not a tuning shift.
+        //   * idle_timeout(10min): a NAS that idles overnight reclaims idle
+        //     connections instead of holding 20 handles open against a
+        //     MariaDB that may itself drop them (its own `wait_timeout`),
+        //     which would otherwise surface as a stale-connection error on
+        //     the next request after a quiet period.
+        .acquire_timeout(Duration::from_secs(30))
+        .idle_timeout(Duration::from_secs(600))
         .after_connect(|conn, _meta| {
             Box::pin(async move {
                 conn.execute("SET time_zone = '+00:00'").await?;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -659,38 +659,54 @@ pub fn build_router(state: AppState) -> Router {
     apply_csp_layer(app, report_only)
 }
 
-async fn health_check() -> &'static str {
-    "ok"
+/// Liveness + DB-readiness probe (#21). Returns `200 "ok"` only when a
+/// `SELECT 1` against the pool succeeds; `503 "db unavailable"` otherwise.
+/// Promoting `/health` from a bare process-alive stub to a DB-readiness
+/// check lets the deployment's external monitor distinguish a live process
+/// from one that has lost its database — the relevant failure mode on the
+/// single-tenant NAS where app and MariaDB are separate containers.
+async fn health_check(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    if db_is_healthy(&state.pool).await {
+        (StatusCode::OK, "ok").into_response()
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "db unavailable").into_response()
+    }
+}
+
+/// Run a cheap `SELECT 1` to confirm the pool can reach the database.
+/// Extracted so the readiness decision is unit-testable against a
+/// deliberately-unreachable lazy pool without standing up a full router.
+async fn db_is_healthy(pool: &crate::db::DbPool) -> bool {
+    sqlx::query("SELECT 1").execute(pool).await.is_ok()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
-    use tower::ServiceExt;
 
-    fn test_app() -> Router {
-        Router::new().route("/health", axum::routing::get(health_check))
-    }
-
+    /// #21 (DB hardening): the `/health` probe now reports DB readiness, not
+    /// just process liveness. A pool that cannot reach its database must make
+    /// `db_is_healthy` return `false` (the handler maps that to `503`). We
+    /// exercise the failure path against a lazy pool pointed at an
+    /// unreachable address — `connect_lazy` never blocks at construction, and
+    /// the first `SELECT 1` fails fast with a connection-refused error, so the
+    /// test needs no live database and stays in the default `cargo test` run.
+    /// The happy path (`200 "ok"` against a real MariaDB) is covered by the
+    /// E2E suite, which runs the binary against a live database.
     #[tokio::test]
-    async fn test_health_check_returns_ok() {
-        let app = test_app();
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/health")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        assert_eq!(&body[..], b"ok");
+    async fn db_is_healthy_returns_false_on_unreachable_db() {
+        // Short acquire_timeout so the test fails fast: sqlx retries the
+        // connection within the acquire window, so the pool default (30s)
+        // would otherwise stall this unit test for the full timeout.
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_millis(300))
+            .connect_lazy("mysql://invalid:invalid@127.0.0.1:1/nonexistent")
+            .expect("connect_lazy builds a pool without connecting");
+        assert!(!db_is_healthy(&pool).await);
     }
 }

--- a/tests/admin_system_integration.rs
+++ b/tests/admin_system_integration.rs
@@ -748,15 +748,24 @@ async fn load_from_db_clamps_out_of_range_timeouts_to_default(pool: DbPool) {
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[sqlx::test(migrations = "./migrations")]
 async fn migrate_legacy_env_vars_copies_timeout_env_vars_when_row_is_seeded_default(
     pool: DbPool,
 ) {
     use std::env;
+    // Serialize against every other env-var-touching test in this binary.
+    // `migrate_legacy_env_vars` reads ALL env keys at once, and the three
+    // MYBIBLI_*_TIMEOUT_SECS tests set/remove the same two vars, so without
+    // this shared lock a sibling's `remove_var` can land between this test's
+    // `set_var` and `migrate`, dropping the value back to the seeded default.
+    // (That race flaked CI on 2026-06-02 — got 10 instead of 30.)
+    let _guard = ENV_VAR_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     // Set both env vars, leave both rows at the seeded defaults (5 / 10).
-    // SAFETY: same single-threaded-test contract as the API-key cases above —
-    // setenv contends with other threads that read the same vars, but no other
-    // sqlx::test in this suite touches MYBIBLI_*_TIMEOUT_SECS.
+    // SAFETY: the lock above serializes all env-var manipulation in this binary.
     unsafe {
         env::set_var("MYBIBLI_METADATA_CHAIN_PROVIDER_TIMEOUT_SECS", "20");
         env::set_var("MYBIBLI_PROVIDER_HEALTH_TIMEOUT_SECS", "30");
@@ -781,9 +790,15 @@ async fn migrate_legacy_env_vars_copies_timeout_env_vars_when_row_is_seeded_defa
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[sqlx::test(migrations = "./migrations")]
 async fn migrate_legacy_env_vars_preserves_admin_change_against_env_var(pool: DbPool) {
     use std::env;
+    // Shared env-var lock — see the sibling timeout test for the race detail.
+    let _guard = ENV_VAR_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     // Simulate an admin save that already moved the row off the seeded default.
     sqlx::query(
         "UPDATE settings SET setting_value = '12' \
@@ -810,9 +825,15 @@ async fn migrate_legacy_env_vars_preserves_admin_change_against_env_var(pool: Db
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[sqlx::test(migrations = "./migrations")]
 async fn migrate_legacy_env_vars_ignores_out_of_range_timeout_env_var(pool: DbPool) {
     use std::env;
+    // Shared env-var lock — see the sibling timeout test for the race detail.
+    let _guard = ENV_VAR_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+
     unsafe {
         env::set_var("MYBIBLI_METADATA_CHAIN_PROVIDER_TIMEOUT_SECS", "0");
         env::set_var("MYBIBLI_PROVIDER_HEALTH_TIMEOUT_SECS", "99999");

--- a/tests/e2e/specs/journeys/health-readiness.spec.ts
+++ b/tests/e2e/specs/journeys/health-readiness.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * #21 (DB hardening) — `/health` DB-readiness probe.
+ *
+ * The endpoint was promoted from a bare process-alive stub (`"ok"` always)
+ * to a readiness check that runs `SELECT 1` against the pool and returns
+ * `200 "ok"` only when the database is reachable. This spec covers the happy
+ * path against the live MariaDB the E2E stack runs against — the unreachable
+ * 503 branch is unit-tested in `src/routes/mod.rs` against a lazy pool.
+ *
+ * Spec ID "HC" — no catalog rows created, no login required (the probe is on
+ * the setup-gate / CSP whitelist and is intentionally unauthenticated).
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("#21 — /health DB-readiness probe", () => {
+  test("returns 200 'ok' when the database is reachable", async ({ request }) => {
+    const response = await request.get("/health");
+    expect(response.status()).toBe(200);
+    expect((await response.text()).trim()).toBe("ok");
+  });
+});


### PR DESCRIPTION
Closes #21.

Triage found 2 of the 5 sub-items already shipped (location-cycle guard in `locations.rs:208`, single-active-loan enforcement in `loans.rs:162`), and `max_connections` landed in #312. This PR closes the three genuinely-remaining items.

## Changes
- **Pool timeouts** (`src/db.rs`): explicit `acquire_timeout(30s)` (= prior sqlx default, so #312's `max_connections` stays the load lever) + `idle_timeout(10min)` to reclaim idle connections on a NAS that idles overnight.
- **`/health` DB-readiness** (`src/routes/mod.rs`): runs `SELECT 1`, returns `200 "ok"` only when the DB is reachable, `503 "db unavailable"` otherwise. Extracted `db_is_healthy()` for a no-DB unit test (fast-fail lazy pool); happy path in new E2E spec.
- **`session_token` FK absence documented** (new migration): column `COMMENT` explaining the deliberate lifecycle-decoupling decision (ephemeral pending row vs independently-purged session; dangling token is a middleware no-op). Visible in `SHOW CREATE TABLE`.

## Tests
- Unit: `db_is_healthy_returns_false_on_unreachable_db` (no DB needed).
- Integration: `seed_gate` green → all migrations (incl. new one) apply cleanly; column comment verified on a scratch DB.
- E2E: `health-readiness.spec.ts` (200 "ok" against live MariaDB), green at CI worker shape (`--workers=2`).
- `cargo clippy --all-targets -- -D warnings` clean; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)