### PR TITLE
refactor(#386): ship #i18n-bundle data island, migrate session-timeout.js

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -726,9 +726,11 @@ loan:
   not_found: "Loan not found."
   col_action: Action
 session:
-  # Mirrored in static/js/session-timeout.js (i18n object) — keep in sync.
-  # The JS picks `expiry_in_minutes` when the remaining window >= 1 min,
-  # else falls back to the parameterless `expiry_soon`.
+  # Emitted to the client via the #i18n-bundle data island
+  # (utils::build_js_i18n_bundle, issue #386) and read by
+  # static/js/session-timeout.js — no hand-synced JS copy. The JS picks
+  # `expiry_in_minutes` when the remaining window >= 1 min, else falls
+  # back to the parameterless `expiry_soon`.
   expiry_soon: "Your session is about to expire."
   expiry_in_minutes: "Your session will expire in %{minutes} min."
   stay_connected: Stay connected

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -722,9 +722,11 @@ loan:
   not_found: "Prêt introuvable."
   col_action: Action
 session:
-  # Reflété dans static/js/session-timeout.js (objet i18n) — garder synchronisé.
-  # Le JS choisit `expiry_in_minutes` si le délai restant >= 1 min,
-  # sinon il bascule sur `expiry_soon` (sans paramètre).
+  # Transmis au client via l'îlot de données #i18n-bundle
+  # (utils::build_js_i18n_bundle, issue #386) et lu par
+  # static/js/session-timeout.js — plus de copie JS synchronisée à la main.
+  # Le JS choisit `expiry_in_minutes` si le délai restant >= 1 min, sinon
+  # il bascule sur `expiry_soon` (sans paramètre).
   expiry_soon: "Votre session va bientôt expirer."
   expiry_in_minutes: "Votre session expirera dans %{minutes} min."
   stay_connected: Rester connecté

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -322,6 +322,42 @@ pub struct BaseContextFields {
     pub nav_menu_open: String,
     pub current_url: String,
     pub lang_toggle_aria: String,
+    /// Issue #386 — JSON i18n bundle for client-side JS modules, emitted
+    /// by `layouts/base.html` as a `<script type="application/json"
+    /// id="i18n-bundle">` data island. See [`build_js_i18n_bundle`].
+    pub js_i18n: String,
+}
+
+/// Issue #386 — build the per-request i18n bundle that
+/// `layouts/base.html` emits as a `<script type="application/json"
+/// id="i18n-bundle">` data island. Client JS reads it once via
+/// `JSON.parse(document.getElementById("i18n-bundle").textContent)`
+/// instead of carrying hand-synced `{en: …, fr: …}` objects (which
+/// silently drifted from `locales/*.yml` and never covered de/it).
+///
+/// Strings are resolved server-side in the REQUEST locale, so JS picks
+/// up de/it for free. `%{minutes}`-style placeholders are preserved
+/// verbatim for client-side substitution.
+///
+/// `<`, `>`, and `&` in the serialized JSON are replaced with their
+/// `\uXXXX` escapes so a translated value containing `</script>` (or
+/// `<!--`) cannot break out of the data island — defense in depth on top
+/// of `tests/locale_html_safety.rs` (which already refuses markup in
+/// locale values).
+pub fn build_js_i18n_bundle(locale: &str) -> String {
+    let bundle = serde_json::json!({
+        "session": {
+            "expiry_soon": rust_i18n::t!("session.expiry_soon", locale = locale).to_string(),
+            "expiry_in_minutes": rust_i18n::t!("session.expiry_in_minutes", locale = locale).to_string(),
+            "stay_connected": rust_i18n::t!("session.stay_connected", locale = locale).to_string(),
+            "dismiss_aria": rust_i18n::t!("session.dismiss_aria", locale = locale).to_string(),
+        }
+    });
+    serde_json::to_string(&bundle)
+        .unwrap_or_else(|_| "{}".to_string())
+        .replace('<', "\\u003c")
+        .replace('>', "\\u003e")
+        .replace('&', "\\u0026")
 }
 
 /// Build the shared fields for a full-page render. Caller provides the
@@ -358,6 +394,7 @@ pub fn base_context(
         nav_menu_open: rust_i18n::t!("nav.menu_open", locale = locale).to_string(),
         current_url: current_url(uri),
         lang_toggle_aria: rust_i18n::t!("nav.language_toggle_aria", locale = locale).to_string(),
+        js_i18n: build_js_i18n_bundle(locale),
     }
 }
 
@@ -397,6 +434,7 @@ pub(crate) fn test_base_context(
         nav_menu_open: rust_i18n::t!("nav.menu_open", locale = locale).to_string(),
         current_url: "/".to_string(),
         lang_toggle_aria: rust_i18n::t!("nav.language_toggle_aria", locale = locale).to_string(),
+        js_i18n: build_js_i18n_bundle(locale),
     }
 }
 
@@ -657,5 +695,60 @@ mod tests {
                 "{name} resolved to the raw i18n key {value} — missing en.yml entry?"
             );
         }
+    }
+
+    // ─── #386 — JS i18n bundle ─────────────────────────────────────
+
+    #[test]
+    fn js_i18n_bundle_carries_session_keys_as_valid_json() {
+        let json = build_js_i18n_bundle("en");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("bundle must be valid JSON");
+        let session = &parsed["session"];
+        for key in [
+            "expiry_soon",
+            "expiry_in_minutes",
+            "stay_connected",
+            "dismiss_aria",
+        ] {
+            assert!(
+                session[key].as_str().is_some_and(|s| !s.is_empty()),
+                "session.{key} must be a non-empty string in the bundle"
+            );
+        }
+        // The parameterized string keeps its client-substituted placeholder.
+        assert!(
+            session["expiry_in_minutes"]
+                .as_str()
+                .unwrap()
+                .contains("%{minutes}"),
+            "expiry_in_minutes must preserve the %{{minutes}} placeholder for client-side substitution"
+        );
+    }
+
+    #[test]
+    fn js_i18n_bundle_resolves_per_locale() {
+        let en = build_js_i18n_bundle("en");
+        let de = build_js_i18n_bundle("de");
+        // de/it were the gap the hand-synced JS objects never covered —
+        // prove the server-side bundle resolves them and differs from en.
+        let en_v: serde_json::Value = serde_json::from_str(&en).unwrap();
+        let de_v: serde_json::Value = serde_json::from_str(&de).unwrap();
+        assert_ne!(
+            en_v["session"]["stay_connected"], de_v["session"]["stay_connected"],
+            "de bundle must carry the German string, not the English fallback"
+        );
+    }
+
+    #[test]
+    fn js_i18n_bundle_escapes_angle_brackets_for_safe_embedding() {
+        // The serialized bundle must never contain a literal `<` or `>` —
+        // they're \uXXXX-escaped so a future translated value containing
+        // `</script>` can't break out of the data island.
+        let json = build_js_i18n_bundle("en");
+        assert!(
+            !json.contains('<') && !json.contains('>'),
+            "bundle must escape < and > to \\u003c / \\u003e: {json}"
+        );
     }
 }

--- a/static/js/session-timeout.js
+++ b/static/js/session-timeout.js
@@ -13,6 +13,22 @@
     var timerId = null;
     var toastEl = null;
 
+    // Issue #386 — read the server-rendered i18n bundle once. Strings are
+    // already resolved in the request locale (en/fr/de/it), so this module
+    // no longer carries a hand-synced {en, fr} object that drifted from
+    // locales/*.yml and never covered de/it. Returns the `session` subtree
+    // (or {} if the data island is missing/malformed — degrades to blank
+    // text rather than throwing).
+    function getSessionStrings() {
+        try {
+            var el = document.getElementById("i18n-bundle");
+            var bundle = el ? JSON.parse(el.textContent) : {};
+            return bundle.session || {};
+        } catch (e) {
+            return {};
+        }
+    }
+
     function getTimeoutSecs() {
         var attr = document.body.getAttribute("data-session-timeout");
         return attr ? parseInt(attr, 10) : 0;
@@ -51,36 +67,25 @@
         // i18n: detect language from <html lang> and use appropriate strings
         var msgEl = toastEl.querySelector("#session-timeout-message");
         var btnEl = toastEl.querySelector("#session-keepalive-btn");
-        var lang = document.documentElement.lang || "en";
-        // Mirrored in locales/{en,fr}.yml under `session.*` — keep in sync.
-        // `expiry_soon` = short/parameterless form when remaining < 1 min.
+        // i18n: strings come from the server-rendered #i18n-bundle data
+        // island (issue #386), already localized for the request locale.
+        // `expiry_soon` = short/parameterless form when remaining < 1 min;
         // `expiry_in_minutes` = parameterized on %{minutes}.
-        var i18n = {
-            en: {
-                expiry_soon: "Your session is about to expire.",
-                expiry_in_minutes: "Your session will expire in %{minutes} min.",
-                stay: "Stay connected",
-                dismiss: "Dismiss",
-            },
-            fr: {
-                expiry_soon: "Votre session va bientôt expirer.",
-                expiry_in_minutes: "Votre session expirera dans %{minutes} min.",
-                stay: "Rester connecté",
-                dismiss: "Fermer",
-            },
-        };
-        var strings = i18n[lang] || i18n.en;
+        var strings = getSessionStrings();
         var minutes = Math.round(warningBeforeSecs / 60);
         var msg =
             minutes >= 1
-                ? strings.expiry_in_minutes.replace("%{minutes}", String(minutes))
-                : strings.expiry_soon;
+                ? (strings.expiry_in_minutes || "").replace(
+                      "%{minutes}",
+                      String(minutes),
+                  )
+                : strings.expiry_soon || "";
         msgEl.textContent = msg;
-        btnEl.textContent = strings.stay;
+        btnEl.textContent = strings.stay_connected || "";
         btnEl.addEventListener("click", keepAlive);
         var dismissBtn = toastEl.querySelector("#session-timeout-dismiss");
         if (dismissBtn) {
-            dismissBtn.setAttribute("aria-label", strings.dismiss);
+            dismissBtn.setAttribute("aria-label", strings.dismiss_aria || "");
             dismissBtn.addEventListener("click", hideWarning);
         }
         document.body.appendChild(toastEl);

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ base.csrf_token|e }}">
+    {# Issue #386 — i18n bundle for client-side JS modules. Resolved
+       server-side in the request locale; read once via JSON.parse in
+       static/js/*.js. `< > &` are \uXXXX-escaped in build_js_i18n_bundle
+       so the data island can't be broken out of. CSP-clean (the
+       templates_audit no-inline-markup gate allowlists application/json). #}
+    <script type="application/json" id="i18n-bundle">{{ base.js_i18n|safe }}</script>
     <title>{% block title %}mybibli{% endblock %}</title>
     <link rel="stylesheet" href="/static/css/output.css">
     <link rel="stylesheet" href="/static/css/browse.css">

--- a/tests/e2e/specs/journeys/session-inactivity-timeout.spec.ts
+++ b/tests/e2e/specs/journeys/session-inactivity-timeout.spec.ts
@@ -76,6 +76,13 @@ test.describe("Story 7-2 — session inactivity timeout", () => {
     await expect(toast).toBeVisible({ timeout: 15_000 });
     await expect(toast).toHaveAttribute("role", "alert");
 
+    // #386 — the warning + button copy come from the server-rendered
+    // #i18n-bundle data island (no hand-synced JS strings). Assert they
+    // actually populated, so a broken bundle wiring fails loudly instead
+    // of silently showing an empty toast.
+    await expect(page.locator("#session-timeout-message")).not.toHaveText("");
+    await expect(page.locator("#session-keepalive-btn")).not.toHaveText("");
+
     const stay = page.locator("#session-keepalive-btn");
     await stay.click();
 


### PR DESCRIPTION
Closes #386. Builds on #398 (the embed made the bundle field a one-line add).

## What

JS modules carried hand-synced `{en: …, fr: …}` i18n objects that drifted from `locales/*.yml` and never covered de/it. This ships the shared pattern deferred from #29:

- **`utils::build_js_i18n_bundle(locale)`** resolves the JS-needed strings in the request locale and `serde_json`-encodes them, escaping `< > &` → `\uXXXX` so a translated value containing `</script>` (or `<!--`) can't break out of the data island (defense in depth on top of `tests/locale_html_safety.rs`).
- **`BaseContextFields.js_i18n`** carries the JSON — one-line add each in the struct + `base_context()`, thanks to #398's embed. `layouts/base.html` emits it in `<head>` as `<script type="application/json" id="i18n-bundle">`. CSP-clean (the `templates_audit` no-inline-markup gate allowlists `application/json` data islands).
- **PoC migration:** `static/js/session-timeout.js` drops its hardcoded en/fr object and reads `JSON.parse(#i18n-bundle).session.*`. The inactivity toast now localizes in **de/it for free**. The `%{minutes}` placeholder is preserved for client-side substitution.
- Stale "keep in sync with the JS object" comments in `en/fr` locale files now point at the bundle mechanism.

### Rendered output (FR locale)
```html
<script type="application/json" id="i18n-bundle">{"session":{"dismiss_aria":"Fermer","expiry_in_minutes":"Votre session expirera dans %{minutes} min.","expiry_soon":"Votre session va bientôt expirer.","stay_connected":"Rester connecté"}}</script>
```

## Follow-up (separate, out of scope)

`inline-form.js` + `mybibli.js` carry the same hand-synced pattern. Migrating them needs new locale keys (with de/it copy), so they're a separate sweep — the infrastructure here is ready for them.

## Testing

- `cargo check` + `cargo clippy --all-targets` clean
- `cargo test` — **1025 lib** (+3 new on `build_js_i18n_bundle`: valid JSON, per-locale resolution incl. de, `< >` escaping) + full integration + `locale_parity` + `locale_html_safety` green
- `templates_audit` no-inline-markup gate green with the new data island
- `./scripts/e2e-reset.sh` + `CI=true npx playwright test --workers=2` — **282 passed**; `session-inactivity-timeout.spec.ts` now asserts the toast copy is non-empty (bundle-wiring regression guard). The one non-green was the pre-existing known-flaky `title-detail-volumes` (passes in isolation, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)