### PR TITLE
fix(#55): admin users panel hardening

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -394,6 +394,8 @@ error:
     has_titles: "%{name} kann nicht gelöscht werden. Dieser Mitwirkende ist mit %{count} Titel(n) verknüpft. Bitte zuerst alle Verknüpfungen entfernen."
   user:
     username_empty: Benutzername ist erforderlich
+    username_too_short: Der Benutzername muss mindestens 3 Zeichen lang sein
+    username_too_long: Der Benutzername darf höchstens 255 Zeichen lang sein
     username_taken: "Benutzername \"%{username}\" ist bereits vergeben"
     password_too_short: Das Passwort muss mindestens 8 Zeichen lang sein
     password_too_long: Das Passwort darf höchstens 72 Zeichen lang sein

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -401,6 +401,8 @@ error:
     has_titles: "Cannot delete %{name}. This contributor is associated with %{count} title(s). Remove the contributor from all titles first."
   user:
     username_empty: Username is required
+    username_too_short: Username must be at least 3 characters
+    username_too_long: Username must be at most 255 characters
     username_taken: "Username '%{username}' is already taken"
     password_too_short: Password must be at least 8 characters
     password_too_long: Password must be at most 72 characters

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -396,6 +396,8 @@ error:
     has_titles: "Impossible de supprimer %{name}. Ce contributeur est associé à %{count} titre(s). Retirez d'abord le contributeur de tous les titres."
   user:
     username_empty: "Le nom d'utilisateur est requis"
+    username_too_short: "Le nom d'utilisateur doit contenir au moins 3 caractères"
+    username_too_long: "Le nom d'utilisateur doit contenir au plus 255 caractères"
     username_taken: "Le nom d'utilisateur « %{username} » est déjà pris"
     password_too_short: "Le mot de passe doit contenir au moins 8 caractères"
     password_too_long: "Le mot de passe ne peut dépasser 72 caractères"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -388,6 +388,8 @@ error:
     has_titles: "Impossibile eliminare %{name}. Questo collaboratore è associato a %{count} titolo(i). Rimuovi prima il collaboratore da tutti i titoli."
   user:
     username_empty: Il nome utente è obbligatorio
+    username_too_short: Il nome utente deve contenere almeno 3 caratteri
+    username_too_long: Il nome utente deve contenere al massimo 255 caratteri
     username_taken: "Il nome utente «%{username}» è già in uso"
     password_too_short: La password deve avere almeno 8 caratteri
     password_too_long: La password deve avere al massimo 72 caratteri

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -606,6 +606,31 @@ pub async fn admin_users_create_form(
     Ok(Html(html))
 }
 
+/// Shared username validation for the admin create + update handlers (#55
+/// MEDIUM #2). Bounds are in characters: empty → `username_empty`, `<3` →
+/// `username_too_short`, `>255` → `username_too_long`. The upper bound matches
+/// the `users.username VARCHAR(255)` column, so an over-long value surfaces as
+/// a clean localized 400 instead of a MariaDB truncation error (500).
+fn validate_username(username: &str, loc: &'static str) -> Result<(), AppError> {
+    if username.is_empty() {
+        return Err(AppError::BadRequest(
+            rust_i18n::t!("error.user.username_empty", locale = loc).to_string(),
+        ));
+    }
+    let char_count = username.chars().count();
+    if char_count < 3 {
+        return Err(AppError::BadRequest(
+            rust_i18n::t!("error.user.username_too_short", locale = loc).to_string(),
+        ));
+    }
+    if char_count > 255 {
+        return Err(AppError::BadRequest(
+            rust_i18n::t!("error.user.username_too_long", locale = loc).to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn admin_users_create(
     State(state): State<AppState>,
     session: Session,
@@ -615,13 +640,9 @@ pub async fn admin_users_create(
     session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
-    // Validate username (trim whitespace, check not empty)
+    // Validate username (trim whitespace; empty / length bounds — #55 MEDIUM #2)
     let username = form.username.trim().to_string();
-    if username.is_empty() {
-        return Err(AppError::BadRequest(
-            rust_i18n::t!("error.user.username_empty", locale = loc).to_string(),
-        ));
-    }
+    validate_username(&username, loc)?;
 
     // Validate password length (8-72 chars)
     if form.password.len() < 8 {
@@ -691,24 +712,6 @@ pub async fn admin_users_edit_form(
     let html = form
         .render()
         .map_err(|_| AppError::Internal("admin users edit form render failed".to_string()))?;
-    Ok(Html(html))
-}
-
-pub async fn admin_users_row_view(
-    State(state): State<AppState>,
-    session: Session,
-    Extension(locale): Extension<Locale>,
-    axum::extract::Path(id): axum::extract::Path<u64>,
-) -> Result<Html<String>, AppError> {
-    session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
-    let loc = locale.0;
-
-    // Fetch user
-    let user = UserModel::find_by_id(&state.pool, id)
-        .await?
-        .ok_or(AppError::NotFound("User not found".to_string()))?;
-
-    let html = render_user_row(&state, loc, &session, &user).await?;
     Ok(Html(html))
 }
 
@@ -805,13 +808,9 @@ pub async fn admin_users_update(
     session.require_role_with_return(Role::Admin, "/admin?tab=users", locale.0)?;
     let loc = locale.0;
 
-    // Validate username (trim whitespace, check not empty)
+    // Validate username (trim whitespace; empty / length bounds — #55 MEDIUM #2)
     let username = form.username.trim().to_string();
-    if username.is_empty() {
-        return Err(AppError::BadRequest(
-            rust_i18n::t!("error.user.username_empty", locale = loc).to_string(),
-        ));
-    }
+    validate_username(&username, loc)?;
 
     // Validate role
     if form.role != "admin" && form.role != "librarian" {
@@ -908,8 +907,25 @@ pub async fn admin_users_deactivate(
         AppError::Internal("admin session missing user_id".to_string())
     })?;
 
-    // Deactivate the user (guards handled by UserModel::deactivate)
-    let sessions_killed = UserModel::deactivate(&state.pool, id, form.version, acting_admin_id).await?;
+    // Deactivate the user (guards handled by UserModel::deactivate). Map the
+    // raw guard conflict keys to localized copy (#55 HIGH #6). VersionMismatch
+    // is already localized by AppError::IntoResponse (#370), so it falls
+    // through the catch-all unchanged.
+    let sessions_killed =
+        match UserModel::deactivate(&state.pool, id, form.version, acting_admin_id).await {
+            Ok(n) => n,
+            Err(AppError::Conflict(ref msg)) if msg == "self_deactivate_blocked" => {
+                return Err(AppError::Conflict(
+                    rust_i18n::t!("error.user.self_deactivate", locale = loc).to_string(),
+                ));
+            }
+            Err(AppError::Conflict(ref msg)) if msg == "last_admin_blocked" => {
+                return Err(AppError::Conflict(
+                    rust_i18n::t!("error.user.last_admin", locale = loc).to_string(),
+                ));
+            }
+            Err(e) => return Err(e),
+        };
     tracing::info!(user_id = id, sessions_killed, "user deactivated");
 
     // Fetch updated user and render row
@@ -1408,6 +1424,22 @@ fn render_shell(
         .map_err(|_| AppError::Internal("admin shell render failed".to_string()))
 }
 
+/// Upper bound on the `?page=` query param for the users panel (#55 HIGH #4).
+/// The offset is `(page - 1) * 25`, so an unclamped attacker-supplied page
+/// (e.g. `?page=4000000000`) overflows the `u32` multiply — a debug panic /
+/// release wrap — before the later `min(total_pages)` display clamp can run.
+/// 10 000 pages × 25 rows = 250 000 users, far beyond any single-tenant
+/// library, so clamping here is purely defensive and never truncates a real
+/// result set.
+const MAX_USERS_PAGE: u32 = 10_000;
+
+/// Normalize the users-panel `?page=` param to `1..=MAX_USERS_PAGE` (#55 HIGH
+/// #4). Pure + testable: `None`/`0` → 1, oversized → `MAX_USERS_PAGE`, so the
+/// `(page - 1) * 25` offset can never overflow `u32`.
+fn clamp_users_page(page: Option<u32>) -> u32 {
+    page.unwrap_or(1).clamp(1, MAX_USERS_PAGE)
+}
+
 async fn render_users_panel(
     state: &AppState,
     loc: &'static str,
@@ -1416,7 +1448,10 @@ async fn render_users_panel(
     filters: Option<UsersFilters>,
 ) -> Result<String, AppError> {
     let pool = &state.pool;
-    let current_page = page.unwrap_or(1).max(1);
+    // Clamp BEFORE computing the offset so a huge `?page=` can't overflow the
+    // `(current_page - 1) * 25` multiply (#55 HIGH #4). The display-time
+    // `min(total_pages)` clamp below still narrows this to the real last page.
+    let current_page = clamp_users_page(page);
 
     // Extract and normalize filters
     let filters = filters.unwrap_or(UsersFilters { role: None, status: None, page: None });
@@ -1955,6 +1990,45 @@ mod tests {
                 .require_role_with_return(Role::Admin, "/admin", "fr")
                 .is_ok()
         );
+    }
+
+    // ─── #55: username validation + pagination clamp ────────
+
+    #[test]
+    fn validate_username_rejects_empty_short_and_overlong() {
+        // Empty, below the 3-char floor, and above the 255-char ceiling all
+        // map to a BadRequest (localized copy) rather than reaching the DB.
+        assert!(matches!(
+            validate_username("", "en"),
+            Err(AppError::BadRequest(_))
+        ));
+        assert!(matches!(
+            validate_username("ab", "en"),
+            Err(AppError::BadRequest(_))
+        ));
+        let too_long = "x".repeat(256);
+        assert!(matches!(
+            validate_username(&too_long, "en"),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn validate_username_accepts_in_range() {
+        assert!(validate_username("abc", "en").is_ok());
+        assert!(validate_username(&"x".repeat(255), "en").is_ok());
+    }
+
+    #[test]
+    fn clamp_users_page_normalizes_bounds_and_prevents_offset_overflow() {
+        assert_eq!(clamp_users_page(None), 1);
+        assert_eq!(clamp_users_page(Some(0)), 1);
+        assert_eq!(clamp_users_page(Some(5)), 5);
+        assert_eq!(clamp_users_page(Some(u32::MAX)), MAX_USERS_PAGE);
+        // The whole point of the clamp: the `(page - 1) * 25` offset built in
+        // render_users_panel can never overflow u32 for any input.
+        let offset = (clamp_users_page(Some(u32::MAX)) - 1).checked_mul(25);
+        assert!(offset.is_some(), "clamped offset must not overflow u32");
     }
 
     // ─── Story 10-4: admin tabs mobile dropdown ─────────────

--- a/tests/admin_user_deactivate_modal.rs
+++ b/tests/admin_user_deactivate_modal.rs
@@ -489,6 +489,57 @@ async fn deactivate_user_via_existing_handler_still_works(pool: MySqlPool) {
 }
 
 #[sqlx::test(migrations = "./migrations")]
+async fn deactivate_self_returns_localized_self_deactivate_conflict(pool: MySqlPool) {
+    // #55 HIGH #6: the self-deactivate guard previously bubbled the raw
+    // conflict key "self_deactivate_blocked" to the user. The handler now maps
+    // it to the localized error.user.self_deactivate copy. Acting admin == target
+    // → the self-deactivate guard fires before the (unreachable-in-practice)
+    // last-admin guard.
+    let admin_id = admin_user_id(&pool, "admin").await;
+    let admin_version = user_version(&pool, admin_id).await;
+    let admin_cookie = seed_session(&pool, "admin").await;
+    let app = build_router(build_state(pool.clone()));
+
+    let body = format!("version={admin_version}&_csrf_token={TEST_CSRF_TOKEN}");
+    let resp = app
+        .oneshot(req_form(
+            Method::POST,
+            &format!("/admin/users/{admin_id}/deactivate"),
+            body,
+            Some(&admin_cookie),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "self-deactivate must be a 409 Conflict"
+    );
+    let text = body_text(resp).await;
+    assert!(
+        text.contains("cannot deactivate your own account")
+            || text.contains("propre compte"),
+        "body must carry the localized self-deactivate copy, not the raw \
+         'self_deactivate_blocked' key; got: {text}"
+    );
+    assert!(
+        !text.contains("self_deactivate_blocked"),
+        "raw conflict key must not leak to the user; got: {text}"
+    );
+
+    // And the admin row is untouched (guard fired before any UPDATE).
+    let (still_active,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM users WHERE id = ? AND deleted_at IS NULL",
+    )
+    .bind(admin_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(still_active, 1, "self-deactivate must not soft-delete the row");
+}
+
+#[sqlx::test(migrations = "./migrations")]
 async fn admin_users_panel_renders_row_target_div_for_each_active_user(pool: MySqlPool) {
     // Load-bearing assertion for the modal's hardcoded
     // `hx_target="#admin-users-row-{id}"` (templates/fragments/admin_user_deactivate_modal.html).

--- a/tests/e2e/specs/journeys/admin-user-validation.spec.ts
+++ b/tests/e2e/specs/journeys/admin-user-validation.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * #55 MEDIUM #2 — admin user creation: username length validation.
+ *
+ * The create handler now rejects usernames shorter than 3 or longer than 255
+ * characters with a localized BadRequest, instead of only checking emptiness
+ * (and letting an over-long name surface as a raw DB truncation 500). This
+ * spec drives the real POST /admin/users handler with the page's CSRF token,
+ * mirroring the seeding pattern in admin-smoke.spec.ts.
+ *
+ * Spec ID "UV" — creates no persisted rows on the happy path (both cases are
+ * rejected before insert).
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+test.describe("#55 — admin username length validation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  async function csrfToken(page: import("@playwright/test").Page): Promise<string> {
+    await page.goto("/admin?tab=users");
+    return page.evaluate(
+      () =>
+        document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')
+          ?.content || "",
+    );
+  }
+
+  test("rejects a too-short username with localized copy", async ({ page }) => {
+    const csrf = await csrfToken(page);
+    const resp = await page.request.post("/admin/users", {
+      form: { username: "ab", password: "valid-password-123", role: "librarian", _csrf_token: csrf },
+    });
+    expect(resp.status()).toBe(400);
+    expect(await resp.text()).toMatch(/at least 3 characters|au moins 3 caractères/i);
+  });
+
+  test("rejects an over-long username with localized copy", async ({ page }) => {
+    const csrf = await csrfToken(page);
+    const resp = await page.request.post("/admin/users", {
+      form: {
+        username: "x".repeat(256),
+        password: "valid-password-123",
+        role: "librarian",
+        _csrf_token: csrf,
+      },
+    });
+    expect(resp.status()).toBe(400);
+    expect(await resp.text()).toMatch(/at most 255 characters|au plus 255 caractères/i);
+  });
+});


### PR DESCRIPTION
Closes #55.

Triage against current code found most of the 18 reviewed items already shipped (status-filter validation, hx-confirm removal + username escaping, location-cycle/single-loan guards, etc.). This PR closes the genuinely-remaining ones.

## Implemented
**HIGH**
- **#4 Pagination bounds** — clamp `?page=` to `1..=10_000` before the `(page-1)*25` offset multiply (overflow → debug panic / release wrap). `clamp_users_page` + unit test.
- **#6 Conflict localization** — `admin_users_deactivate` maps raw `self_deactivate_blocked` / `last_admin_blocked` keys to localized copy (VersionMismatch already localized via #370). Integration test on the self-deactivate 409.
- **#7 Dead code** — removed the never-routed `admin_users_row_view`.

**MEDIUM**
- **#2 Username length** — shared `validate_username` (empty / `<3` / `>255` chars) on create + update; 255 ceiling matches `VARCHAR(255)` so over-long → clean 400, not DB-truncation 500. New en/fr keys, unit tests, E2E spec.

## Dispositions for the rest
- **#5 (HIGH) status filter**, **#3/#8 XSS + escaping**, **deactivate-guard placement (MED #5)** — verified already correct in current code.
- **Concurrent-deactivation test (MED #6)** — intentionally NOT added: it would assert serialization the single-tenant design deliberately does not provide (the last-admin guard's `FOR UPDATE` locks only the target row). Explicitly deferred concurrency scope per #16/#53/#54.
- **#11 hash-error i18n** — by-design: argon2 hashing cannot fail for validated 8–72-char input, and localizing one `Internal` while every other stays a generic English literal would be inconsistent.
- **#1 password "bytes" wording** — cosmetic; ASCII-equivalent, left as-is.

## Tests
- Unit: `validate_username_*`, `clamp_users_page_*` (no DB).
- Integration: `deactivate_self_returns_localized_self_deactivate_conflict`; full `admin_user_deactivate_modal` suite green (12/12).
- E2E: `admin-user-validation.spec.ts` + `admin-smoke` regression, green at `--workers=2`.
- `cargo clippy --all-targets -- -D warnings`, `tsc --noEmit`, `cargo sqlx prepare --check` all clean.

## Follow-up
- `admin.rs` is 2042→~2077 lines (pre-existing Rule #12 drift). Extraction into `admin_users.rs` tracked as #391 — kept out of this bug-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)