### PR TITLE
fix(#384): OL author concurrency + UPC-A checksum validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,8 +1077,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1900,6 +1928,7 @@ dependencies = [
  "barcoders",
  "base64",
  "chrono",
+ "futures",
  "genpdf",
  "image",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rust-i18n = "3.1.5"
 axum-extra = { version = "0.10", features = ["cookie"] }
 time = "0.3"
 async-trait = "0.1"
+futures = "0.3"
 base64 = "0.22"
 percent-encoding = "2"
 # Admin Health tab (story 8-1) — disk-usage via statvfs(2). Linux-only.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -379,6 +379,8 @@ error:
     invalid_format: "Ungültiges ISBN-Format — muss 13 Ziffern enthalten"
     already_used: "Diese ISBN wird bereits von einem anderen Titel verwendet — Duplikat wird nicht angelegt"
     not_found: ISBN nicht gefunden
+  upc:
+    invalid_checksum: Ungültige UPC-Prüfsumme
   genre:
     required: Genre ist erforderlich
   media_type:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -386,6 +386,8 @@ error:
     invalid_format: "Invalid ISBN format — must be 13 digits"
     already_used: "Another title already uses this ISBN — refusing to create a duplicate"
     not_found: ISBN not found
+  upc:
+    invalid_checksum: Invalid UPC checksum
   genre:
     required: Genre is required
   media_type:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -381,6 +381,8 @@ error:
     invalid_format: "Format ISBN invalide — doit contenir 13 chiffres"
     already_used: "Un autre titre utilise déjà cet ISBN — refus de créer un doublon"
     not_found: ISBN introuvable
+  upc:
+    invalid_checksum: Checksum UPC invalide
   genre:
     required: Le genre est obligatoire
   media_type:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -373,6 +373,8 @@ error:
     invalid_format: "Formato ISBN non valido — devono essere 13 cifre"
     already_used: "Un altro titolo usa già questo ISBN — non viene creato un duplicato"
     not_found: ISBN non trovato
+  upc:
+    invalid_checksum: Checksum UPC non valido
   genre:
     required: Il genere è obbligatorio
   media_type:

--- a/src/metadata/open_library.rs
+++ b/src/metadata/open_library.rs
@@ -1,8 +1,17 @@
 use async_trait::async_trait;
+use futures::stream::StreamExt;
 
 use crate::models::media_type::MediaType;
 
 use super::provider::{MetadataError, MetadataProvider, MetadataResult};
+
+/// Cap on how many author keys a single book lookup will resolve.
+const MAX_AUTHORS: usize = 5;
+
+/// Cap on concurrent `/authors/{key}.json` lookups (#384). Open Library has
+/// soft per-IP rate limits, so we parallelize author resolution but bound it
+/// to avoid burst-rate-limiting ourselves within the per-provider timeout.
+const MAX_CONCURRENT_AUTHOR_LOOKUPS: usize = 4;
 
 /// Open Library metadata provider.
 /// Free API, no API key required.
@@ -26,31 +35,64 @@ impl OpenLibraryProvider {
         }
     }
 
+    /// SSRF guard + cap: keep only well-formed `/authors/OL…` keys, at most
+    /// `MAX_AUTHORS`, preserving input order. Extracted as a pure helper so
+    /// the validation/cap contract is unit-testable without live HTTP (#384).
+    /// `take(MAX_AUTHORS)` runs BEFORE the filter so the window matches the
+    /// pre-#384 sequential loop exactly.
+    fn valid_author_keys(author_keys: &[String]) -> Vec<&String> {
+        author_keys
+            .iter()
+            .take(MAX_AUTHORS)
+            .filter(|key| {
+                if key.starts_with("/authors/OL") {
+                    true
+                } else {
+                    // Reject crafted keys that could drive an SSRF.
+                    tracing::warn!(author_key = %key, "Skipping invalid Open Library author key");
+                    false
+                }
+            })
+            .collect()
+    }
+
     /// Resolve author keys to names by calling the authors API.
+    ///
+    /// #384: author lookups run concurrently (bounded by
+    /// `MAX_CONCURRENT_AUTHOR_LOOKUPS`) instead of sequentially, shaving
+    /// round-trips for multi-author books inside the per-provider timeout
+    /// budget. `buffered` preserves input order, so the resolved-name order
+    /// is unchanged from the pre-#384 sequential loop.
     async fn resolve_authors(&self, author_keys: &[String]) -> Vec<String> {
-        const MAX_AUTHORS: usize = 5;
-        let mut names = Vec::new();
-        for key in author_keys.iter().take(MAX_AUTHORS) {
-            // Validate key format to prevent SSRF via crafted author keys
-            if !key.starts_with("/authors/OL") {
-                tracing::warn!(author_key = %key, "Skipping invalid Open Library author key");
-                continue;
-            }
-            let url = format!("{}{}.json", self.base_url, key);
-            match self.client.get(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    if let Ok(json) = resp.json::<serde_json::Value>().await
-                        && let Some(name) = json.get("name").and_then(|v| v.as_str())
-                    {
-                        names.push(name.to_string());
+        // Own the keys so each buffered future moves its `String` in (a
+        // borrowed `&String` trips the higher-ranked-lifetime check on the
+        // `buffered` closure). At most MAX_AUTHORS short strings — cheap.
+        let valid_keys: Vec<String> = Self::valid_author_keys(author_keys)
+            .into_iter()
+            .cloned()
+            .collect();
+
+        futures::stream::iter(valid_keys)
+            .map(|key| async move {
+                let url = format!("{}{}.json", self.base_url, key);
+                match self.client.get(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => resp
+                        .json::<serde_json::Value>()
+                        .await
+                        .ok()
+                        .and_then(|json| {
+                            json.get("name").and_then(|v| v.as_str()).map(String::from)
+                        }),
+                    _ => {
+                        tracing::warn!(author_key = %key, "Failed to resolve Open Library author");
+                        None
                     }
                 }
-                _ => {
-                    tracing::warn!(author_key = %key, "Failed to resolve Open Library author");
-                }
-            }
-        }
-        names
+            })
+            .buffered(MAX_CONCURRENT_AUTHOR_LOOKUPS)
+            .filter_map(|name| async move { name })
+            .collect::<Vec<String>>()
+            .await
     }
 
     /// Parse Open Library book JSON response into MetadataResult.
@@ -350,5 +392,36 @@ mod tests {
         });
         let parsed = OpenLibraryProvider::parse_response(&json).unwrap();
         assert_eq!(parsed.author_keys.len(), 2);
+    }
+
+    #[test]
+    fn valid_author_keys_filters_invalid_and_caps_window_preserving_order() {
+        // #384: the SSRF guard (reject non-`/authors/OL…` keys) and the
+        // MAX_AUTHORS cap must survive the move to concurrent resolution.
+        // `take(MAX_AUTHORS)` runs BEFORE the filter, so the window is the
+        // first 5 entries — `/evil/path` inside it is dropped (→ 4 keys),
+        // and OL6A (6th) is outside the window entirely. Order preserved.
+        let keys = vec![
+            "/authors/OL1A".to_string(),
+            "/evil/path".to_string(),
+            "/authors/OL2A".to_string(),
+            "/authors/OL3A".to_string(),
+            "/authors/OL4A".to_string(),
+            "/authors/OL5A".to_string(),
+            "/authors/OL6A".to_string(),
+        ];
+        let valid: Vec<&str> = OpenLibraryProvider::valid_author_keys(&keys)
+            .into_iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            valid,
+            vec!["/authors/OL1A", "/authors/OL2A", "/authors/OL3A", "/authors/OL4A"]
+        );
+    }
+
+    #[test]
+    fn valid_author_keys_empty_input_is_empty() {
+        assert!(OpenLibraryProvider::valid_author_keys(&[]).is_empty());
     }
 }

--- a/src/services/title.rs
+++ b/src/services/title.rs
@@ -39,6 +39,31 @@ impl TitleService {
         check_digit == digits[12]
     }
 
+    /// Validate a UPC-A checksum using the modulo-10 algorithm (#384).
+    /// UPC-A is 12 digits with weights 3 and 1 — the mirror of EAN-13's 1/3
+    /// (odd 1-indexed positions ×3, even ×1). Catches fat-fingered manual
+    /// UPC entries before they reach the provider chain.
+    pub fn validate_upc12_checksum(upc: &str) -> bool {
+        if upc.len() != 12 {
+            return false;
+        }
+
+        let digits: Vec<u32> = match upc.chars().map(|c| c.to_digit(10)).collect() {
+            Some(d) => d,
+            None => return false,
+        };
+
+        let sum: u32 = digits
+            .iter()
+            .enumerate()
+            .take(11)
+            .map(|(i, &d)| if i % 2 == 0 { d * 3 } else { d })
+            .sum();
+
+        let check_digit = (10 - (sum % 10)) % 10;
+        check_digit == digits[11]
+    }
+
     /// Create a new title from a scanned ISBN.
     /// Returns (title, is_new) where is_new indicates if it was just created.
     /// Note: There is a theoretical TOCTOU race between find_by_isbn and create,
@@ -117,6 +142,21 @@ impl TitleService {
         if code_type == CodeType::Isbn && !Self::validate_isbn13_checksum(code) {
             return Err(AppError::BadRequest(
                 rust_i18n::t!("error.isbn.invalid_checksum").to_string(),
+            ));
+        }
+
+        // Validate UPC-A checksum for 12-digit codes (#384). `CodeType::Upc`
+        // is a catch-all for 8–13 digit product barcodes (EAN-8, UPC-A,
+        // EAN-13 — see routes::catalog::detect_code_type), so the mod-10 guard
+        // is scoped to the 12-digit UPC-A case. Running the UPC-A algorithm on
+        // a 13-digit EAN would reject valid product codes; those lengths keep
+        // their pre-#384 (unvalidated) behaviour.
+        if code_type == CodeType::Upc
+            && code.len() == 12
+            && !Self::validate_upc12_checksum(code)
+        {
+            return Err(AppError::BadRequest(
+                rust_i18n::t!("error.upc.invalid_checksum").to_string(),
             ));
         }
 
@@ -653,6 +693,52 @@ mod tests {
     #[test]
     fn test_isbn_all_zeros() {
         assert!(TitleService::validate_isbn13_checksum("0000000000000"));
+    }
+
+    // ─── #384: UPC-A checksum ───────────────────────────────
+
+    #[test]
+    fn test_valid_upc_036000291452() {
+        // Classic UPC-A example (check digit 2).
+        assert!(TitleService::validate_upc12_checksum("036000291452"));
+    }
+
+    #[test]
+    fn test_valid_upc_012345678905() {
+        // Another well-known valid UPC-A (check digit 5).
+        assert!(TitleService::validate_upc12_checksum("012345678905"));
+    }
+
+    #[test]
+    fn test_invalid_upc_wrong_checksum() {
+        // Last digit flipped 2 → 3.
+        assert!(!TitleService::validate_upc12_checksum("036000291453"));
+    }
+
+    #[test]
+    fn test_invalid_upc_too_short() {
+        assert!(!TitleService::validate_upc12_checksum("03600029145"));
+    }
+
+    #[test]
+    fn test_invalid_upc_too_long() {
+        // 13 digits is an EAN-13, not a UPC-A.
+        assert!(!TitleService::validate_upc12_checksum("0360002914521"));
+    }
+
+    #[test]
+    fn test_invalid_upc_non_numeric() {
+        assert!(!TitleService::validate_upc12_checksum("03600029145X"));
+    }
+
+    #[test]
+    fn test_invalid_upc_empty() {
+        assert!(!TitleService::validate_upc12_checksum(""));
+    }
+
+    #[test]
+    fn test_upc_all_zeros() {
+        assert!(TitleService::validate_upc12_checksum("000000000000"));
     }
 
     #[test]

--- a/tests/upc_checksum_guard.rs
+++ b/tests/upc_checksum_guard.rs
@@ -1,0 +1,66 @@
+//! Integration tests for #384: UPC-A check-digit validation in
+//! `TitleService::create_from_code`.
+//!
+//! `CodeType::Upc` is a catch-all for 8–13 digit product barcodes (EAN-8,
+//! UPC-A, EAN-13 — see `routes::catalog::detect_code_type`). The #384 guard
+//! is deliberately scoped to the 12-digit UPC-A case, so a 13-digit EAN-13
+//! product code (also classified `Upc`) must NOT be rejected by the UPC-A
+//! mod-10 algorithm. These tests lock both halves of that contract.
+//!
+//! To run locally:
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true \
+//!     DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test upc_checksum_guard
+
+use mybibli::error::AppError;
+use mybibli::models::media_type::{CodeType, MediaType};
+use mybibli::services::title::TitleService;
+use sqlx::MySqlPool;
+
+#[sqlx::test(migrations = "./migrations")]
+async fn invalid_12_digit_upc_is_rejected(pool: MySqlPool) {
+    // 036000291453 = the valid UPC-A 036000291452 with its check digit
+    // flipped 2 → 3. The #384 guard must reject it before the provider chain.
+    let err = TitleService::create_from_code(
+        &pool,
+        "036000291453",
+        MediaType::Book,
+        CodeType::Upc,
+        None,
+    )
+    .await
+    .expect_err("invalid 12-digit UPC-A must be rejected");
+    assert!(matches!(err, AppError::BadRequest(_)), "expected BadRequest, got {err:?}");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn valid_12_digit_upc_is_accepted(pool: MySqlPool) {
+    let (_title, is_new) = TitleService::create_from_code(
+        &pool,
+        "036000291452",
+        MediaType::Book,
+        CodeType::Upc,
+        None,
+    )
+    .await
+    .expect("valid UPC-A must be accepted");
+    assert!(is_new, "a fresh UPC-A should create a new title");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn thirteen_digit_ean_classified_as_upc_is_not_rejected(pool: MySqlPool) {
+    // 0093624738626 is a real 13-digit EAN-13 CD barcode that
+    // detect_code_type classifies as CodeType::Upc. The #384 guard is scoped
+    // to 12-digit codes, so it must pass through untouched (no UPC-A check).
+    let (_title, is_new) = TitleService::create_from_code(
+        &pool,
+        "0093624738626",
+        MediaType::Cd,
+        CodeType::Upc,
+        None,
+    )
+    .await
+    .expect("13-digit EAN classified as UPC must pass the #384 guard");
+    assert!(is_new, "a fresh 13-digit EAN should create a new title");
+}


### PR DESCRIPTION
Two of the three provider-robustness follow-ups deferred from #23. The third (per-provider configurable timeout) is a feature, not a fix, and is split out to **#396**.

## 1. Open Library author-resolution concurrency

`OpenLibraryProvider::resolve_authors` resolved `/authors/{key}.json` lookups **sequentially**; for multi-author books each round-trip ate into the per-provider timeout budget. It now resolves them **concurrently** via `futures` `buffered`, capped at `MAX_CONCURRENT_AUTHOR_LOOKUPS = 4` (Open Library has soft per-IP limits). `buffered` preserves input order, so the resolved-name order is unchanged.

The SSRF guard (reject non-`/authors/OL…` keys) + `MAX_AUTHORS` cap are extracted into a pure, unit-tested `valid_author_keys` helper.

Adds the `futures = "0.3"` crate (already transitively present via `futures-util`).

## 2. UPC-A checksum validation

New `TitleService::validate_upc12_checksum` (mod-10, weights 3/1 — the mirror of EAN-13's 1/3), and `create_from_code` now rejects a bad check digit with `error.upc.invalid_checksum` (added to all 4 locales).

**Key design point:** `CodeType::Upc` is a **catch-all** for 8–13 digit product barcodes (EAN-8, UPC-A, EAN-13 — see `routes::catalog::detect_code_type`). Running the UPC-A algorithm on a 13-digit EAN would reject valid product codes, so the guard is **scoped to `len == 12`**. A `#[sqlx::test]` locks the regression: a 13-digit EAN classified as `Upc` (e.g. the CD barcode `0093624738626` used by the media-type-scanning E2E) is **not** rejected.

## Testing

- 8 UPC-A unit tests + 2 `valid_author_keys` unit tests
- 3 `#[sqlx::test]` integration tests (`tests/upc_checksum_guard.rs`): bad 12-digit UPC rejected, valid UPC accepted, 13-digit EAN-as-Upc accepted
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --test locale_parity` green (de/en/fr/it)

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)