### PR TITLE
fix: log-level form 409 + transport-crate log noise (#406, #405)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,77 @@ pub fn csp_report_only() -> bool {
     report_only
 }
 
+/// Transport-crate log targets that emit pure HTTP-connection DEBUG noise
+/// (connect/pool internals) with no diagnostic value for mybibli itself.
+/// Fix #405: capped to `warn` by default so that even a global `debug`
+/// directive — or a legitimate `mybibli=debug` — does not drag in the
+/// per-request hyper/reqwest firehose (~2 MB/day observed in prod when the
+/// dev `.env` shipped `MYBIBLI_LOG_LEVEL=debug`).
+const LOG_NOISE_CAPS: &str = "hyper_util=warn,reqwest=warn,hyper=warn";
+
+/// Combine the operator's log-level directive with the default noise caps.
+///
+/// The caps are placed FIRST and the operator directive LAST, so an explicit
+/// operator entry for the same target wins (`tracing-subscriber` keeps the
+/// last directive for a given target), while target-specific caps still beat
+/// a bare global level via longest-match specificity. Concretely:
+/// - `info`                 → caps + `info` (no transport noise)
+/// - `mybibli=debug`        → caps + `mybibli=debug` (app debug, no noise)
+/// - `debug`                → global debug, but transport crates stay `warn`
+/// - `hyper_util=trace`     → operator override wins, full transport trace
+pub fn combine_log_directives(operator: &str) -> String {
+    let operator = operator.trim();
+    if operator.is_empty() {
+        return LOG_NOISE_CAPS.to_string();
+    }
+    format!("{LOG_NOISE_CAPS},{operator}")
+}
+
+#[cfg(test)]
+mod combine_log_directives_tests {
+    use super::{LOG_NOISE_CAPS, combine_log_directives};
+    use tracing_subscriber::EnvFilter;
+
+    #[test]
+    fn caps_are_prepended_and_operator_appended() {
+        let combined = combine_log_directives("info");
+        assert_eq!(combined, format!("{LOG_NOISE_CAPS},info"));
+        // The caps come BEFORE the operator so a same-target operator entry
+        // (added later) wins in tracing-subscriber's last-wins semantics.
+        assert!(combined.starts_with(LOG_NOISE_CAPS));
+        assert!(combined.ends_with("info"));
+    }
+
+    #[test]
+    fn empty_operator_yields_caps_only() {
+        assert_eq!(combine_log_directives(""), LOG_NOISE_CAPS);
+        assert_eq!(combine_log_directives("   "), LOG_NOISE_CAPS);
+    }
+
+    #[test]
+    fn every_realistic_directive_combination_parses() {
+        // The combined string must always be a valid EnvFilter directive,
+        // for plain levels, app-scoped debug, global debug, and overrides.
+        for op in ["info", "debug", "warn", "mybibli=debug", "hyper_util=trace"] {
+            let combined = combine_log_directives(op);
+            assert!(
+                EnvFilter::try_new(&combined).is_ok(),
+                "combined directive {combined:?} must parse as a valid EnvFilter"
+            );
+        }
+    }
+
+    #[test]
+    fn operator_override_for_a_capped_target_is_last() {
+        // An operator that explicitly wants hyper_util=trace must have that
+        // directive AFTER the cap, so it wins (last-wins for same target).
+        let combined = combine_log_directives("hyper_util=trace");
+        let cap_pos = combined.find("hyper_util=warn").expect("cap present");
+        let override_pos = combined.find("hyper_util=trace").expect("override present");
+        assert!(override_pos > cap_pos, "operator override must come after the cap");
+    }
+}
+
 #[cfg(test)]
 mod csp_report_only_tests {
     use super::csp_report_only;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,21 +77,26 @@ async fn main() {
     // NAS's `docker-compose.yml` `environment:` block and restart the
     // container; for a deep one-shot investigation, `mybibli=trace`.
     use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
-    let log_level_directive: String = std::env::var("MYBIBLI_LOG_LEVEL")
+    let operator_directive: String = std::env::var("MYBIBLI_LOG_LEVEL")
         .or_else(|_| std::env::var("RUST_LOG"))
         .unwrap_or_else(|_| "info".to_string());
     // `EnvFilter::try_new` rejects garbage; fall back to `info` so a typo
-    // can't silence the subscriber entirely.
-    let env_filter = match EnvFilter::try_new(&log_level_directive) {
-        Ok(f) => f,
-        Err(e) => {
-            eprintln!(
-                "[mybibli] invalid MYBIBLI_LOG_LEVEL/RUST_LOG directive {:?} ({}). Falling back to `info`.",
-                log_level_directive, e
-            );
-            EnvFilter::new("info")
-        }
+    // can't silence the subscriber entirely. Validate the operator directive
+    // alone first, then layer on the Fix #405 transport-crate noise caps via
+    // `combine_log_directives` so even a global `debug` keeps hyper/reqwest
+    // at `warn`.
+    let validated_operator = if EnvFilter::try_new(&operator_directive).is_ok() {
+        operator_directive.clone()
+    } else {
+        eprintln!(
+            "[mybibli] invalid MYBIBLI_LOG_LEVEL/RUST_LOG directive {:?}. Falling back to `info`.",
+            operator_directive
+        );
+        "info".to_string()
     };
+    let log_level_directive = mybibli::config::combine_log_directives(&validated_operator);
+    let env_filter = EnvFilter::try_new(&log_level_directive)
+        .unwrap_or_else(|_| EnvFilter::new("info"));
     // Fix #308 (v1.7.1): wrap the EnvFilter in a `reload::Layer` so the
     // admin "Log level" form (System tab) can swap it at runtime via
     // the handle stored in AppState. Closes the v1.7.0 #301 gap — the
@@ -339,10 +344,19 @@ async fn main() {
     // restarting the process. Closure validates via `EnvFilter::try_new`
     // and translates any parse error to a `String` for the handler to
     // surface in a localized BadRequest feedback.
+    // The closure validates the operator directive via `EnvFilter::try_new`,
+    // then layers on the Fix #405 noise caps via `combine_log_directives`
+    // before swapping — so a DB-reconciled or admin-saved `debug` keeps the
+    // transport crates at `warn`, identical to the boot path above.
     let log_level_reloader: mybibli::LogLevelReloader = {
         let handle = filter_reload_handle.clone();
         std::sync::Arc::new(move |directive: &str| -> Result<(), String> {
-            let new_filter = tracing_subscriber::EnvFilter::try_new(directive)
+            // Validate the operator directive alone so the error message
+            // points at what the operator actually typed.
+            tracing_subscriber::EnvFilter::try_new(directive)
+                .map_err(|e| format!("invalid directive: {e}"))?;
+            let combined = mybibli::config::combine_log_directives(directive);
+            let new_filter = tracing_subscriber::EnvFilter::try_new(&combined)
                 .map_err(|e| format!("invalid directive: {e}"))?;
             handle
                 .modify(|f| *f = new_filter)
@@ -358,10 +372,10 @@ async fn main() {
         let guard = settings_arc.read().expect("settings RwLock not poisoned");
         guard.log_level.clone()
     };
-    if persisted_level != log_level_directive {
+    if persisted_level != validated_operator {
         match log_level_reloader(&persisted_level) {
             Ok(()) => tracing::info!(
-                from_env = %log_level_directive,
+                from_env = %validated_operator,
                 to_db = %persisted_level,
                 "Fix #308: reconciled tracing filter to DB-persisted log_level"
             ),

--- a/src/routes/admin_system.rs
+++ b/src/routes/admin_system.rs
@@ -263,15 +263,23 @@ fn helper_text_for(value: &str, loc: &'static str) -> String {
 // They have been removed; this file now imports the canonical
 // implementations at the top of the module.
 
-/// Collect the 5 setting rows we render in the panel. Versions come from the
+/// Collect every setting row the panel renders. Versions come from the
 /// DB (the `AppSettings` cache doesn't carry per-row versions); values can
 /// come either from the DB or the cache — they're the same after a save.
+///
+/// Fix #406: every key whose form carries a hidden `*_version` field for
+/// the optimistic-lock check MUST be in this `IN` list. A key omitted here
+/// makes `render_panel_html` fall back to `version = 1`, so once that row's
+/// DB version advances past 1 the form posts a stale version and every save
+/// 409s forever (`log_level` was stuck this way; the two #334 timeout keys
+/// carried the same latent bug — they only survived while their version was
+/// still 1).
 async fn fetch_setting_rows(
     pool: &DbPool,
 ) -> Result<HashMap<String, (String, i32)>, AppError> {
     let rows: Vec<(String, String, i32)> = sqlx::query_as(
         "SELECT setting_key, setting_value, version FROM settings \
-         WHERE setting_key IN (?, ?, ?, ?, ?, ?, ?) AND deleted_at IS NULL",
+         WHERE setting_key IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND deleted_at IS NULL",
     )
     .bind(KEY_OVERDUE_THRESHOLD)
     .bind(KEY_DEFAULT_LANGUAGE)
@@ -280,6 +288,9 @@ async fn fetch_setting_rows(
     .bind(KEY_TMDB)
     .bind(KEY_DEFAULT_CURRENCY)
     .bind(KEY_SHOW_VALUE_INDICATORS)
+    .bind(KEY_LOG_LEVEL)
+    .bind(KEY_METADATA_CHAIN_TIMEOUT)
+    .bind(KEY_PROVIDER_HEALTH_TIMEOUT)
     .fetch_all(pool)
     .await?;
     let mut map = HashMap::new();

--- a/tests/admin_system_integration.rs
+++ b/tests/admin_system_integration.rs
@@ -175,6 +175,103 @@ async fn save_loans_settings_updates_row_and_reloads_cache(pool: DbPool) {
     );
 }
 
+/// Extract the hidden `log_level_version` field value from the freshly
+/// rendered System panel — i.e. the version the form will actually POST.
+async fn fetch_log_level_version(router: &axum::Router, session_cookie: &str) -> i32 {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::get("/admin/system")
+                .header("cookie", format!("session={}", session_cookie))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let html = String::from_utf8(bytes.to_vec()).unwrap();
+    let needle = "name=\"log_level_version\" value=\"";
+    let start = html.find(needle).expect("log_level_version hidden field") + needle.len();
+    let rest = &html[start..];
+    let end = rest.find('"').unwrap();
+    rest[..end].parse().expect("log_level_version is an integer")
+}
+
+/// Regression for #406: the System-tab "Log level" form must carry the
+/// *current* DB version, not a hardcoded fallback of 1. Before the fix,
+/// `fetch_setting_rows` omitted `log_level` from its `IN` list, so
+/// `render_panel_html` fell back to `version = 1`; once the row advanced
+/// past 1 (after the first successful save) every subsequent save POSTed a
+/// stale version → 0 rows matched → permanent 409. This test does two saves
+/// in a row using the version the panel actually renders — the second save
+/// would 409 under the bug.
+#[sqlx::test(migrations = "./migrations")]
+async fn save_log_level_twice_succeeds_version_round_trips(pool: DbPool) {
+    let username = seed_admin(&pool).await;
+    let state = state_with_pool(pool.clone());
+    let cache = state.settings.clone();
+    let router = app(state);
+    let (cookie, csrf) = login_and_extract(&router, &username, "librarian").await;
+
+    // First save: seed row is ('log_level', 'info', 1) → version 1 matches,
+    // DB row advances to version 2, value 'debug'.
+    let body = format!("log_level=debug&log_level_version=1&_csrf_token={}", csrf);
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/admin/system/log-level")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "first log-level save returns 200");
+    assert_eq!(cache.read().unwrap().log_level, "debug");
+
+    // The freshly rendered panel must carry the NEW version (2), not the
+    // pre-fix fallback of 1 — this is the core of #406.
+    let rendered_version = fetch_log_level_version(&router, &cookie).await;
+    assert_eq!(
+        rendered_version, 2,
+        "System panel must render the current DB version, not the fallback 1 (#406)"
+    );
+
+    // Second save using the version the panel actually rendered — must NOT 409.
+    let body = format!(
+        "log_level=info&log_level_version={}&_csrf_token={}",
+        rendered_version, csrf
+    );
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/admin/system/log-level")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "second consecutive log-level save must succeed, not 409 (#406)"
+    );
+
+    // DB reflects the second save; version advanced 1 → 2 → 3.
+    let row: (String, i32) = sqlx::query_as(
+        "SELECT setting_value, version FROM settings WHERE setting_key = 'log_level'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "info");
+    assert_eq!(row.1, 3, "version must advance across two consecutive saves");
+    assert_eq!(cache.read().unwrap().log_level, "info");
+}
+
 #[sqlx::test(migrations = "./migrations")]
 async fn save_loans_settings_rejects_zero_and_leaves_row_unchanged(pool: DbPool) {
     let username = seed_admin(&pool).await;

--- a/tests/e2e/specs/journeys/admin-system-settings.spec.ts
+++ b/tests/e2e/specs/journeys/admin-system-settings.spec.ts
@@ -93,6 +93,50 @@ test.describe("Story 8-5 — Admin System Settings", () => {
     ).toBeVisible({ timeout: 10000 });
   });
 
+  test("log level saves twice in a row without a 409 (#406)", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    const logInput = page.locator(
+      'form#admin-system-log-form input[name="log_level"]',
+    );
+    const logSubmit = page.locator(
+      'form#admin-system-log-form button[type="submit"]',
+    );
+    await expect(logInput).toBeVisible();
+
+    // First save: bumps the DB row's version (1 → 2).
+    await logInput.fill("debug");
+    await logSubmit.click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(
+          /Log level saved|Niveau de journalisation enregistré/i,
+        ),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Second consecutive save. Before the #406 fix the swapped form still
+    // carried a stale version (always 1 — `log_level` was missing from
+    // `fetch_setting_rows`), so this POST 409'd and silently did nothing.
+    await logInput.fill("info");
+    await logSubmit.click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/Log level saved|Niveau de journalisation enregistré/i)
+        .last(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Strongest proof the second save actually persisted: the reloaded form
+    // shows "info", not the stuck "debug" of the 409 path. Ends on the seed
+    // default ("info") so no reset is needed for isolation.
+    await page.goto("/admin?tab=system");
+    await expect(logInput).toHaveValue("info");
+  });
+
   test("provider key save renders mask after reload, clear wipes", async ({
     page,
   }) => {


### PR DESCRIPTION
Patch toward **v1.8.7** — two coupled logging fixes diagnosed from the prod NAS on 2026-06-10.

## #406 — Admin "Log level" form silently fails to persist (the real bug)

`POST /admin/system/log-level` returned **409** every time and the live filter never swapped. Root cause: `fetch_setting_rows` omitted `log_level` (and the two #334 timeout keys) from its `IN` list, so `render_panel_html` fell back to `version = 1`. Once the DB row advanced past version 1 (after the first successful save) the form always POSTed a stale version → 0 rows matched → permanent 409. The two timeout settings carried the same latent bug, surviving only while their version was still 1.

**Fix:** add `log_level` + both timeout keys to the query so the rendered form carries the real DB version.

## #405 — Log hygiene: cap transport-crate noise

Prod ran at global `debug` (the dev `.env` shipped `MYBIBLI_LOG_LEVEL=debug`), flooding ~2 MB/day of `hyper_util`/`reqwest` connection/pool DEBUG with no diagnostic value. New `combine_log_directives` prepends `hyper_util=warn,reqwest=warn,hyper=warn` to the operator directive (overridable — an explicit `hyper_util=trace` still wins), applied on both the boot path and the Fix #308 reload closure (DB reconcile + admin runtime change).

## Tests
- Unit: `combine_log_directives` (4 cases).
- Integration: `save_log_level_twice_succeeds_version_round_trips` — two consecutive saves through the full router (second 409'd under the bug) + asserts the panel renders the current version.
- E2E: log-level double-save via the real System-tab UI.
- Local gates green: build, `clippy --all-targets -D warnings`, `tsc --noEmit`, integration (21), lib (1029), E2E spec `CI=true --workers=2` (11).

Closes #406
Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)