### PR TITLE
fix(#22): E2E test-hygiene consolidation

### DIFF
--- a/tests/e2e/helpers/catalog.ts
+++ b/tests/e2e/helpers/catalog.ts
@@ -1,0 +1,70 @@
+/**
+ * Catalog test helpers (#22 test-hygiene consolidation).
+ *
+ * Centralizes the two ID-resolution patterns that several specs previously
+ * inlined fragilely: reading the title id from the scan skeleton element, and
+ * resolving a volume id from its label via the title detail page (replacing a
+ * brute-force `/volume/{1..N}` scan that broke once ids exceeded a hardcoded
+ * cap under parallel load).
+ */
+import { Page, Locator, expect } from "@playwright/test";
+
+/**
+ * Select the first non-placeholder option of a `<select>` by its value rather
+ * than by positional index (#22). Order-independent of any leading empty
+ * "choose…" option, so it doesn't break if the option list is reordered.
+ */
+export async function selectFirstRealOption(select: Locator): Promise<void> {
+  const value = await select
+    .locator('option[value]:not([value=""])')
+    .first()
+    .getAttribute("value");
+  expect(value, "select must expose at least one non-placeholder option").toBeTruthy();
+  await select.selectOption(value!);
+}
+
+/**
+ * Read the title id encoded in the scan skeleton element's id
+ * (`id="feedback-entry-{titleId}"`). This is the designed contract from
+ * `src/routes/catalog.rs::skeleton_feedback_html` — the only deterministic
+ * title-id source the browser has after an ISBN scan. Centralized here so the
+ * former inline copies in metadata-editing.spec.ts stay in sync.
+ */
+export async function titleIdFromSkeleton(page: Page): Promise<string> {
+  await page.waitForSelector(".feedback-skeleton, .feedback-entry", {
+    timeout: 10000,
+  });
+  const feedbackEl = page.locator("[id^='feedback-entry-']").first();
+  const feedbackId = await feedbackEl.getAttribute("id");
+  const titleId = feedbackId?.replace("feedback-entry-", "");
+  expect(
+    titleId,
+    "scan skeleton element must encode the title id in its element id",
+  ).toBeTruthy();
+  return titleId!;
+}
+
+/**
+ * Resolve a volume's numeric id from its label by reading the volume link on
+ * the title detail page — a deterministic replacement for the former
+ * brute-force `/volume/{1..N}` fetch loop, which broke once volume ids
+ * exceeded the hardcoded cap under parallel execution.
+ */
+export async function volumeIdByLabel(
+  page: Page,
+  titleId: string,
+  label: string,
+): Promise<string> {
+  await page.goto(`/title/${titleId}`);
+  const link = page
+    .locator('a[href^="/volume/"]')
+    .filter({ hasText: new RegExp(`^\\s*${label}\\s*$`) });
+  const href = await link.first().getAttribute("href");
+  expect(
+    href,
+    `title ${titleId} detail page must list a volume link for ${label}`,
+  ).toBeTruthy();
+  const id = href!.replace(/^\/volume\//, "").replace(/\/.*$/, "");
+  expect(id).toMatch(/^\d+$/);
+  return id;
+}

--- a/tests/e2e/helpers/isbn.ts
+++ b/tests/e2e/helpers/isbn.ts
@@ -35,6 +35,31 @@ export function specIsbn(specId: string, seq: number = 1): string {
 }
 
 /**
+ * Per-spec unique location code (L-code) generator (#22).
+ *
+ * L-codes are validated as exactly `"L"` + 4 ASCII digits
+ * (`LocationService::validate_lcode`), so the addressable space is only 4
+ * digits. This helper formalizes the convention the specs already follow by
+ * hand: the leading digit is a per-spec bucket (1-9) and the trailing 3 digits
+ * are a sequence (0-999), e.g. `specLcode(4, 1) === "L4001"`. Pass a bucket
+ * that is unique to your spec file to keep labels collision-free under
+ * `fullyParallel: true`.
+ *
+ * @param bucket - Per-spec bucket digit, 1-9
+ * @param seq - Sequence within the spec, 0-999 (default 1)
+ * @returns A valid 5-character L-code
+ */
+export function specLcode(bucket: number, seq: number = 1): string {
+  if (!Number.isInteger(bucket) || bucket < 1 || bucket > 9) {
+    throw new Error(`L-code bucket must be an integer 1-9, got ${bucket}`);
+  }
+  if (!Number.isInteger(seq) || seq < 0 || seq > 999) {
+    throw new Error(`L-code seq must be an integer 0-999, got ${seq}`);
+  }
+  return `L${bucket}${seq.toString().padStart(3, "0")}`;
+}
+
+/**
  * Compute EAN-13 check digit (modulo 10 algorithm).
  * @param first12 - First 12 digits of the ISBN
  * @returns Single check digit character (0-9)

--- a/tests/e2e/specs/journeys/borrowers.spec.ts
+++ b/tests/e2e/specs/journeys/borrowers.spec.ts
@@ -1,12 +1,9 @@
 import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
 
 test.describe("Borrower CRUD & Search (Story 4-1)", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/login");
-    await page.locator("#username").fill("admin");
-    await page.locator("#password").fill("admin");
-    await page.locator("#login-submit").click();
-    await expect(page).toHaveURL(/\/catalog/, { timeout: 5000 });
+    await loginAs(page);
   });
 
   // AC1: Borrowers list page

--- a/tests/e2e/specs/journeys/catalog-contributor.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-contributor.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
 import { specIsbn } from "../../helpers/isbn";
 import { captureEntityCounts } from "../../helpers/db-snapshot";
+import { selectFirstRealOption } from "../../helpers/catalog";
 
 const VALID_ISBN = specIsbn("CC", 1);
 
@@ -61,15 +62,15 @@ test.describe("Contributor Management", () => {
     const form = page.locator("#contributor-form-container form");
     await expect(form).toBeVisible({ timeout: 5000 });
 
-    // Fill contributor name
-    await form.locator("#contributor-name-input").fill("Albert Camus");
+    // Fill contributor name — unique per run to avoid parallel collisions (#22)
+    await form.locator("#contributor-name-input").fill(`CC-AC2 Camus ${Date.now()}`);
 
     // Select first role (Auteur should be first alphabetically)
     const roleSelect = form.locator("#contributor-role-select");
     const options = roleSelect.locator("option");
     const optCount = await options.count();
     if (optCount > 1) {
-      await roleSelect.selectOption({ index: 1 });
+      await selectFirstRealOption(roleSelect);
     }
 
     await form.locator('button[type="submit"]').click();
@@ -98,10 +99,13 @@ test.describe("Contributor Management", () => {
     let form = page.locator("#contributor-form-container form");
     await expect(form).toBeVisible({ timeout: 5000 });
 
-    await form.locator("#contributor-name-input").fill("Boris Vian");
+    // Same contributor name reused below to trigger the duplicate-role error;
+    // unique per run to avoid parallel collisions (#22).
+    const dupContributor = `CC-AC3 Vian ${Date.now()}`;
+    await form.locator("#contributor-name-input").fill(dupContributor);
     const roleSelect = form.locator("#contributor-role-select");
     if ((await roleSelect.locator("option").count()) > 1) {
-      await roleSelect.selectOption({ index: 1 });
+      await selectFirstRealOption(roleSelect);
     }
     await form.locator('button[type="submit"]').click();
     // Wait for success feedback before retrying
@@ -118,10 +122,10 @@ test.describe("Contributor Management", () => {
     form = page.locator("#contributor-form-container form");
     await expect(form).toBeVisible({ timeout: 5000 });
 
-    await form.locator("#contributor-name-input").fill("Boris Vian");
+    await form.locator("#contributor-name-input").fill(dupContributor);
     const roleSelect2 = form.locator("#contributor-role-select");
     if ((await roleSelect2.locator("option").count()) > 1) {
-      await roleSelect2.selectOption({ index: 1 });
+      await selectFirstRealOption(roleSelect2);
     }
     await form.locator('button[type="submit"]').click();
 
@@ -157,7 +161,7 @@ test.describe("Contributor Management", () => {
     await form.locator("#contributor-name-input").fill(CONTRIBUTOR_NAME);
     const roleSelect = form.locator("#contributor-role-select");
     if ((await roleSelect.locator("option").count()) > 1) {
-      await roleSelect.selectOption({ index: 1 });
+      await selectFirstRealOption(roleSelect);
     }
     await form.locator('button[type="submit"]').click();
     // Wait for success feedback confirming contributor was added (appears at top of feedback list)
@@ -304,10 +308,10 @@ test.describe("Contributor Management", () => {
     const form = page.locator("#contributor-form-container form");
     await expect(form).toBeVisible({ timeout: 5000 });
 
-    await form.locator("#contributor-name-input").fill("Test Author");
+    await form.locator("#contributor-name-input").fill(`CC-AC8 Author ${Date.now()}`);
     const roleSelect = form.locator("#contributor-role-select");
     if ((await roleSelect.locator("option").count()) > 1) {
-      await roleSelect.selectOption({ index: 1 });
+      await selectFirstRealOption(roleSelect);
     }
     await form.locator('button[type="submit"]').click();
 
@@ -408,7 +412,7 @@ test.describe("#325 — Add contributor from /title/:id", () => {
     await form.locator("#contributor-name-input").fill(NAME);
     const roleSelect = form.locator("#contributor-role-select");
     await expect(roleSelect.locator("option")).not.toHaveCount(0);
-    await roleSelect.selectOption({ index: 1 });
+    await selectFirstRealOption(roleSelect);
 
     // Step 6: submit → success FeedbackEntry must land in #feedback-list.
     await form.locator('button[type="submit"]').click();

--- a/tests/e2e/specs/journeys/epic2-smoke.spec.ts
+++ b/tests/e2e/specs/journeys/epic2-smoke.spec.ts
@@ -74,9 +74,9 @@ test.describe("Epic 2 Smoke Test — Full Shelving Journey", () => {
     await searchField.fill(TEST_ISBN.substring(0, 5));
     await searchField.press("Enter");
     const resultsBody = page.locator("#browse-results");
+    // Results may or may not contain matches depending on FULLTEXT index
+    // timing, so we assert the results region renders rather than its content.
     await expect(resultsBody).toBeVisible({ timeout: 5000 });
-    const resultsHtml = await resultsBody.innerHTML().catch(() => "");
-    // Results may or may not contain matches depending on FULLTEXT index timing
   });
 
   test("batch shelving: scan L-code first → then V-codes auto-shelve", async ({

--- a/tests/e2e/specs/journeys/loans.spec.ts
+++ b/tests/e2e/specs/journeys/loans.spec.ts
@@ -6,6 +6,7 @@ import {
   createLoan,
   scanTitleAndVolume,
 } from "../../helpers/loans";
+import { titleIdFromSkeleton, volumeIdByLabel } from "../../helpers/catalog";
 
 // CR #300: per-test unique ISBNs — each test gets a fresh title so the
 // V-code scan never hits the phantom-volume confirmation modal.
@@ -45,28 +46,27 @@ test.describe("Loan Registration & Validation (Story 4-2)", () => {
   test("attempt to lend non-loanable volume → verify error", async ({ page }) => {
     await scanTitleAndVolume(page, specIsbn("LN", 4), "V0063");
 
-    // Find the volume ID by scanning volume detail pages for label V0063.
-    // The range is bounded by the number of volumes seeded in this test run.
-    const volumeId = await page.evaluate(async () => {
-      for (let id = 1; id <= 100; id++) {
-        try {
-          const resp = await fetch(`/volume/${id}`);
-          if (!resp.ok) continue;
-          const html = await resp.text();
-          if (html.includes("V0063")) return id;
-        } catch {
-          continue;
-        }
-      }
-      return null;
-    });
-    expect(volumeId).not.toBeNull();
+    // Resolve the volume id deterministically from the title detail page's
+    // volume link, instead of brute-force scanning /volume/{1..N} (#22).
+    const titleId = await titleIdFromSkeleton(page);
+    const volumeId = await volumeIdByLabel(page, titleId, "V0063");
 
-    // Set the volume condition to "Endommagé" (non-loanable)
+    // Set the volume condition to the damaged (non-loanable) state. Select by
+    // the value of whichever option's label matches in either language rather
+    // than hardcoding the French "Endommagé" string (#22). Reference-data
+    // values aren't localized (NFR41), so the bilingual regex tolerates either
+    // a French- or English-seeded state name without depending on the option
+    // ordering or the UI locale.
     await page.goto(`/volume/${volumeId}/edit`);
     const conditionSelect = page.locator('select[name="condition_state_id"]');
     await expect(conditionSelect).toBeVisible({ timeout: 3000 });
-    await conditionSelect.selectOption({ label: "Endommagé" });
+    const damagedValue = await conditionSelect
+      .locator("option")
+      .filter({ hasText: /Damaged|Endommagé/i })
+      .first()
+      .getAttribute("value");
+    expect(damagedValue).toBeTruthy();
+    await conditionSelect.selectOption(damagedValue!);
     await page.locator('main button[type="submit"]').last().click();
     // Positive assertion on the volume detail URL — the handler returns
     // `Redirect::to("/volume/{id}")` on success (src/routes/catalog.rs).
@@ -267,29 +267,19 @@ test.describe("Volume detail — loan status role-aware (FR59)", () => {
     const volumeLabel = uniqueVcode();
     const ANON_ISBN = specIsbn("LN", 8);
 
-    // Seed: title + volume + borrower + active loan.
+    // Seed: title + volume + borrower + active loan. Capture the title id from
+    // the scan skeleton up front — createBorrower/createLoan navigate away, so
+    // the skeleton is gone by the time we need the volume id.
     await scanTitleAndVolume(page, ANON_ISBN, volumeLabel);
+    const titleId = await titleIdFromSkeleton(page);
     await createBorrower(page, borrowerName);
     await createLoan(page, volumeLabel, borrowerName);
 
-    // Find the volume ID by brute-force scanning /volume/<id> for the
-    // V-code (matches the pattern used by the "non-loanable" test
-    // earlier in this file). The loans table renders V-codes as plain
-    // text, NOT as links — that's why we can't extract the href there.
-    const volumeId = await page.evaluate(async (label) => {
-      for (let id = 1; id <= 200; id++) {
-        try {
-          const resp = await fetch(`/volume/${id}`);
-          if (!resp.ok) continue;
-          const html = await resp.text();
-          if (html.includes(label)) return id;
-        } catch {
-          continue;
-        }
-      }
-      return null;
-    }, volumeLabel);
-    expect(volumeId).not.toBeNull();
+    // Resolve the volume id deterministically from the title detail page's
+    // volume link instead of brute-force scanning /volume/{1..N} (#22). The
+    // loans table renders V-codes as plain text, so the title detail page is
+    // the stable source for the id.
+    const volumeId = await volumeIdByLabel(page, titleId, volumeLabel);
     const volumeUrl = `/volume/${volumeId}`;
 
     // 1. Anonymous render via a FRESH browser context — defeats the

--- a/tests/e2e/specs/journeys/location-contents.spec.ts
+++ b/tests/e2e/specs/journeys/location-contents.spec.ts
@@ -1,12 +1,10 @@
 import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specLcode } from "../../helpers/isbn";
 
 test.describe("Browse Shelf Contents (Story 2-3)", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/login");
-    await page.locator("#username").fill("admin");
-    await page.locator("#password").fill("admin");
-    await page.locator('#login-submit').click();
-    await expect(page).toHaveURL(/\/catalog/, { timeout: 5000 });
+    await loginAs(page);
   });
 
   test("location detail shows breadcrumb and heading", async ({ page }) => {
@@ -14,7 +12,7 @@ test.describe("Browse Shelf Contents (Story 2-3)", () => {
     await page.goto("/locations");
     await page.locator("summary").filter({ hasText: /add root|ajouter/i }).click();
     await page.locator("#new-name").fill("LC-ContentTest");
-    await page.locator("#new-lcode").fill("L4001");
+    await page.locator("#new-lcode").fill(specLcode(4, 1));
     await page.locator("#add-root-submit").click();
     await expect(page).toHaveURL(/\/locations/, { timeout: 5000 });
     await expect(page.locator("text=LC-ContentTest")).toBeVisible({ timeout: 5000 });
@@ -35,7 +33,7 @@ test.describe("Browse Shelf Contents (Story 2-3)", () => {
     await page.goto("/locations");
     await page.locator("summary").filter({ hasText: /add root|ajouter/i }).click();
     await page.locator("#new-name").fill("LC-EmptyShelf");
-    await page.locator("#new-lcode").fill("L4002");
+    await page.locator("#new-lcode").fill(specLcode(4, 2));
     await page.locator("#add-root-submit").click();
     await expect(page).toHaveURL(/\/locations/, { timeout: 5000 });
     await expect(page.locator("text=LC-EmptyShelf")).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/specs/journeys/metadata-editing.spec.ts
+++ b/tests/e2e/specs/journeys/metadata-editing.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
 import { specIsbn } from "../../helpers/isbn";
+import { titleIdFromSkeleton } from "../../helpers/catalog";
 
 const ISBN_EDIT = specIsbn("ME", 1);
 const ISBN_CANCEL = specIsbn("ME", 2);
@@ -19,13 +20,8 @@ test.describe("Metadata Editing & Re-Download (Story 3-5)", () => {
     await scanField.fill(ISBN_EDIT);
     await scanField.press("Enter");
 
-    // Wait for any scan feedback
-    await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 10000 });
-
-    // Extract title ID from skeleton element (id="feedback-entry-{N}")
-    const feedbackEl = page.locator("[id^='feedback-entry-']").first();
-    const feedbackId = await feedbackEl.getAttribute("id");
-    const titleId = feedbackId?.replace("feedback-entry-", "");
+    // Resolve the title id from the scan skeleton (#22 — shared helper).
+    const titleId = await titleIdFromSkeleton(page);
 
     // Navigate directly to title detail page
     await page.goto(`/title/${titleId}`);
@@ -72,13 +68,8 @@ test.describe("Metadata Editing & Re-Download (Story 3-5)", () => {
     await scanField.fill(ISBN_CANCEL);
     await scanField.press("Enter");
 
-    // Wait for any scan feedback
-    await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 10000 });
-
-    // Extract title ID from skeleton element (id="feedback-entry-{N}")
-    const feedbackEl = page.locator("[id^='feedback-entry-']").first();
-    const feedbackId = await feedbackEl.getAttribute("id");
-    const titleId = feedbackId?.replace("feedback-entry-", "");
+    // Resolve the title id from the scan skeleton (#22 — shared helper).
+    const titleId = await titleIdFromSkeleton(page);
 
     // Navigate directly to title detail page
     await page.goto(`/title/${titleId}`);
@@ -112,13 +103,8 @@ test.describe("Metadata Editing & Re-Download (Story 3-5)", () => {
     await scanField.fill(ISBN_SMOKE);
     await scanField.press("Enter");
 
-    // Wait for any scan feedback
-    await page.waitForSelector(".feedback-skeleton, .feedback-entry", { timeout: 10000 });
-
-    // Extract title ID from skeleton element (id="feedback-entry-{N}")
-    const feedbackEl = page.locator("[id^='feedback-entry-']").first();
-    const feedbackId = await feedbackEl.getAttribute("id");
-    const titleId = feedbackId?.replace("feedback-entry-", "");
+    // Resolve the title id from the scan skeleton (#22 — shared helper).
+    const titleId = await titleIdFromSkeleton(page);
 
     // Navigate directly to title detail page
     await page.goto(`/title/${titleId}`);


### PR DESCRIPTION
Closes #22.

Triage found 4 of the 12 reviewed items already resolved (createLoan consistency, ST-author scoping, INVALID_ISBN checksum, xpath traversal). This PR clears the remaining actionable items.

## Changes
- **Item 1 — loginAs**: `borrowers.spec.ts` + `location-contents.spec.ts` use `loginAs()` instead of inline manual login.
- **Items 7 + 8 — deterministic ID lookup**: new `helpers/catalog.ts` (`titleIdFromSkeleton`, `volumeIdByLabel`). `loans.spec.ts` AC3/FR59 drop the brute-force `/volume/{1..N}` loops (broke past the hardcoded 100/200 cap under parallel load); `metadata-editing.spec.ts`'s three inline skeleton-id extractions now share the helper.
- **Item 6 — value-based select**: `selectFirstRealOption()` replaces the six `selectOption({index:1})` calls in `catalog-contributor.spec.ts`.
- **Item 4 — unique names**: hardcoded "Albert Camus"/"Boris Vian"/"Test Author" → per-run unique; AC3's duplicate test keeps one shared name within the test.
- **Item 3 — specLcode**: `specLcode(bucket, seq)` generator formalizing the existing per-spec L-code prefix convention; adopted in `location-contents.spec.ts`.
- **Item 12**: removed the unused `resultsHtml` variable in `epic2-smoke.spec.ts`.
- **Item 11 (bonus)**: `loans.spec.ts` selects the damaged volume state by value of the bilingual-label-matched option rather than the hardcoded "Endommagé" string.

## Tests
- 32 affected specs (loans, metadata-editing, catalog-contributor, borrowers, location-contents, epic2-smoke) green at `--workers=2`.
- `tsc --noEmit` clean; no-`waitForTimeout` flake gate clean. Test-only change — no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)