### PR TITLE
feat: saved searches (#367)

### DIFF
--- a/docs/manual/en/03-usage.tex
+++ b/docs/manual/en/03-usage.tex
@@ -87,6 +87,28 @@ page that has the home-page scan field — that includes the home
 page, \texttt{/search} and \texttt{/loans}. Faster than typing.
 \end{tip}
 
+\subsection{Saved searches}\label{sec:saved-searches}
+
+Recurring lookups (``comics without a cover'', ``uncategorized
+titles'', ``everything overdue'') can be saved once and re-run with a
+single click. On the home page, compose the search you want — type a
+query, click a filter chip, choose a sort order — then open the
+\textbf{Saved searches} dropdown next to the sort control and use
+\emph{Save current search} to name and store it.
+
+Saved searches are \textbf{shared across the whole instance}: every
+librarian sees and can run the same set. To run one, open the dropdown
+and click its name — the home page reloads with that query, filter and
+sort applied. Each entry also offers \emph{Rename} and \emph{Delete}
+(both confirm in a modal). Deleting is reversible: saving a new search
+with the same name restores the old one.
+
+\begin{note}
+Saved searches capture the existing browse criteria (query, one filter
+chip, sort column and direction) — they are not a free-form query
+builder. The control is visible to librarians and administrators only.
+\end{note}
+
 \section{Moving a volume to another location}\label{sec:move-volume}
 
 \begin{enumerate}

--- a/docs/manual/fr/03-usage.tex
+++ b/docs/manual/fr/03-usage.tex
@@ -93,6 +93,32 @@ depuis n'importe quelle page qui dispose du champ de scan d'accueil
 Plus rapide que la frappe.
 \end{tip}
 
+\subsection{Recherches sauvegardées}\label{sec:saved-searches}
+
+Les recherches récurrentes (« BD sans couverture », « titres non
+classés », « tout ce qui est en retard ») peuvent être sauvegardées
+une fois puis relancées d'un seul clic. Sur la page d'accueil,
+composez la recherche voulue — saisissez une requête, cliquez une
+puce de filtre, choisissez un tri — puis ouvrez le menu déroulant
+\textbf{Recherches sauvegardées} à côté du contrôle de tri et utilisez
+\emph{Sauver la recherche courante} pour la nommer et l'enregistrer.
+
+Les recherches sauvegardées sont \textbf{partagées par toute
+l'instance} : tous les bibliothécaires voient et peuvent lancer le
+même ensemble. Pour en lancer une, ouvrez le menu et cliquez son nom
+— la page d'accueil se recharge avec cette requête, ce filtre et ce
+tri appliqués. Chaque entrée propose aussi \emph{Renommer} et
+\emph{Supprimer} (confirmation par fenêtre modale). La suppression est
+réversible : sauvegarder une nouvelle recherche du même nom restaure
+l'ancienne.
+
+\begin{note}
+Les recherches sauvegardées capturent les critères de navigation
+existants (requête, une puce de filtre, colonne et sens de tri) — ce
+n'est pas un constructeur de requêtes libre. Le contrôle n'est visible
+que pour les bibliothécaires et les administrateurs.
+\end{note}
+
 \section{Déplacer un volume vers un autre lieu}\label{sec:move-volume}
 
 \begin{enumerate}

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -965,7 +965,27 @@ admin:
     error_not_found: "API-Schlüssel nicht gefunden."
     error_already_revoked: "Dieser Schlüssel wurde bereits widerrufen."
     error_version_conflict: "Dieser Schlüssel wurde durch einen anderen Administrator geändert. Bitte das Panel neu laden."
+saved_searches:
+  toggle_label: "Gespeicherte Suchen"
+  name_label: "Name der Suche"
+  name_placeholder: "Diese Suche benennen"
+  save_label: "Aktuelle Suche speichern"
+  empty: "Noch keine gespeicherten Suchen"
+  run_aria: "Gespeicherte Suche ausführen: %{name}"
+  edit_aria: "Gespeicherte Suche umbenennen: %{name}"
+  delete_aria: "Gespeicherte Suche löschen: %{name}"
+  rename_modal_heading: "Gespeicherte Suche umbenennen"
+  delete_modal_heading: "Gespeicherte Suche löschen"
+  delete_modal_body: "Die gespeicherte Suche „%{name}“ löschen? Sie können sie später neu erstellen, indem Sie eine Suche mit demselben Namen speichern."
+  btn_rename: "Umbenennen"
+  btn_delete: "Löschen"
+  btn_cancel: "Abbrechen"
 success:
+  saved_search:
+    created: "Suche „%{name}“ gespeichert"
+    reactivated: "Gespeicherte Suche „%{name}“ wiederhergestellt"
+    renamed: "Suche umbenannt in „%{name}“"
+    deleted: "Gespeicherte Suche „%{name}“ gelöscht"
   reference_data:
     created: "%{name} hinzugefügt"
     reactivated: "%{name} reaktiviert"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -978,7 +978,27 @@ admin:
     error_not_found: "API key not found."
     error_already_revoked: "This key has already been revoked."
     error_version_conflict: "This key was modified by another administrator. Reload the panel."
+saved_searches:
+  toggle_label: "Saved searches"
+  name_label: "Search name"
+  name_placeholder: "Name this search"
+  save_label: "Save current search"
+  empty: "No saved searches yet"
+  run_aria: "Run saved search: %{name}"
+  edit_aria: "Rename saved search: %{name}"
+  delete_aria: "Delete saved search: %{name}"
+  rename_modal_heading: "Rename saved search"
+  delete_modal_heading: "Delete saved search"
+  delete_modal_body: "Delete the saved search \"%{name}\"? You can re-create it later by saving a search with the same name."
+  btn_rename: "Rename"
+  btn_delete: "Delete"
+  btn_cancel: "Cancel"
 success:
+  saved_search:
+    created: "Saved search '%{name}'"
+    reactivated: "Restored saved search '%{name}'"
+    renamed: "Renamed saved search to '%{name}'"
+    deleted: "Deleted saved search '%{name}'"
   reference_data:
     created: "Added %{name}"
     reactivated: "Reactivated %{name}"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -974,7 +974,27 @@ admin:
     error_not_found: "Clé d'API introuvable."
     error_already_revoked: "Cette clé a déjà été révoquée."
     error_version_conflict: "Cette clé a été modifiée par un autre administrateur. Rechargez le panneau."
+saved_searches:
+  toggle_label: "Recherches sauvegardées"
+  name_label: "Nom de la recherche"
+  name_placeholder: "Nommer cette recherche"
+  save_label: "Sauver la recherche courante"
+  empty: "Aucune recherche sauvegardée"
+  run_aria: "Lancer la recherche sauvegardée : %{name}"
+  edit_aria: "Renommer la recherche sauvegardée : %{name}"
+  delete_aria: "Supprimer la recherche sauvegardée : %{name}"
+  rename_modal_heading: "Renommer la recherche sauvegardée"
+  delete_modal_heading: "Supprimer la recherche sauvegardée"
+  delete_modal_body: "Supprimer la recherche sauvegardée « %{name} » ? Vous pourrez la recréer plus tard en sauvegardant une recherche du même nom."
+  btn_rename: "Renommer"
+  btn_delete: "Supprimer"
+  btn_cancel: "Annuler"
 success:
+  saved_search:
+    created: "Recherche « %{name} » sauvegardée"
+    reactivated: "Recherche « %{name} » restaurée"
+    renamed: "Recherche renommée en « %{name} »"
+    deleted: "Recherche « %{name} » supprimée"
   reference_data:
     created: "Ajout de %{name}"
     reactivated: "Réactivation de %{name}"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -951,7 +951,27 @@ admin:
     error_not_found: "Chiave API non trovata."
     error_already_revoked: "Questa chiave è già stata revocata."
     error_version_conflict: "Questa chiave è stata modificata da un altro amministratore. Ricarica il pannello."
+saved_searches:
+  toggle_label: "Ricerche salvate"
+  name_label: "Nome della ricerca"
+  name_placeholder: "Assegna un nome a questa ricerca"
+  save_label: "Salva la ricerca corrente"
+  empty: "Nessuna ricerca salvata"
+  run_aria: "Esegui ricerca salvata: %{name}"
+  edit_aria: "Rinomina ricerca salvata: %{name}"
+  delete_aria: "Elimina ricerca salvata: %{name}"
+  rename_modal_heading: "Rinomina ricerca salvata"
+  delete_modal_heading: "Elimina ricerca salvata"
+  delete_modal_body: "Eliminare la ricerca salvata «%{name}»? Potrai ricrearla in seguito salvando una ricerca con lo stesso nome."
+  btn_rename: "Rinomina"
+  btn_delete: "Elimina"
+  btn_cancel: "Annulla"
 success:
+  saved_search:
+    created: "Ricerca «%{name}» salvata"
+    reactivated: "Ricerca salvata «%{name}» ripristinata"
+    renamed: "Ricerca rinominata in «%{name}»"
+    deleted: "Ricerca salvata «%{name}» eliminata"
   reference_data:
     created: "Aggiunto %{name}"
     reactivated: "Riattivato %{name}"

--- a/migrations/20260610140000_create_saved_searches_table.sql
+++ b/migrations/20260610140000_create_saved_searches_table.sql
@@ -1,0 +1,31 @@
+-- CR #367: saved_searches table.
+--
+-- A saved search is a named, re-runnable bundle of the home browse state
+-- (free-text `q`, active filter chip, sort column + direction) — everything
+-- already encoded in the `/?q=...&filter=...&sort=...&dir=...` URL. The four
+-- criteria are stored as separate nullable columns (not a blob) so the run
+-- path can re-validate `sort`/`dir` against the existing whitelist.
+--
+-- Single-tenant: saved searches are GLOBAL (shared by every librarian),
+-- consistent with the one-settings-table model — no per-user FK.
+--
+-- UNIQUE on `name` (case-insensitive via utf8mb4_unicode_ci). Soft-delete +
+-- name reuse reactivates the trashed row (mirrors the genres CRUD pattern),
+-- so the UNIQUE is on `name` alone, not `(name, deleted_at)`.
+
+CREATE TABLE IF NOT EXISTS saved_searches (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  q TEXT NULL COMMENT 'Free-text search query (the home `q` param)',
+  filter VARCHAR(255) NULL COMMENT 'Active filter chip value, e.g. genre:3 / no_cover / overdue',
+  sort VARCHAR(50) NULL COMMENT 'Sort column name (validated against whitelist on run)',
+  dir VARCHAR(4) NULL COMMENT 'Sort direction: asc / desc',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  version INT NOT NULL DEFAULT 1,
+
+  UNIQUE KEY uq_saved_searches_name (name),
+  KEY idx_saved_searches_deleted_at (deleted_at),
+  KEY idx_saved_searches_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -9,6 +9,7 @@ pub mod location;
 pub mod location_node_type;
 pub mod media_type;
 pub mod metadata_cache;
+pub mod saved_search;
 pub mod series;
 pub mod session;
 pub mod title;

--- a/src/models/saved_search.rs
+++ b/src/models/saved_search.rs
@@ -1,0 +1,310 @@
+use sqlx::Row;
+
+use crate::db::DbPool;
+use crate::error::AppError;
+use crate::models::{CONFLICT_NAME_TAKEN, CreateOutcome};
+use crate::services::locking::check_update_result;
+
+/// A named, re-runnable bundle of the home browse state (CR #367). Global
+/// (single-tenant) — no per-user scope. The four criteria columns mirror the
+/// home `SearchParams` (`q`, `filter`, `sort`, `dir`); `None` means the field
+/// was absent from the saved URL.
+#[derive(Debug, Clone)]
+pub struct SavedSearchModel {
+    pub id: u64,
+    pub name: String,
+    pub q: Option<String>,
+    pub filter: Option<String>,
+    pub sort: Option<String>,
+    pub dir: Option<String>,
+    pub version: i32,
+}
+
+impl std::fmt::Display for SavedSearchModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl SavedSearchModel {
+    fn from_row(r: &sqlx::mysql::MySqlRow) -> Result<Self, AppError> {
+        Ok(SavedSearchModel {
+            id: r.try_get("id")?,
+            name: r.try_get("name")?,
+            q: r.try_get("q")?,
+            filter: r.try_get("filter")?,
+            sort: r.try_get("sort")?,
+            dir: r.try_get("dir")?,
+            version: r.try_get("version")?,
+        })
+    }
+
+    /// All non-deleted saved searches, sorted by name — ready for the
+    /// home search-bar dropdown.
+    pub async fn list_all(pool: &DbPool) -> Result<Vec<SavedSearchModel>, AppError> {
+        let rows = sqlx::query(
+            "SELECT id, name, q, filter, sort, dir, version \
+             FROM saved_searches WHERE deleted_at IS NULL ORDER BY name",
+        )
+        .fetch_all(pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for r in &rows {
+            out.push(Self::from_row(r)?);
+        }
+        Ok(out)
+    }
+
+    pub async fn find_by_id(pool: &DbPool, id: u64) -> Result<Option<SavedSearchModel>, AppError> {
+        let row = sqlx::query(
+            "SELECT id, name, q, filter, sort, dir, version \
+             FROM saved_searches WHERE id = ? AND deleted_at IS NULL",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+
+        match row {
+            Some(r) => Ok(Some(Self::from_row(&r)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Insert a new saved search capturing the current browse criteria. On a
+    /// UNIQUE collision with a soft-deleted row, reactivate it (refreshing the
+    /// criteria) and return `Reactivated`; on collision with a live row,
+    /// `Conflict(name_taken)`.
+    pub async fn create(
+        pool: &DbPool,
+        name: &str,
+        q: Option<&str>,
+        filter: Option<&str>,
+        sort: Option<&str>,
+        dir: Option<&str>,
+    ) -> Result<CreateOutcome, AppError> {
+        match sqlx::query(
+            "INSERT INTO saved_searches (name, q, filter, sort, dir) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(name)
+        .bind(q)
+        .bind(filter)
+        .bind(sort)
+        .bind(dir)
+        .execute(pool)
+        .await
+        {
+            Ok(res) => Ok(CreateOutcome::Created(res.last_insert_id())),
+            Err(sqlx::Error::Database(db_err)) if db_err.code().as_deref() == Some("23000") => {
+                let existing: Option<(u64, i32)> = sqlx::query_as(
+                    "SELECT id, version FROM saved_searches \
+                     WHERE name = ? AND deleted_at IS NOT NULL LIMIT 1",
+                )
+                .bind(name)
+                .fetch_optional(pool)
+                .await?;
+
+                match existing {
+                    Some((id, version)) => {
+                        let res = sqlx::query(
+                            "UPDATE saved_searches \
+                             SET deleted_at = NULL, q = ?, filter = ?, sort = ?, dir = ?, \
+                                 version = version + 1 \
+                             WHERE id = ? AND version = ?",
+                        )
+                        .bind(q)
+                        .bind(filter)
+                        .bind(sort)
+                        .bind(dir)
+                        .bind(id)
+                        .bind(version)
+                        .execute(pool)
+                        .await?;
+                        if res.rows_affected() == 1 {
+                            Ok(CreateOutcome::Reactivated(id))
+                        } else {
+                            Err(AppError::Conflict(CONFLICT_NAME_TAKEN.to_string()))
+                        }
+                    }
+                    None => Err(AppError::Conflict(CONFLICT_NAME_TAKEN.to_string())),
+                }
+            }
+            Err(other) => Err(AppError::from(other)),
+        }
+    }
+
+    pub async fn rename(
+        pool: &DbPool,
+        id: u64,
+        version: i32,
+        new_name: &str,
+    ) -> Result<(), AppError> {
+        let res = sqlx::query(
+            "UPDATE saved_searches SET name = ?, version = version + 1 \
+             WHERE id = ? AND version = ? AND deleted_at IS NULL",
+        )
+        .bind(new_name)
+        .bind(id)
+        .bind(version)
+        .execute(pool)
+        .await
+        .map_err(|err| match &err {
+            sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23000") => {
+                AppError::Conflict(CONFLICT_NAME_TAKEN.to_string())
+            }
+            _ => AppError::from(err),
+        })?;
+        check_update_result(res.rows_affected(), "saved_search")
+    }
+
+    pub async fn soft_delete(pool: &DbPool, id: u64, version: i32) -> Result<(), AppError> {
+        let res = sqlx::query(
+            "UPDATE saved_searches SET deleted_at = NOW(), version = version + 1 \
+             WHERE id = ? AND version = ? AND deleted_at IS NULL",
+        )
+        .bind(id)
+        .bind(version)
+        .execute(pool)
+        .await?;
+        check_update_result(res.rows_affected(), "saved_search")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        let s = SavedSearchModel {
+            id: 1,
+            name: "BD without cover".to_string(),
+            q: None,
+            filter: Some("no_cover".to_string()),
+            sort: None,
+            dir: None,
+            version: 1,
+        };
+        assert_eq!(s.to_string(), "BD without cover");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn create_and_find_round_trips_criteria(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let outcome = SavedSearchModel::create(
+            &pool,
+            "Z-uncategorized-recent",
+            Some("asterix"),
+            Some("uncategorized"),
+            Some("title"),
+            Some("desc"),
+        )
+        .await?;
+        let id = match outcome {
+            CreateOutcome::Created(id) => id,
+            CreateOutcome::Reactivated(_) => panic!("expected Created"),
+        };
+        let found = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        assert_eq!(found.name, "Z-uncategorized-recent");
+        assert_eq!(found.q.as_deref(), Some("asterix"));
+        assert_eq!(found.filter.as_deref(), Some("uncategorized"));
+        assert_eq!(found.sort.as_deref(), Some("title"));
+        assert_eq!(found.dir.as_deref(), Some("desc"));
+        assert_eq!(found.version, 1);
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn create_allows_all_null_criteria(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let id = SavedSearchModel::create(&pool, "Z-empty", None, None, None, None)
+            .await?
+            .id();
+        let found = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        assert!(found.q.is_none() && found.filter.is_none());
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn create_collision_with_active_returns_conflict(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        SavedSearchModel::create(&pool, "Z-dup", None, None, None, None).await?;
+        let res = SavedSearchModel::create(&pool, "Z-dup", None, None, None, None).await;
+        assert!(matches!(&res, Err(AppError::Conflict(m)) if m == CONFLICT_NAME_TAKEN));
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn create_collision_with_deleted_reactivates_and_refreshes_criteria(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let id = SavedSearchModel::create(&pool, "Z-react", Some("old"), None, None, None)
+            .await?
+            .id();
+        let row = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        SavedSearchModel::soft_delete(&pool, id, row.version).await?;
+
+        let outcome = SavedSearchModel::create(&pool, "Z-react", Some("new"), Some("no_cover"), None, None).await?;
+        match outcome {
+            CreateOutcome::Reactivated(rid) => assert_eq!(rid, id),
+            CreateOutcome::Created(_) => panic!("expected Reactivated"),
+        }
+        let restored = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        assert_eq!(restored.q.as_deref(), Some("new"), "criteria refreshed on reactivate");
+        assert_eq!(restored.filter.as_deref(), Some("no_cover"));
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn case_insensitive_name_collision(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        SavedSearchModel::create(&pool, "Z-CaseSaved", None, None, None, None).await?;
+        let res = SavedSearchModel::create(&pool, "z-casesaved", None, None, None, None).await;
+        assert!(matches!(&res, Err(AppError::Conflict(m)) if m == CONFLICT_NAME_TAKEN));
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn rename_round_trip_and_version_bump(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let id = SavedSearchModel::create(&pool, "Z-old-name", None, None, None, None)
+            .await?
+            .id();
+        let row = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        SavedSearchModel::rename(&pool, id, row.version, "Z-new-name").await?;
+        let renamed = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        assert_eq!(renamed.name, "Z-new-name");
+        assert_eq!(renamed.version, row.version + 1);
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn rename_version_mismatch_conflicts(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let id = SavedSearchModel::create(&pool, "Z-stale", None, None, None, None)
+            .await?
+            .id();
+        let res = SavedSearchModel::rename(&pool, id, 999, "Z-stale-new").await;
+        assert!(matches!(res, Err(AppError::VersionMismatch { entity: "saved_search" })));
+        Ok(())
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn soft_delete_hides_row(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let id = SavedSearchModel::create(&pool, "Z-del", None, None, None, None)
+            .await?
+            .id();
+        let row = SavedSearchModel::find_by_id(&pool, id).await?.unwrap();
+        SavedSearchModel::soft_delete(&pool, id, row.version).await?;
+        assert!(SavedSearchModel::find_by_id(&pool, id).await?.is_none());
+        Ok(())
+    }
+}

--- a/src/routes/home.rs
+++ b/src/routes/home.rs
@@ -44,6 +44,9 @@ pub struct HomeTemplate {
     pub active_filter: String,
     pub current_sort: String,
     pub current_dir: String,
+    /// CR #367 — pre-rendered `#saved-searches-list` fragment for the
+    /// home search-bar dropdown. Built by `saved_searches::render_list_html`.
+    pub saved_searches_html: String,
     pub genres: Vec<GenreModel>,
     pub volume_states: Vec<VolumeStateModel>,
     pub results: Option<PaginatedList<SearchResult>>,
@@ -759,9 +762,38 @@ pub async fn home(
         0
     };
 
+    // CR #367 — pre-render the saved-searches control (toggle + dropdown +
+    // save-form + list). Librarian+ only, so the cheap indexed query is
+    // skipped for anonymous browsers. The save-form's hidden inputs carry the
+    // current browse state (q/filter/sort/dir).
+    let saved_searches_html = if session.role >= Role::Librarian {
+        let cur_filter = params.filter.clone().unwrap_or_default();
+        let cur_sort = results
+            .as_ref()
+            .and_then(|r| r.sort.clone())
+            .unwrap_or_else(|| "title".to_string());
+        let cur_dir = results
+            .as_ref()
+            .and_then(|r| r.dir.clone())
+            .unwrap_or_else(|| "asc".to_string());
+        crate::routes::saved_searches::render_control_html(
+            pool,
+            loc,
+            &session.csrf_token,
+            &query,
+            &cur_filter,
+            &cur_sort,
+            &cur_dir,
+        )
+        .await?
+    } else {
+        String::new()
+    };
+
     let base = base_context(&session, loc, "home", &uri, state.session_timeout_secs());
     let template = HomeTemplate {
         base,
+        saved_searches_html,
         subtitle: rust_i18n::t!("home.subtitle", locale = loc).to_string(),
         search_placeholder: rust_i18n::t!("home.search_placeholder", locale = loc).to_string(),
         searching_announcement: rust_i18n::t!("home.searching_announcement", locale = loc).to_string(),
@@ -1246,6 +1278,7 @@ pub(crate) mod tests {
         let active_loans_label = format!("{active_loans} active loans");
         HomeTemplate {
             base: crate::utils::test_base_context(role, "home", crate::config::AppSettings::default().session_timeout_secs),
+            saved_searches_html: String::new(),
             home_search_help: crate::utils::TooltipData::placeholder_only(
                 "tip-home-search-text",
                 "Type to search.",

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod catalog;
 pub mod contributors;
 pub mod home;
 pub mod home_indicators;
+pub mod saved_searches;
 pub mod home_scan;
 mod home_search_fragment;
 #[cfg(test)]
@@ -337,6 +338,28 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/wishlist/{id}/delete-modal",
             axum::routing::get(wishlist::wishlist_delete_modal),
+        )
+        // CR #367 — saved searches (Librarian+). Run path is just a link
+        // to `/?q=...`; these routes cover create + rename/delete modals.
+        .route(
+            "/saved-searches",
+            axum::routing::post(saved_searches::create),
+        )
+        .route(
+            "/saved-searches/{id}/rename-modal",
+            axum::routing::get(saved_searches::rename_modal),
+        )
+        .route(
+            "/saved-searches/{id}/rename",
+            axum::routing::post(saved_searches::rename),
+        )
+        .route(
+            "/saved-searches/{id}/delete-modal",
+            axum::routing::get(saved_searches::delete_modal),
+        )
+        .route(
+            "/saved-searches/{id}/delete",
+            axum::routing::post(saved_searches::delete),
         )
         // CR #241 — JSON HTTP API under /api/v1/* (API-key auth).
         // CSRF middleware short-circuits on `/api/*` (see csrf.rs).

--- a/src/routes/saved_searches.rs
+++ b/src/routes/saved_searches.rs
@@ -1,0 +1,392 @@
+//! Saved searches (CR #367) — named, re-runnable bundles of the home
+//! browse state (`q`/`filter`/`sort`/`dir`). GLOBAL (single-tenant), so the
+//! whole instance shares one set. Surfaced as a dropdown on the home search
+//! bar; edit (rename) and delete go through UX-DR8 modals (`#modal-slot` +
+//! `static/js/modal.js`). All mutating handlers are Librarian+.
+//!
+//! Run path is just a link to `/?q=...&filter=...&sort=...&dir=...` — no
+//! dedicated route; the home handler validates the criteria as usual.
+
+use askama::Template;
+use axum::Form;
+use axum::extract::{Path, Query, State};
+use axum::response::Html;
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::error::AppError;
+use crate::middleware::auth::{Role, Session};
+use crate::middleware::htmx::{HtmxResponse, OobUpdate};
+use crate::middleware::locale::Locale;
+use crate::models::CreateOutcome;
+use crate::models::saved_search::SavedSearchModel;
+use crate::utils::{feedback_html, html_escape, url_encode};
+
+const RETURN_PATH: &str = "/";
+
+// ─── Form structs ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateSavedSearchForm {
+    pub name: String,
+    pub q: Option<String>,
+    pub filter: Option<String>,
+    pub sort: Option<String>,
+    pub dir: Option<String>,
+    pub _csrf_token: String,
+}
+
+#[derive(Deserialize)]
+pub struct RenameSavedSearchForm {
+    pub name: String,
+    pub version: i32,
+    pub _csrf_token: String,
+}
+
+#[derive(Deserialize)]
+pub struct DeleteSavedSearchForm {
+    pub version: i32,
+    pub _csrf_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VersionQuery {
+    pub version: i32,
+}
+
+// ─── Display + template structs ────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct SavedSearchRowDisplay {
+    id: u64,
+    name: String,
+    run_url: String,
+    version: i32,
+    run_aria: String,
+    edit_aria: String,
+    delete_aria: String,
+}
+
+#[derive(Template)]
+#[template(path = "fragments/saved_searches_list.html")]
+struct SavedSearchesList {
+    rows: Vec<SavedSearchRowDisplay>,
+    empty_label: String,
+    edit_label: String,
+    delete_label: String,
+}
+
+/// Full home search-bar control: toggle button + dropdown panel + the
+/// "save current search" form + the list (included from the same list
+/// fragment so the row markup stays single-sourced). Rendered by the home
+/// handler; the save-form's hidden inputs carry the CURRENT browse state.
+#[derive(Template)]
+#[template(path = "fragments/saved_searches_control.html")]
+struct SavedSearchControl {
+    csrf_token: String,
+    cur_q: String,
+    cur_filter: String,
+    cur_sort: String,
+    cur_dir: String,
+    toggle_label: String,
+    name_label: String,
+    name_placeholder: String,
+    save_label: String,
+    // Fields below feed the `{% include %}`d saved_searches_list.html.
+    rows: Vec<SavedSearchRowDisplay>,
+    empty_label: String,
+    edit_label: String,
+    delete_label: String,
+}
+
+#[derive(Template)]
+#[template(path = "fragments/saved_search_rename_modal.html")]
+struct SavedSearchRenameModal {
+    csrf_token: String,
+    title: String,
+    name_label: String,
+    confirm_label: String,
+    cancel_label: String,
+    action_url: String,
+    version: i32,
+    current_name: String,
+}
+
+#[derive(Template)]
+#[template(path = "fragments/saved_search_delete_modal.html")]
+struct SavedSearchDeleteModal {
+    csrf_token: String,
+    title: String,
+    body_html: String,
+    confirm_label: String,
+    cancel_label: String,
+    action_url: String,
+    version: i32,
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+fn validate_name(name: &str, loc: &'static str) -> Result<String, AppError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::BadRequest(
+            rust_i18n::t!("error.reference_data.name_empty", locale = loc).to_string(),
+        ));
+    }
+    if trimmed.chars().count() > 255 {
+        return Err(AppError::BadRequest(
+            rust_i18n::t!("error.reference_data.name_too_long", locale = loc).to_string(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Normalize an optional form field: trim, then `None` if empty. Keeps the
+/// stored criteria clean (no empty-string `q`) so the run URL stays tidy.
+fn norm(v: Option<String>) -> Option<String> {
+    v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
+/// Build the home browse URL that re-runs a saved search.
+fn build_run_url(s: &SavedSearchModel) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(q) = s.q.as_deref().filter(|v| !v.is_empty()) {
+        parts.push(format!("q={}", url_encode(q)));
+    }
+    if let Some(f) = s.filter.as_deref().filter(|v| !v.is_empty()) {
+        parts.push(format!("filter={}", url_encode(f)));
+    }
+    if let Some(sort) = s.sort.as_deref().filter(|v| !v.is_empty()) {
+        parts.push(format!("sort={}", url_encode(sort)));
+    }
+    if let Some(dir) = s.dir.as_deref().filter(|v| !v.is_empty()) {
+        parts.push(format!("dir={}", url_encode(dir)));
+    }
+    if parts.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/?{}", parts.join("&"))
+    }
+}
+
+fn make_row(s: &SavedSearchModel, loc: &'static str) -> SavedSearchRowDisplay {
+    SavedSearchRowDisplay {
+        id: s.id,
+        name: s.name.clone(),
+        run_url: build_run_url(s),
+        version: s.version,
+        run_aria: rust_i18n::t!("saved_searches.run_aria", locale = loc, name = &s.name).to_string(),
+        edit_aria: rust_i18n::t!("saved_searches.edit_aria", locale = loc, name = &s.name)
+            .to_string(),
+        delete_aria: rust_i18n::t!("saved_searches.delete_aria", locale = loc, name = &s.name)
+            .to_string(),
+    }
+}
+
+/// Render the `#saved-searches-list` fragment. Shared by the home handler
+/// (initial render) and every mutating handler (refresh after save/rename/
+/// delete). `pub(crate)` so `routes::home` can populate `saved_searches_html`.
+pub(crate) async fn render_list_html(pool: &crate::db::DbPool, loc: &'static str) -> Result<String, AppError> {
+    let searches = SavedSearchModel::list_all(pool).await?;
+    let rows = searches.iter().map(|s| make_row(s, loc)).collect();
+    SavedSearchesList {
+        rows,
+        empty_label: rust_i18n::t!("saved_searches.empty", locale = loc).to_string(),
+        edit_label: rust_i18n::t!("saved_searches.btn_rename", locale = loc).to_string(),
+        delete_label: rust_i18n::t!("saved_searches.btn_delete", locale = loc).to_string(),
+    }
+    .render()
+    .map_err(|_| AppError::Internal("saved searches list render failed".to_string()))
+}
+
+/// Render the whole home search-bar control (toggle + panel + save-form +
+/// list). `pub(crate)` so `routes::home` calls it with the current browse
+/// state. The list rows are shared with `render_list_html` via the included
+/// `saved_searches_list.html` fragment.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn render_control_html(
+    pool: &crate::db::DbPool,
+    loc: &'static str,
+    csrf_token: &str,
+    cur_q: &str,
+    cur_filter: &str,
+    cur_sort: &str,
+    cur_dir: &str,
+) -> Result<String, AppError> {
+    let searches = SavedSearchModel::list_all(pool).await?;
+    let rows = searches.iter().map(|s| make_row(s, loc)).collect();
+    SavedSearchControl {
+        csrf_token: csrf_token.to_string(),
+        cur_q: cur_q.to_string(),
+        cur_filter: cur_filter.to_string(),
+        cur_sort: cur_sort.to_string(),
+        cur_dir: cur_dir.to_string(),
+        toggle_label: rust_i18n::t!("saved_searches.toggle_label", locale = loc).to_string(),
+        name_label: rust_i18n::t!("saved_searches.name_label", locale = loc).to_string(),
+        name_placeholder: rust_i18n::t!("saved_searches.name_placeholder", locale = loc)
+            .to_string(),
+        save_label: rust_i18n::t!("saved_searches.save_label", locale = loc).to_string(),
+        rows,
+        empty_label: rust_i18n::t!("saved_searches.empty", locale = loc).to_string(),
+        edit_label: rust_i18n::t!("saved_searches.btn_rename", locale = loc).to_string(),
+        delete_label: rust_i18n::t!("saved_searches.btn_delete", locale = loc).to_string(),
+    }
+    .render()
+    .map_err(|_| AppError::Internal("saved searches control render failed".to_string()))
+}
+
+fn success_feedback(loc: &'static str, key: &str, name: &str) -> String {
+    let msg = rust_i18n::t!(key, locale = loc, name = name).to_string();
+    feedback_html("success", &msg, "")
+}
+
+// ─── Handlers ──────────────────────────────────────────────────────
+
+pub async fn create(
+    State(state): State<AppState>,
+    session: Session,
+    axum::Extension(locale): axum::Extension<Locale>,
+    Form(form): Form<CreateSavedSearchForm>,
+) -> Result<HtmxResponse, AppError> {
+    session.require_role_with_return(Role::Librarian, RETURN_PATH, locale.0)?;
+    let loc = locale.0;
+    let name = validate_name(&form.name, loc)?;
+    let q = norm(form.q);
+    let filter = norm(form.filter);
+    let sort = norm(form.sort);
+    let dir = norm(form.dir);
+
+    let outcome = SavedSearchModel::create(
+        &state.pool,
+        &name,
+        q.as_deref(),
+        filter.as_deref(),
+        sort.as_deref(),
+        dir.as_deref(),
+    )
+    .await?;
+    let feedback = match outcome {
+        CreateOutcome::Created(_) => success_feedback(loc, "success.saved_search.created", &name),
+        CreateOutcome::Reactivated(_) => {
+            success_feedback(loc, "success.saved_search.reactivated", &name)
+        }
+    };
+    let list_html = render_list_html(&state.pool, loc).await?;
+    Ok(HtmxResponse {
+        main: list_html,
+        oob: vec![OobUpdate {
+            swap_mode: Default::default(),
+            target: "feedback-list".to_string(),
+            content: feedback,
+        }],
+    })
+}
+
+pub async fn rename_modal(
+    State(state): State<AppState>,
+    session: Session,
+    axum::Extension(locale): axum::Extension<Locale>,
+    Path(id): Path<u64>,
+    Query(q): Query<VersionQuery>,
+) -> Result<Html<String>, AppError> {
+    session.require_role_with_return(Role::Librarian, RETURN_PATH, locale.0)?;
+    let loc = locale.0;
+    let row = SavedSearchModel::find_by_id(&state.pool, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("saved_search".to_string()))?;
+    let html = SavedSearchRenameModal {
+        csrf_token: session.csrf_token.clone(),
+        title: rust_i18n::t!("saved_searches.rename_modal_heading", locale = loc).to_string(),
+        name_label: rust_i18n::t!("saved_searches.name_label", locale = loc).to_string(),
+        confirm_label: rust_i18n::t!("saved_searches.btn_rename", locale = loc).to_string(),
+        cancel_label: rust_i18n::t!("saved_searches.btn_cancel", locale = loc).to_string(),
+        action_url: format!("/saved-searches/{}/rename", id),
+        version: q.version,
+        current_name: row.name,
+    }
+    .render()
+    .map_err(|_| AppError::Internal("rename modal render failed".to_string()))?;
+    Ok(Html(html))
+}
+
+pub async fn rename(
+    State(state): State<AppState>,
+    session: Session,
+    axum::Extension(locale): axum::Extension<Locale>,
+    Path(id): Path<u64>,
+    Form(form): Form<RenameSavedSearchForm>,
+) -> Result<axum::response::Response, AppError> {
+    session.require_role_with_return(Role::Librarian, RETURN_PATH, locale.0)?;
+    let loc = locale.0;
+    let name = validate_name(&form.name, loc)?;
+    SavedSearchModel::rename(&state.pool, id, form.version, &name).await?;
+    let list_html = render_list_html(&state.pool, loc).await?;
+    let feedback = success_feedback(loc, "success.saved_search.renamed", &name);
+    Ok(HtmxResponse {
+        main: list_html,
+        oob: vec![OobUpdate {
+            swap_mode: Default::default(),
+            target: "feedback-list".to_string(),
+            content: feedback,
+        }],
+    }
+    .into_response_with_hx_trigger("modal-close"))
+}
+
+pub async fn delete_modal(
+    State(state): State<AppState>,
+    session: Session,
+    axum::Extension(locale): axum::Extension<Locale>,
+    Path(id): Path<u64>,
+    Query(q): Query<VersionQuery>,
+) -> Result<Html<String>, AppError> {
+    session.require_role_with_return(Role::Librarian, RETURN_PATH, locale.0)?;
+    let loc = locale.0;
+    let row = SavedSearchModel::find_by_id(&state.pool, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("saved_search".to_string()))?;
+    let body = rust_i18n::t!(
+        "saved_searches.delete_modal_body",
+        locale = loc,
+        name = html_escape(&row.name)
+    )
+    .to_string();
+    let html = SavedSearchDeleteModal {
+        csrf_token: session.csrf_token.clone(),
+        title: rust_i18n::t!("saved_searches.delete_modal_heading", locale = loc).to_string(),
+        body_html: body,
+        confirm_label: rust_i18n::t!("saved_searches.btn_delete", locale = loc).to_string(),
+        cancel_label: rust_i18n::t!("saved_searches.btn_cancel", locale = loc).to_string(),
+        action_url: format!("/saved-searches/{}/delete", id),
+        version: q.version,
+    }
+    .render()
+    .map_err(|_| AppError::Internal("delete modal render failed".to_string()))?;
+    Ok(Html(html))
+}
+
+pub async fn delete(
+    State(state): State<AppState>,
+    session: Session,
+    axum::Extension(locale): axum::Extension<Locale>,
+    Path(id): Path<u64>,
+    Form(form): Form<DeleteSavedSearchForm>,
+) -> Result<axum::response::Response, AppError> {
+    session.require_role_with_return(Role::Librarian, RETURN_PATH, locale.0)?;
+    let loc = locale.0;
+    let row = SavedSearchModel::find_by_id(&state.pool, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("saved_search".to_string()))?;
+    SavedSearchModel::soft_delete(&state.pool, id, form.version).await?;
+    let list_html = render_list_html(&state.pool, loc).await?;
+    let feedback = success_feedback(loc, "success.saved_search.deleted", &row.name);
+    Ok(HtmxResponse {
+        main: list_html,
+        oob: vec![OobUpdate {
+            swap_mode: Default::default(),
+            target: "feedback-list".to_string(),
+            content: feedback,
+        }],
+    }
+    .into_response_with_hx_trigger("modal-close"))
+}

--- a/src/routes/saved_searches.rs
+++ b/src/routes/saved_searches.rs
@@ -29,9 +29,17 @@ const RETURN_PATH: &str = "/";
 #[derive(Deserialize)]
 pub struct CreateSavedSearchForm {
     pub name: String,
+    // `ss_*`-prefixed on the wire to avoid colliding with the home search
+    // field's `hx-include="[name='filter'],[name='sort'],[name='dir']"` —
+    // the save-form is always in the DOM, so unprefixed names would inject
+    // duplicate params into every browse search (#367 CI regression).
+    #[serde(rename = "ss_q")]
     pub q: Option<String>,
+    #[serde(rename = "ss_filter")]
     pub filter: Option<String>,
+    #[serde(rename = "ss_sort")]
     pub sort: Option<String>,
+    #[serde(rename = "ss_dir")]
     pub dir: Option<String>,
     pub _csrf_token: String,
 }

--- a/static/js/saved-searches.js
+++ b/static/js/saved-searches.js
@@ -60,7 +60,10 @@
             return;
         }
 
-        // Click outside the whole control → close.
+        // Click outside the whole control → close. But ignore clicks inside
+        // a modal (rename/delete dialogs live in #modal-slot, outside the
+        // control) so the dropdown stays open behind the modal.
+        if (t.closest("#modal-slot") || t.closest("dialog")) return;
         if (isOpen() && !t.closest("#" + CONTROL_ID)) {
             close();
         }

--- a/static/js/saved-searches.js
+++ b/static/js/saved-searches.js
@@ -1,0 +1,79 @@
+// saved-searches.js — CR #367 home search-bar dropdown toggle.
+//
+// Pure delegated event handlers, CSP-clean (no inline handlers/styles/globals).
+// The dropdown content (save-form + list) is server-rendered by routes::home
+// and refreshed via HTMX OOB/target swaps; this module only owns the
+// open/close UI affordance:
+//   - click on [data-action="toggle-saved-searches"] toggles the panel
+//   - click outside the control closes it
+//   - Escape closes it (unless a modal is open — modal.js owns Escape then)
+//
+// Rename/delete go through UX-DR8 modals (#modal-slot + modal.js), so this
+// module deliberately does NOT manage them.
+(function () {
+    "use strict";
+
+    var CONTROL_ID = "saved-searches-control";
+    var PANEL_ID = "saved-searches-panel";
+    var TOGGLE_ID = "saved-searches-toggle";
+
+    function panel() {
+        return document.getElementById(PANEL_ID);
+    }
+    function toggleBtn() {
+        return document.getElementById(TOGGLE_ID);
+    }
+
+    function isOpen() {
+        var p = panel();
+        return p != null && !p.classList.contains("hidden");
+    }
+
+    function open() {
+        var p = panel();
+        if (!p) return;
+        p.classList.remove("hidden");
+        var btn = toggleBtn();
+        if (btn) btn.setAttribute("aria-expanded", "true");
+    }
+
+    function close() {
+        var p = panel();
+        if (!p) return;
+        p.classList.add("hidden");
+        var btn = toggleBtn();
+        if (btn) btn.setAttribute("aria-expanded", "false");
+    }
+
+    document.addEventListener("click", function (evt) {
+        var t = evt.target;
+        if (!t || !t.closest) return;
+
+        // Toggle button (or any child) → flip the panel.
+        if (t.closest('[data-action="toggle-saved-searches"]')) {
+            evt.preventDefault();
+            if (isOpen()) {
+                close();
+            } else {
+                open();
+            }
+            return;
+        }
+
+        // Click outside the whole control → close.
+        if (isOpen() && !t.closest("#" + CONTROL_ID)) {
+            close();
+        }
+    });
+
+    document.addEventListener("keydown", function (evt) {
+        if (evt.key !== "Escape") return;
+        // Defer to modal.js when a modal is open (it owns Escape then).
+        if (document.querySelector('dialog[open], [aria-modal="true"]')) return;
+        if (isOpen()) {
+            close();
+            var btn = toggleBtn();
+            if (btn) btn.focus();
+        }
+    });
+})();

--- a/templates/fragments/saved_search_delete_modal.html
+++ b/templates/fragments/saved_search_delete_modal.html
@@ -1,0 +1,19 @@
+{# Saved-search delete confirm modal (CR #367) — UX-DR8 macro, `delete`
+   variant (soft-delete, reversible by re-saving the same name). On success
+   the `delete` handler returns the fresh #saved-searches-list (form target)
+   + HX-Trigger: modal-close so static/js/modal.js closes the dialog. #}
+{% import "components/modal.html" as modal %}
+{% call modal::modal(
+    "delete",
+    title,
+    body_html,
+    confirm_label,
+    cancel_label,
+    action_url,
+    "POST",
+    csrf_token,
+    "#saved-searches-list",
+    "outerHTML",
+    version,
+    "",
+) %}{% endcall %}

--- a/templates/fragments/saved_search_rename_modal.html
+++ b/templates/fragments/saved_search_rename_modal.html
@@ -1,0 +1,34 @@
+{# Saved-search rename modal (CR #367). Dedicated UX-DR8-shaped dialog (not
+   the shared macro) because it hosts a name <input> that must take initial
+   focus: `data-modal-default-focus` sits on the input, and static/js/modal.js
+   `findInitialFocus` returns the FIRST such element (rendered before the
+   button row). modal.js promotes the <dialog> via showModal(), installs the
+   Tab-cycle / Escape / backdrop guards, and the scanner-guard 7-5 observer
+   protects it. On success the `rename` handler returns the fresh
+   #saved-searches-list (form target) + HX-Trigger: modal-close. CSP-clean. #}
+<dialog open aria-modal="true" data-modal-variant="warning"
+        class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 rounded-lg">
+    <div class="bg-white dark:bg-stone-900 rounded-lg shadow-xl max-w-md w-full mx-4 border border-stone-200 dark:border-stone-700">
+        <div class="p-6">
+            <h3 class="text-lg font-bold text-stone-900 dark:text-white mb-2">{{ title }}</h3>
+            <div data-modal-error role="alert" class="hidden mb-4"></div>
+            <form hx-post="{{ action_url }}" hx-target="#saved-searches-list" hx-swap="outerHTML" class="flex flex-col gap-3">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
+                <input type="hidden" name="version" value="{{ version }}">
+                <label for="saved-search-rename-input" class="block text-sm font-medium text-stone-700 dark:text-stone-300">{{ name_label }}</label>
+                <input id="saved-search-rename-input"
+                       name="name"
+                       type="text"
+                       value="{{ current_name|e }}"
+                       maxlength="255"
+                       autocomplete="off"
+                       data-modal-default-focus
+                       class="w-full rounded-md border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 px-3 py-2 text-sm">
+                <div class="flex gap-2">
+                    <button type="button" data-modal-cancel class="flex-1 px-4 py-2 bg-stone-300 dark:bg-stone-700 rounded-md font-semibold hover:bg-stone-400 dark:hover:bg-stone-600">{{ cancel_label }}</button>
+                    <button type="submit" data-modal-confirm class="flex-1 px-4 py-2 text-white rounded-md font-semibold bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed">{{ confirm_label }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</dialog>

--- a/templates/fragments/saved_searches_control.html
+++ b/templates/fragments/saved_searches_control.html
@@ -1,0 +1,33 @@
+{# Saved-searches home search-bar control (CR #367). Toggle button + dropdown
+   panel containing the "save current search" form (hidden inputs carry the
+   CURRENT browse state passed by routes::home) and the saved-searches list.
+   Shown to Librarian+ only (gated by the caller in home.html). The dropdown
+   open/close is driven by static/js/saved-searches.js (CSP-clean, delegated
+   data-action handler). The list is single-sourced via {% include %}. #}
+<div id="saved-searches-control" class="relative">
+    <button type="button" id="saved-searches-toggle"
+            data-action="toggle-saved-searches"
+            aria-haspopup="true" aria-expanded="false" aria-controls="saved-searches-panel"
+            class="flex items-center gap-1 text-xs border border-stone-300 dark:border-stone-600 rounded px-2 py-1 bg-white dark:bg-stone-800 text-stone-700 dark:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-700">
+        {{ toggle_label }}
+    </button>
+    <div id="saved-searches-panel"
+         class="hidden absolute left-0 mt-1 z-30 w-72 rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 shadow-lg p-3">
+        <form hx-post="/saved-searches" hx-target="#saved-searches-list" hx-swap="outerHTML"
+              class="flex flex-col gap-2 border-b border-stone-100 dark:border-stone-700 pb-3">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
+            <input type="hidden" name="q" value="{{ cur_q|e }}">
+            <input type="hidden" name="filter" value="{{ cur_filter|e }}">
+            <input type="hidden" name="sort" value="{{ cur_sort|e }}">
+            <input type="hidden" name="dir" value="{{ cur_dir|e }}">
+            <label for="saved-search-name" class="sr-only">{{ name_label }}</label>
+            <input id="saved-search-name" name="name" type="text" required maxlength="255"
+                   placeholder="{{ name_placeholder }}"
+                   autocomplete="off"
+                   class="w-full rounded border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 px-2 py-1 text-sm">
+            <button type="submit"
+                    class="px-3 py-1 text-sm bg-indigo-600 hover:bg-indigo-700 text-white rounded-md">{{ save_label }}</button>
+        </form>
+        {% include "fragments/saved_searches_list.html" %}
+    </div>
+</div>

--- a/templates/fragments/saved_searches_control.html
+++ b/templates/fragments/saved_searches_control.html
@@ -15,11 +15,15 @@
          class="hidden absolute left-0 mt-1 z-30 w-72 rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 shadow-lg p-3">
         <form hx-post="/saved-searches" hx-target="#saved-searches-list" hx-swap="outerHTML"
               class="flex flex-col gap-2 border-b border-stone-100 dark:border-stone-700 pb-3">
+            {# Inputs are `ss_*`-prefixed (NOT q/filter/sort/dir): the home
+               search field's hx-include grabs [name='filter'|'sort'|'dir'],
+               and this form is always in the DOM, so unprefixed names would
+               inject duplicate params into every browse search (#367). #}
             <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
-            <input type="hidden" name="q" value="{{ cur_q|e }}">
-            <input type="hidden" name="filter" value="{{ cur_filter|e }}">
-            <input type="hidden" name="sort" value="{{ cur_sort|e }}">
-            <input type="hidden" name="dir" value="{{ cur_dir|e }}">
+            <input type="hidden" name="ss_q" value="{{ cur_q|e }}">
+            <input type="hidden" name="ss_filter" value="{{ cur_filter|e }}">
+            <input type="hidden" name="ss_sort" value="{{ cur_sort|e }}">
+            <input type="hidden" name="ss_dir" value="{{ cur_dir|e }}">
             <label for="saved-search-name" class="sr-only">{{ name_label }}</label>
             <input id="saved-search-name" name="name" type="text" required maxlength="255"
                    placeholder="{{ name_placeholder }}"

--- a/templates/fragments/saved_searches_list.html
+++ b/templates/fragments/saved_searches_list.html
@@ -1,0 +1,34 @@
+{# Saved-searches list (CR #367). Rendered into the home search-bar
+   dropdown by `routes::home` (initial) and re-rendered by every saved-search
+   mutation handler (create/rename/delete) targeting #saved-searches-list.
+   Each row: a run-link (full nav to the saved browse state) + rename/delete
+   buttons that load UX-DR8 modals into #modal-slot. CSP-clean. #}
+<div id="saved-searches-list" class="mt-2 max-h-72 overflow-y-auto">
+    {% if rows.is_empty() %}
+    <p class="px-3 py-2 text-sm text-stone-500 dark:text-stone-400">{{ empty_label }}</p>
+    {% else %}
+    <ul class="divide-y divide-stone-100 dark:divide-stone-700">
+        {% for row in rows %}
+        <li class="flex items-center justify-between gap-1 px-2 py-1.5">
+            <a href="{{ row.run_url }}"
+               aria-label="{{ row.run_aria }}"
+               class="flex-1 truncate text-sm text-stone-800 dark:text-stone-100 hover:underline">{{ row.name }}</a>
+            <button type="button"
+                    data-modal-trigger
+                    hx-get="/saved-searches/{{ row.id }}/rename-modal?version={{ row.version }}"
+                    hx-target="#modal-slot"
+                    hx-swap="innerHTML"
+                    aria-label="{{ row.edit_aria }}"
+                    class="shrink-0 px-2 py-1 text-xs text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-white">{{ edit_label }}</button>
+            <button type="button"
+                    data-modal-trigger
+                    hx-get="/saved-searches/{{ row.id }}/delete-modal?version={{ row.version }}"
+                    hx-target="#modal-slot"
+                    hx-swap="innerHTML"
+                    aria-label="{{ row.delete_aria }}"
+                    class="shrink-0 px-2 py-1 text-xs text-red-600 hover:text-red-700">{{ delete_label }}</button>
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -118,6 +118,7 @@
     <script src="/static/js/csrf.js"></script>
     <script src="/static/js/inline-form.js"></script>
     <script src="/static/js/modal.js"></script>
+    <script src="/static/js/saved-searches.js"></script>
     <script src="/static/js/nav.js"></script>
     <script src="/static/js/tooltip.js"></script>
     <script src="/static/js/shortcuts.js"></script>

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -266,6 +266,13 @@
        additions) and the recent-cataloged / recent-returns / stats-by-
        genre rails now follow below, visible without scrolling past
        the actual search results. #}
+    {# CR #367 — feedback sink for saved-search actions (create/rename/delete).
+       The home page had no #feedback-list (unlike catalog/admin); without it
+       the saved-search success OOB swaps were silently dropped. #}
+    <div class="w-full max-w-4xl mt-4">
+        <div id="feedback-list" aria-live="polite" aria-relevant="additions" class="space-y-2"></div>
+    </div>
+
     <!-- Browse toggle + sort -->
     <div class="w-full max-w-4xl mt-6 flex items-center justify-between">
         <div class="flex items-center gap-3">

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -268,6 +268,11 @@
        the actual search results. #}
     <!-- Browse toggle + sort -->
     <div class="w-full max-w-4xl mt-6 flex items-center justify-between">
+        <div class="flex items-center gap-3">
+        {# CR #367 — saved-searches control (Librarian+); the whole control
+           is server-rendered in routes::home so it carries the current
+           browse state + localized strings. #}
+        {% if base.role == "librarian" || base.role == "admin" %}{{ saved_searches_html|safe }}{% endif %}
         {# CR #250 — wrapped in #browse-sort-control so browse-mode.js
            can hide it in list mode (where the sortable column headers
            replace the <select>). Visible in grid mode (cards have no
@@ -283,6 +288,7 @@
                 <option value="genre_name:asc" {% if current_sort == "genre_name" && current_dir == "asc" %}selected{% endif %}>{{ col_genre }} &#9650;</option>
                 <option value="genre_name:desc" {% if current_sort == "genre_name" && current_dir == "desc" %}selected{% endif %}>{{ col_genre }} &#9660;</option>
             </select>
+        </div>
         </div>
         <div role="radiogroup" aria-label="{{ browse_mode_label }}" class="flex border border-stone-300 dark:border-stone-600 rounded-md overflow-hidden">
             <button type="button" data-browse-mode="list" role="radio" aria-checked="true" aria-label="{{ browse_list_label }}"

--- a/tests/e2e/specs/journeys/saved-searches.spec.ts
+++ b/tests/e2e/specs/journeys/saved-searches.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * CR #367 E2E — Saved searches.
+ *
+ * Real user journey from a blank browser (Foundation Rule #7): loginAs →
+ * compose a browse state → save it → run it → rename it → delete it. Saved
+ * searches are GLOBAL (shared across the instance), so the test uses a
+ * unique name and cleans up after itself (the delete step) to avoid
+ * polluting the shared E2E database. Spec ID "SS".
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+test.describe("CR #367 — Saved searches", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("lifecycle: create → run → rename → delete", async ({ page }) => {
+    await loginAs(page, "admin");
+    // Establish a browse state to capture.
+    await page.goto("/?q=tintin&sort=title&dir=asc");
+
+    const name = uniqueName("E2E-Saved");
+    const renamed = uniqueName("E2E-Renamed");
+
+    // --- Create: open dropdown, name + save the current search ---
+    await page.locator("#saved-searches-toggle").click();
+    await expect(page.locator("#saved-searches-panel")).toBeVisible();
+    await page.locator("#saved-search-name").fill(name);
+    await page.locator('#saved-searches-panel form button[type="submit"]').click();
+
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/Saved search|sauvegardée|gespeichert|salvata/i),
+    ).toBeVisible({ timeout: 10000 });
+
+    const runLink = page.locator("#saved-searches-list a", { hasText: name });
+    await expect(runLink).toBeVisible();
+
+    // --- Run: the link re-applies the saved browse state ---
+    await runLink.click();
+    await expect(page).toHaveURL(/[?&]q=tintin/);
+
+    // --- Rename via UX-DR8 modal ---
+    await page.locator("#saved-searches-toggle").click();
+    const row = page.locator("#saved-searches-list li", { hasText: name });
+    await row.locator('button[hx-get*="/rename-modal"]').click();
+
+    const renameInput = page.locator("#saved-search-rename-input");
+    await expect(renameInput).toBeVisible({ timeout: 10000 });
+    await renameInput.fill(renamed);
+    await page.locator("#modal-slot button[data-modal-confirm]").click();
+
+    await expect(
+      page.locator("#saved-searches-list a", { hasText: renamed }),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.locator("#saved-searches-list a", { hasText: name }),
+    ).toHaveCount(0);
+
+    // --- Delete via UX-DR8 modal (cleanup) ---
+    const renamedRow = page.locator("#saved-searches-list li", {
+      hasText: renamed,
+    });
+    await renamedRow.locator('button[hx-get*="/delete-modal"]').click();
+    await expect(page.locator("#modal-slot dialog")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.locator("#modal-slot button[data-modal-confirm]").click();
+
+    await expect(
+      page.locator("#saved-searches-list a", { hasText: renamed }),
+    ).toHaveCount(0, { timeout: 10000 });
+  });
+
+  test("librarian sees the control; the save form is present", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+    await page.goto("/");
+    await expect(page.locator("#saved-searches-toggle")).toBeVisible();
+    await page.locator("#saved-searches-toggle").click();
+    await expect(page.locator("#saved-search-name")).toBeVisible();
+  });
+});

--- a/tests/saved_searches_integration.rs
+++ b/tests/saved_searches_integration.rs
@@ -1,0 +1,284 @@
+//! Saved searches (CR #367) integration tests.
+//!
+//! Drives the whole router through `tower::oneshot` against a fresh
+//! `#[sqlx::test]` database so every middleware (session, CSRF, locale,
+//! role-gate) runs end-to-end. Covers: create captures the browse state and
+//! renders a run-link on the home dropdown; rename + delete round-trip via
+//! the modal POST endpoints; role gating (librarian allowed, anonymous
+//! bounced to /login).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use mybibli::db::DbPool;
+use std::sync::{Arc, RwLock};
+use tower::ServiceExt;
+
+fn state_with_pool(pool: DbPool) -> mybibli::AppState {
+    mybibli::AppState {
+        pool,
+        settings: Arc::new(RwLock::new(mybibli::config::AppSettings::default())),
+        http_client: reqwest::Client::new(),
+        registry: Arc::new(mybibli::metadata::registry::ProviderRegistry::new()),
+        covers_dir: std::path::PathBuf::from("/tmp"),
+        provider_health: mybibli::tasks::provider_health::new_provider_health_map(),
+        mariadb_version_cache: mybibli::services::admin_health::new_mariadb_version_cache(),
+        setup_gate: Arc::new(RwLock::new(
+            mybibli::middleware::setup_gate::SetupGateState::default(),
+        )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
+        log_level_reloader: mybibli::noop_log_level_reloader(),
+    }
+}
+
+fn app(state: mybibli::AppState) -> axum::Router {
+    mybibli::routes::build_router(state)
+}
+
+// Argon2 hash for password "librarian" — same hash used across the suite.
+const PW_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$NfI9SYT0huhcqAanQWa9pw$mSEHLW8Wl8wlk504MRpzyS42JlcU9w2CXYVVFMFvbcU";
+
+async fn seed_user(pool: &DbPool, username: &str, role: &str) -> String {
+    sqlx::query("INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)")
+        .bind(username)
+        .bind(PW_HASH)
+        .bind(role)
+        .execute(pool)
+        .await
+        .unwrap();
+    username.to_string()
+}
+
+fn extract_session_cookie(res: &axum::response::Response) -> Option<String> {
+    let header = res
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .find(|s| s.starts_with("session="))?;
+    let kv = header.split(';').next()?;
+    let (_, raw_value) = kv.split_once('=')?;
+    Some(
+        percent_encoding::percent_decode_str(raw_value)
+            .decode_utf8_lossy()
+            .to_string(),
+    )
+}
+
+async fn fetch_csrf_token(router: &axum::Router, session_cookie: &str) -> String {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::get("/")
+                .header("cookie", format!("session={}", session_cookie))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let html = String::from_utf8(bytes.to_vec()).unwrap();
+    let needle = "name=\"csrf-token\" content=\"";
+    let start = html.find(needle).expect("csrf-token meta tag") + needle.len();
+    let rest = &html[start..];
+    let end = rest.find('"').unwrap();
+    rest[..end].to_string()
+}
+
+async fn login_and_extract(router: &axum::Router, username: &str) -> (String, String) {
+    let body = format!("username={username}&password=librarian");
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER, "login should succeed");
+    let cookie = extract_session_cookie(&res).expect("session cookie");
+    let csrf = fetch_csrf_token(router, &cookie).await;
+    (cookie, csrf)
+}
+
+async fn post_form(
+    router: &axum::Router,
+    uri: &str,
+    cookie: &str,
+    body: String,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::post(uri)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn home_html(router: &axum::Router, cookie: &str) -> String {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::get("/")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_captures_state_and_renders_run_link_on_home(pool: DbPool) {
+    let user = seed_user(&pool, "ss_admin", "admin").await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login_and_extract(&router, &user).await;
+
+    let body = format!(
+        "name=Z-BD-no-cover&q=asterix&filter=no_cover&sort=title&dir=desc&_csrf_token={}",
+        csrf
+    );
+    let res = post_form(&router, "/saved-searches", &cookie, body).await;
+    assert_eq!(res.status(), StatusCode::OK, "create returns 200");
+
+    // DB row carries the captured criteria.
+    let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT name, filter, dir FROM saved_searches WHERE deleted_at IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "Z-BD-no-cover");
+    assert_eq!(row.1.as_deref(), Some("no_cover"));
+    assert_eq!(row.2.as_deref(), Some("desc"));
+
+    // Home page renders the run-link with the rebuilt browse URL (& escaped).
+    let html = home_html(&router, &cookie).await;
+    assert!(html.contains("Z-BD-no-cover"), "saved search name shown on home");
+    // Askama escapes `&` as the numeric entity `&#38;` (both `&#38;` and
+    // `&amp;` are valid; the browser decodes either to `&`).
+    assert!(
+        html.contains("/?q=asterix&#38;filter=no_cover&#38;sort=title&#38;dir=desc"),
+        "run-link rebuilds the saved browse URL"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn rename_then_delete_round_trip(pool: DbPool) {
+    let user = seed_user(&pool, "ss_admin", "admin").await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login_and_extract(&router, &user).await;
+
+    post_form(
+        &router,
+        "/saved-searches",
+        &cookie,
+        format!("name=Z-orig&q=foo&_csrf_token={}", csrf),
+    )
+    .await;
+    let (id, version): (u64, i32) =
+        sqlx::query_as("SELECT id, version FROM saved_searches WHERE name = 'Z-orig'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    // Rename.
+    let res = post_form(
+        &router,
+        &format!("/saved-searches/{}/rename", id),
+        &cookie,
+        format!("name=Z-renamed&version={}&_csrf_token={}", version, csrf),
+    )
+    .await;
+    assert_eq!(res.status(), StatusCode::OK, "rename returns 200");
+    let renamed: (String, i32) =
+        sqlx::query_as("SELECT name, version FROM saved_searches WHERE id = ?")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(renamed.0, "Z-renamed");
+    assert_eq!(renamed.1, version + 1);
+
+    // Delete (using the bumped version).
+    let res = post_form(
+        &router,
+        &format!("/saved-searches/{}/delete", id),
+        &cookie,
+        format!("version={}&_csrf_token={}", renamed.1, csrf),
+    )
+    .await;
+    assert_eq!(res.status(), StatusCode::OK, "delete returns 200");
+    let remaining: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM saved_searches WHERE deleted_at IS NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(remaining.0, 0, "soft-deleted row no longer active");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn librarian_can_create(pool: DbPool) {
+    let user = seed_user(&pool, "ss_lib", "librarian").await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login_and_extract(&router, &user).await;
+
+    let res = post_form(
+        &router,
+        "/saved-searches",
+        &cookie,
+        format!("name=Z-lib&_csrf_token={}", csrf),
+    )
+    .await;
+    assert_eq!(res.status(), StatusCode::OK, "librarian may create saved searches");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn anonymous_create_redirects_to_login(pool: DbPool) {
+    let router = app(state_with_pool(pool.clone()));
+    // No session cookie → CSRF layer is skipped (nothing to forge against) and
+    // the handler's require_role bounces Anonymous to /login.
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/saved-searches")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("name=Z-anon"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    assert_eq!(res.headers().get("location").unwrap().to_str().unwrap(), "/login");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn empty_name_is_rejected(pool: DbPool) {
+    let user = seed_user(&pool, "ss_admin", "admin").await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login_and_extract(&router, &user).await;
+
+    let res = post_form(
+        &router,
+        "/saved-searches",
+        &cookie,
+        format!("name=%20%20&_csrf_token={}", csrf),
+    )
+    .await;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST, "blank name rejected");
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM saved_searches")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0, "no row created on validation failure");
+}

--- a/tests/saved_searches_integration.rs
+++ b/tests/saved_searches_integration.rs
@@ -145,7 +145,7 @@ async fn create_captures_state_and_renders_run_link_on_home(pool: DbPool) {
     let (cookie, csrf) = login_and_extract(&router, &user).await;
 
     let body = format!(
-        "name=Z-BD-no-cover&q=asterix&filter=no_cover&sort=title&dir=desc&_csrf_token={}",
+        "name=Z-BD-no-cover&ss_q=asterix&ss_filter=no_cover&ss_sort=title&ss_dir=desc&_csrf_token={}",
         csrf
     );
     let res = post_form(&router, "/saved-searches", &cookie, body).await;
@@ -183,7 +183,7 @@ async fn rename_then_delete_round_trip(pool: DbPool) {
         &router,
         "/saved-searches",
         &cookie,
-        format!("name=Z-orig&q=foo&_csrf_token={}", csrf),
+        format!("name=Z-orig&ss_q=foo&_csrf_token={}", csrf),
     )
     .await;
     let (id, version): (u64, i32) =


### PR DESCRIPTION
Headline feature of the **v1.9.0** scope. Saved searches over the existing home filter/sort surface (no query-builder, no raw SQL).

**Design decisions (confirmed with Guy):**
- **Global** (single-tenant) — no per-user FK, consistent with the one-settings-table model.
- **Surfacing:** dropdown on the home search bar (save + run) + UX-DR8 modals for edit/delete.
- Depth: saved-search over the existing `q`/`filter`/`sort`/`dir` surface (the query-builder is deferred to the v2.0 #206 work).

## Progress
- [x] Migration `saved_searches` + `SavedSearchModel` (CRUD, soft-delete reactivation, optimistic lock) + 9 unit tests
- [ ] Routes `src/routes/saved_searches.rs` (create / dropdown / rename / delete-modal / delete)
- [ ] Templates (dropdown fragment, row, UX-DR8 delete modal) + home search-bar mount
- [ ] `static/js/saved-searches.js` (CSP-clean dropdown toggle)
- [ ] i18n (de/en/fr/it)
- [ ] Integration tests (router CRUD + role gating + CSRF) + E2E (create → run → edit → delete)
- [ ] User-manual section

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)