### PR TITLE
feat(#396): per-provider configurable metadata timeout

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -914,6 +914,9 @@ admin:
     provider_health_timeout_label: "Zeitüberschreitung der Provider-Health-Sonde (Sekunden)"
     provider_health_timeout_help: "Maximale Wartezeit für die HEAD-Antwort jedes Anbieters beim Erreichbarkeits-Ping (alle 5 Minuten). Standard 10. Grenzen 1–60. In der nächsten Runde wirksam — kein Neustart."
     btn_save_timeouts: "Zeitüberschreitungen speichern"
+    # CR #396 — Zeitüberschreitungs-Überschreibungen pro Anbieter.
+    provider_timeouts_help: "Überschreiben Sie die Metadaten-Zeitüberschreitung für einzelne Anbieter. Lassen Sie ein Feld leer, um den globalen Standard (%{default} s) zu verwenden. Grenzen 1–60. Beim nächsten Scan wirksam — kein Neustart."
+    btn_save_provider_timeouts: "Zeitüberschreitungen pro Anbieter speichern"
   api_keys:
     panel_heading: "API-Schlüssel"
     intro: "API-Schlüssel authentifizieren externe Aufrufer an der HTTP-JSON-API unter /api/v1/*. Lese-Schlüssel können Datensätze auflisten und abrufen; Schreib-Schlüssel können zusätzlich freigegebene Titelfelder per PATCH bearbeiten. Jeder Schlüssel wird genau EINMAL beim Anlegen angezeigt — jetzt kopieren oder widerrufen und neu erstellen."
@@ -1002,6 +1005,7 @@ success:
     valuation_saved: "Bewertungseinstellungen gespeichert"
     log_level_saved: "Protokollebene gespeichert — sofort wirksam, kein Neustart erforderlich"
     timeouts_saved: "Zeitüberschreitungen gespeichert — beim nächsten Scan / Ping wirksam, kein Neustart erforderlich"
+    provider_timeouts_saved: "Zeitüberschreitungen pro Anbieter gespeichert — beim nächsten Scan wirksam, kein Neustart erforderlich"
     no_changes: "Keine Änderungen"
     provider_set: "%{provider}-Schlüssel gespeichert"
     provider_cleared: "%{provider}-Schlüssel gelöscht"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -927,6 +927,9 @@ admin:
     provider_health_timeout_label: "Provider-health probe timeout (seconds)"
     provider_health_timeout_help: "Maximum time the 5-min reachability ping waits for each provider HEAD response. Default 10. Bounded 1–60. Applied on the next round — no restart."
     btn_save_timeouts: "Save timeout settings"
+    # CR #396 — per-provider metadata-timeout overrides.
+    provider_timeouts_help: "Override the metadata timeout for individual providers. Leave a field empty to use the global default (%{default} s). Bounded 1–60. Applied on the next scan — no restart."
+    btn_save_provider_timeouts: "Save per-provider timeouts"
   api_keys:
     panel_heading: "API keys"
     intro: "API keys authenticate external callers to the HTTP JSON API under /api/v1/*. Read keys can list and fetch records; write keys can also PATCH whitelisted title fields. Each key is shown ONCE at creation — copy it now or revoke and re-create."
@@ -1015,6 +1018,7 @@ success:
     valuation_saved: "Library valuation settings saved"
     log_level_saved: "Log level saved — applied immediately, no restart required"
     timeouts_saved: "Timeouts saved — applied on the next chain run / ping round, no restart required"
+    provider_timeouts_saved: "Per-provider timeouts saved — applied on the next chain run, no restart required"
     no_changes: "No changes"
     provider_set: "%{provider} key saved"
     provider_cleared: "%{provider} key cleared"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -923,6 +923,9 @@ admin:
     provider_health_timeout_label: "Délai d'attente de la sonde provider-health (secondes)"
     provider_health_timeout_help: "Temps maximal d'attente de la réponse HEAD de chaque fournisseur lors du ping de joignabilité (toutes les 5 min). Par défaut 10. Bornes 1–60. Appliqué au prochain tour — sans redémarrage."
     btn_save_timeouts: "Enregistrer les délais d'attente"
+    # CR #396 — délais d'attente par fournisseur (surcharges).
+    provider_timeouts_help: "Surchargez le délai d'attente des métadonnées pour chaque fournisseur. Laissez un champ vide pour utiliser la valeur globale par défaut (%{default} s). Bornes 1–60. Appliqué au prochain scan — sans redémarrage."
+    btn_save_provider_timeouts: "Enregistrer les délais par fournisseur"
   api_keys:
     panel_heading: "Clés d'API"
     intro: "Les clés d'API authentifient les appelants externes à l'API JSON HTTP sous /api/v1/*. Les clés en lecture peuvent lister et consulter ; les clés en écriture peuvent aussi modifier les champs autorisés (PATCH). Chaque clé n'est affichée QU'UNE FOIS à la création — copiez-la maintenant ou révoquez-la et recréez-en une."
@@ -1011,6 +1014,7 @@ success:
     valuation_saved: "Paramètres de valorisation enregistrés"
     log_level_saved: "Niveau de journalisation enregistré — appliqué immédiatement, pas de redémarrage requis"
     timeouts_saved: "Délais d'attente enregistrés — appliqués au prochain scan / tour de ping, pas de redémarrage requis"
+    provider_timeouts_saved: "Délais par fournisseur enregistrés — appliqués au prochain scan, pas de redémarrage requis"
     no_changes: "Aucune modification"
     provider_set: "Clé %{provider} enregistrée"
     provider_cleared: "Clé %{provider} effacée"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -901,6 +901,9 @@ admin:
     provider_health_timeout_label: "Timeout della sonda provider-health (secondi)"
     provider_health_timeout_help: "Tempo massimo di attesa della risposta HEAD di ciascun fornitore al ping di raggiungibilità (ogni 5 minuti). Predefinito 10. Intervallo 1–60. Applicato al prossimo giro — nessun riavvio."
     btn_save_timeouts: "Salva timeout"
+    # CR #396 — timeout per fornitore (override).
+    provider_timeouts_help: "Sovrascrivi il timeout dei metadati per i singoli fornitori. Lascia un campo vuoto per usare il valore globale predefinito (%{default} s). Intervallo 1–60. Applicato alla prossima scansione — nessun riavvio."
+    btn_save_provider_timeouts: "Salva timeout per fornitore"
   api_keys:
     panel_heading: "Chiavi API"
     intro: "Le chiavi API autenticano chiamanti esterni all'API JSON HTTP sotto /api/v1/*. Le chiavi di lettura possono elencare e recuperare i record; le chiavi di scrittura possono anche modificare via PATCH i campi del titolo abilitati. Ogni chiave è mostrata UNA SOLA volta alla creazione — copiala subito o revocala e ricreala."
@@ -988,6 +991,7 @@ success:
     valuation_saved: "Impostazioni di valutazione salvate"
     log_level_saved: "Livello di log salvato — applicato immediatamente, nessun riavvio richiesto"
     timeouts_saved: "Timeout salvati — applicati alla prossima scansione / giro di ping, nessun riavvio richiesto"
+    provider_timeouts_saved: "Timeout per fornitore salvati — applicati alla prossima scansione, nessun riavvio richiesto"
     no_changes: "Nessuna modifica"
     provider_set: "Chiave %{provider} salvata"
     provider_cleared: "Chiave %{provider} cancellata"

--- a/migrations/20260611000000_settings_per_provider_timeouts.sql
+++ b/migrations/20260611000000_settings_per_provider_timeouts.sql
@@ -1,0 +1,26 @@
+-- CR #396 — per-provider metadata-chain timeout overrides.
+--
+-- One row per registered provider, keyed `provider_timeout.<slug>` where
+-- <slug> is the provider's display name lowercased with non-alphanumeric
+-- runs collapsed to `_` (see src/metadata/provider.rs::provider_slug).
+-- An EMPTY value means "no override — use the global scalar"
+-- (`metadata_chain_per_provider_timeout_secs`, v1.7.9 #334). A non-empty
+-- value must parse as 1..=60 seconds (same bounds as the scalar,
+-- validated by services::admin_system::validate_provider_timeout_secs);
+-- out-of-range rows are ignored at load time with a warning.
+--
+-- Seeding all rows up-front (rather than INSERTing on first save) keeps
+-- the optimistic-lock UPDATE pattern of services::admin_system::save_setting
+-- unchanged. A future provider needs one more row in its own migration —
+-- same contract as the keyed-provider API-key rows from story 8-5.
+
+INSERT INTO settings (setting_key, setting_value, version) VALUES
+('provider_timeout.bdgest', '', 1),
+('provider_timeout.bnf', '', 1),
+('provider_timeout.google_books', '', 1),
+('provider_timeout.library_of_congress', '', 1),
+('provider_timeout.open_library', '', 1),
+('provider_timeout.musicbrainz', '', 1),
+('provider_timeout.omdb', '', 1),
+('provider_timeout.tmdb', '', 1)
+ON DUPLICATE KEY UPDATE setting_key = setting_key;

--- a/scripts/e2e-reset.sh
+++ b/scripts/e2e-reset.sh
@@ -22,7 +22,9 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_FILE="${PROJECT_ROOT}/tests/e2e/docker-compose.test.yml"
-APP_URL="${E2E_APP_URL:-http://localhost:8080/login}"
+# E2E_HOST_PORT flows into docker-compose.test.yml's host-port mapping
+# (default 8080); the wait URL follows it unless E2E_APP_URL pins both.
+APP_URL="${E2E_APP_URL:-http://localhost:${E2E_HOST_PORT:-8080}/login}"
 WAIT_TIMEOUT="${E2E_WAIT_TIMEOUT:-120}"
 
 if [[ ! -f "${COMPOSE_FILE}" ]]; then

--- a/src/config.rs
+++ b/src/config.rs
@@ -391,6 +391,14 @@ pub struct AppSettings {
     /// without a restart, and the task reads through `Arc<RwLock<AppSettings>>`
     /// on each ping round.
     pub provider_health_probe_timeout_secs: u64,
+    // === CR #396 — per-provider metadata-chain timeout overrides ===
+    /// Overrides for `metadata_chain_per_provider_timeout_secs`, keyed by
+    /// provider slug (see `metadata::provider::provider_slug`). Loaded from
+    /// the K/V rows `provider_timeout.<slug>` (migration 20260611000000);
+    /// an empty row value means "no override" and is absent from this map.
+    /// Same `1..=60` bounds as the scalar — out-of-range rows are skipped
+    /// with a warning at load time.
+    pub metadata_chain_provider_timeout_overrides: std::collections::HashMap<String, u64>,
 }
 
 impl Default for AppSettings {
@@ -421,6 +429,8 @@ impl Default for AppSettings {
             // installs behave identically until the admin tunes them.
             metadata_chain_per_provider_timeout_secs: 5,
             provider_health_probe_timeout_secs: 10,
+            // CR #396: no overrides — every provider uses the scalar above.
+            metadata_chain_provider_timeout_overrides: std::collections::HashMap::new(),
         }
     }
 }
@@ -652,6 +662,35 @@ impl AppSettings {
                         );
                     } else {
                         settings.log_level = trimmed.to_string();
+                    }
+                }
+                // CR #396: per-provider timeout overrides. Empty value =
+                // "use the scalar default" (the migration-seed state) —
+                // not an override. Same 1..=60 bounds as the scalar.
+                k if k.starts_with(crate::services::admin_system::PROVIDER_TIMEOUT_KEY_PREFIX) => {
+                    let slug =
+                        &k[crate::services::admin_system::PROVIDER_TIMEOUT_KEY_PREFIX.len()..];
+                    let trimmed = value.trim();
+                    if slug.is_empty() || trimmed.is_empty() {
+                        // Row with no slug is malformed; empty value is the
+                        // documented "no override" state — both are skipped
+                        // silently for the empty-value case.
+                        if slug.is_empty() {
+                            tracing::warn!(key = %key, "provider_timeout row with empty slug, ignoring");
+                        }
+                    } else {
+                        match trimmed.parse::<u64>() {
+                            Ok(v) if (1..=60).contains(&v) => {
+                                settings
+                                    .metadata_chain_provider_timeout_overrides
+                                    .insert(slug.to_string(), v);
+                            }
+                            _ => tracing::warn!(
+                                key = %key,
+                                value = %value,
+                                "provider_timeout override must parse as 1..=60, ignoring"
+                            ),
+                        }
                     }
                 }
                 _ => {} // Ignore unknown keys
@@ -953,6 +992,10 @@ mod tests {
             log_level: "info".to_string(),
             metadata_chain_per_provider_timeout_secs: 7,
             provider_health_probe_timeout_secs: 15,
+            metadata_chain_provider_timeout_overrides: HashMap::from([(
+                "bnf".to_string(),
+                12_u64,
+            )]),
         };
         let cloned = settings.clone();
         assert_eq!(cloned.overdue_threshold_days, 60);
@@ -967,6 +1010,13 @@ mod tests {
         assert_eq!(cloned.tmdb_api_key, "tmdb-key");
         assert_eq!(cloned.metadata_chain_per_provider_timeout_secs, 7);
         assert_eq!(cloned.provider_health_probe_timeout_secs, 15);
+        assert_eq!(
+            cloned
+                .metadata_chain_provider_timeout_overrides
+                .get("bnf")
+                .copied(),
+            Some(12)
+        );
     }
 
     // ─── Story 8-8: setup wizard sentinels ──────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,24 @@ impl AppState {
             .unwrap_or_else(|_| AppSettings::default().metadata_chain_per_provider_timeout_secs)
     }
 
+    /// CR #396: per-provider timeout resolution for `ChainExecutor::execute`
+    /// — the scalar default plus any per-provider overrides set from
+    /// /admin > System. Read per fetch so admin saves take effect on the
+    /// very next chain run.
+    pub fn metadata_chain_provider_timeouts(&self) -> crate::metadata::chain::ProviderTimeouts {
+        self.settings
+            .read()
+            .map(|s| crate::metadata::chain::ProviderTimeouts {
+                default_secs: s.metadata_chain_per_provider_timeout_secs,
+                overrides: s.metadata_chain_provider_timeout_overrides.clone(),
+            })
+            .unwrap_or_else(|_| {
+                crate::metadata::chain::ProviderTimeouts::uniform(
+                    AppSettings::default().metadata_chain_per_provider_timeout_secs,
+                )
+            })
+    }
+
     /// Fix #334 (v1.7.9): per-probe timeout (seconds) for the background
     /// provider-reachability ping task. The task reads through
     /// `Arc<RwLock<AppSettings>>` directly on each round (see

--- a/src/metadata/chain.rs
+++ b/src/metadata/chain.rs
@@ -1,11 +1,42 @@
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::db::DbPool;
 use crate::models::media_type::{CodeType, MediaType};
 use crate::models::metadata_cache::MetadataCacheModel;
 
-use super::provider::{MetadataError, MetadataResult};
+use super::provider::{MetadataError, MetadataResult, provider_slug};
 use super::registry::ProviderRegistry;
+
+/// CR #396 — per-provider timeout resolution for the chain.
+/// `default_secs` carries the global scalar
+/// (`AppSettings::metadata_chain_per_provider_timeout_secs`, v1.7.9 #334);
+/// `overrides` maps provider slugs (see [`provider_slug`]) to a specific
+/// value set from /admin > System. A provider absent from the map uses
+/// the default.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderTimeouts {
+    pub default_secs: u64,
+    pub overrides: HashMap<String, u64>,
+}
+
+impl ProviderTimeouts {
+    /// Uniform timeouts — no overrides. The pre-#396 behavior.
+    pub fn uniform(secs: u64) -> Self {
+        ProviderTimeouts {
+            default_secs: secs,
+            overrides: HashMap::new(),
+        }
+    }
+
+    /// Effective timeout (seconds) for the named provider.
+    pub fn for_provider(&self, provider_name: &str) -> u64 {
+        self.overrides
+            .get(&provider_slug(provider_name))
+            .copied()
+            .unwrap_or(self.default_secs)
+    }
+}
 
 /// Executes metadata lookups through a chain of providers with fallback.
 pub struct ChainExecutor;
@@ -25,7 +56,7 @@ impl ChainExecutor {
         code_type: &CodeType,
         media_type: &MediaType,
         timeout_secs: u64,
-        per_provider_timeout_secs: u64,
+        per_provider_timeouts: &ProviderTimeouts,
     ) -> Option<MetadataResult> {
         tracing::info!(code = %code, code_type = %code_type, media_type = %media_type, "Starting metadata chain");
 
@@ -61,7 +92,8 @@ impl ChainExecutor {
                     limiter.acquire().await;
                 }
 
-                let per_provider_timeout = Duration::from_secs(per_provider_timeout_secs);
+                let provider_timeout_secs = per_provider_timeouts.for_provider(provider_name);
+                let per_provider_timeout = Duration::from_secs(provider_timeout_secs);
                 let lookup_future = match code_type {
                     CodeType::Upc => provider.lookup_by_upc(code),
                     CodeType::Isbn | CodeType::Issn => provider.lookup_by_isbn(code),
@@ -120,7 +152,8 @@ impl ChainExecutor {
                             code = %code,
                             provider = provider_name,
                             duration_ms = duration_ms,
-                            "Provider timed out (5s)"
+                            timeout_secs = provider_timeout_secs,
+                            "Provider timed out"
                         );
                     }
                 }
@@ -260,6 +293,60 @@ mod tests {
         ) -> Result<Option<MetadataResult>, MetadataError> {
             Err(MetadataError::RateLimited)
         }
+    }
+
+    // ─── CR #396 — ProviderTimeouts resolution ────────────────────
+
+    #[test]
+    fn provider_timeouts_default_when_no_override() {
+        let timeouts = ProviderTimeouts::uniform(5);
+        assert_eq!(timeouts.for_provider("BnF"), 5);
+        assert_eq!(timeouts.for_provider("google_books"), 5);
+    }
+
+    #[test]
+    fn provider_timeouts_override_wins_and_resolves_via_slug() {
+        let mut timeouts = ProviderTimeouts::uniform(5);
+        timeouts.overrides.insert("bnf".to_string(), 12);
+        timeouts
+            .overrides
+            .insert("library_of_congress".to_string(), 3);
+        // Display names resolve through provider_slug to the override.
+        assert_eq!(timeouts.for_provider("BnF"), 12);
+        assert_eq!(timeouts.for_provider("Library of Congress"), 3);
+        // Untouched providers keep the default.
+        assert_eq!(timeouts.for_provider("open_library"), 5);
+    }
+
+    #[tokio::test]
+    async fn per_provider_override_timeout_skips_slow_provider() {
+        // SlowProvider sleeps 10 s; with a sub-second override it is
+        // skipped and the chain falls through to the fast provider.
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(SlowProvider));
+        registry.register(Box::new(SuccessProvider { name: "fast" }));
+
+        let mut timeouts = ProviderTimeouts::uniform(60);
+        timeouts
+            .overrides
+            .insert(provider_slug("slow_provider"), 1);
+
+        let chain = registry.chain_for(&MediaType::Book);
+        let mut result = None;
+        for provider in &chain {
+            // Millisecond-scale stand-in for the second-scale resolution
+            // ChainExecutor::execute performs — same for_provider call.
+            let per_provider = Duration::from_millis(timeouts.for_provider(provider.name()) * 100);
+            match tokio::time::timeout(per_provider, provider.lookup_by_isbn("123")).await {
+                Ok(Ok(Some(meta))) => {
+                    result = Some(meta);
+                    break;
+                }
+                _ => continue,
+            }
+        }
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().title.as_deref(), Some("Test Title"));
     }
 
     #[test]

--- a/src/metadata/provider.rs
+++ b/src/metadata/provider.rs
@@ -73,6 +73,31 @@ impl MetadataResult {
     }
 }
 
+/// CR #396 — normalize a provider's display name into the slug used as
+/// the K/V settings suffix (`provider_timeout.<slug>`) and the admin
+/// form field suffix. Lowercases ASCII and collapses every
+/// non-alphanumeric run into a single `_`, trimming leading/trailing
+/// separators: `"BnF"` → `"bnf"`, `"Library of Congress"` →
+/// `"library_of_congress"`. Must stay in sync with the row keys seeded
+/// by migration 20260611000000.
+pub fn provider_slug(name: &str) -> String {
+    let mut slug = String::with_capacity(name.len());
+    let mut last_was_sep = true; // suppress a leading separator
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            slug.push(c.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            slug.push('_');
+            last_was_sep = true;
+        }
+    }
+    if slug.ends_with('_') {
+        slug.pop();
+    }
+    slug
+}
+
 /// Trait for external metadata providers (BnF, Google Books, Open Library, etc.).
 #[async_trait]
 pub trait MetadataProvider: Send + Sync {
@@ -273,5 +298,29 @@ mod tests {
             "Parse error: invalid JSON"
         );
         assert_eq!(MetadataError::Timeout.to_string(), "Request timed out");
+    }
+
+    // ─── CR #396 — provider_slug ─────────────────────────────────
+
+    #[test]
+    fn provider_slug_matches_seeded_row_keys() {
+        // One assertion per provider registered in main.rs — must stay
+        // in sync with migration 20260611000000's row keys.
+        assert_eq!(provider_slug("bdgest"), "bdgest");
+        assert_eq!(provider_slug("BnF"), "bnf");
+        assert_eq!(provider_slug("google_books"), "google_books");
+        assert_eq!(provider_slug("Library of Congress"), "library_of_congress");
+        assert_eq!(provider_slug("open_library"), "open_library");
+        assert_eq!(provider_slug("musicbrainz"), "musicbrainz");
+        assert_eq!(provider_slug("omdb"), "omdb");
+        assert_eq!(provider_slug("tmdb"), "tmdb");
+    }
+
+    #[test]
+    fn provider_slug_collapses_separator_runs_and_trims() {
+        assert_eq!(provider_slug("  A -- B  "), "a_b");
+        assert_eq!(provider_slug("Comic Vine!"), "comic_vine");
+        assert_eq!(provider_slug(""), "");
+        assert_eq!(provider_slug("---"), "");
     }
 }

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -348,7 +348,7 @@ pub async fn admin_bulk_cover_refetch(
             .map(|s| s.metadata_fetch_timeout_secs)
             .unwrap_or(30)
     };
-    let per_provider_timeout_secs = state.metadata_chain_per_provider_timeout_secs();
+    let per_provider_timeouts = state.metadata_chain_provider_timeouts();
 
     tokio::spawn(async move {
         for title in titles {
@@ -372,7 +372,7 @@ pub async fn admin_bulk_cover_refetch(
                     .unwrap_or(crate::models::media_type::MediaType::Book),
                 registry_clone.clone(),
                 timeout_secs,
-                per_provider_timeout_secs,
+                per_provider_timeouts.clone(),
                 http_client_clone.clone(),
                 covers_dir_clone.clone(),
                 true,

--- a/src/routes/admin_system.rs
+++ b/src/routes/admin_system.rs
@@ -36,9 +36,9 @@ use crate::utils::feedback_html;
 use crate::services::admin_system::{
     KEY_DEFAULT_CURRENCY, KEY_DEFAULT_LANGUAGE, KEY_GOOGLE_BOOKS, KEY_LOG_LEVEL,
     KEY_METADATA_CHAIN_TIMEOUT, KEY_OMDB, KEY_OVERDUE_THRESHOLD, KEY_PROVIDER_HEALTH_TIMEOUT,
-    KEY_SHOW_VALUE_INDICATORS, KEY_TMDB, reload_settings_cache, save_setting,
-    validate_default_currency, validate_default_language, validate_log_level,
-    validate_overdue_threshold, validate_provider_timeout_secs,
+    KEY_SHOW_VALUE_INDICATORS, KEY_TMDB, PROVIDER_TIMEOUT_KEY_PREFIX, provider_timeout_key,
+    reload_settings_cache, save_setting, validate_default_currency, validate_default_language,
+    validate_log_level, validate_overdue_threshold, validate_provider_timeout_secs,
 };
 
 // ─── Form structs ─────────────────────────────────────────────────
@@ -130,6 +130,7 @@ pub(crate) struct AdminSystemPanel {
     pub loans_form_html: String,
     pub providers_form_html: String,
     pub timeouts_form_html: String,
+    pub provider_timeouts_form_html: String,
     pub language_form_html: String,
     pub valuation_form_html: String,
     pub log_form_html: String,
@@ -205,6 +206,31 @@ struct AdminSystemTimeoutsForm {
     provider_health_help: String,
     provider_health_value: u64,
     provider_health_version: i32,
+    timeout_min: u64,
+    timeout_max: u64,
+    btn_save: String,
+}
+
+// CR #396 — one rendered row per registered provider in the
+// per-provider-timeouts form. `value` is the raw setting string
+// ("" = no override, use the scalar default); `label` is the
+// provider's display name (a proper noun — never translated, NFR41).
+struct ProviderTimeoutRow {
+    label: String,
+    slug: String,
+    value: String,
+    version: i32,
+}
+
+// CR #396 — per-provider timeout overrides form. Rendered below the
+// scalar timeouts form inside the "Metadata Providers" section.
+#[derive(Template)]
+#[template(path = "fragments/admin_system_provider_timeouts_form.html")]
+struct AdminSystemProviderTimeoutsForm {
+    csrf_token: String,
+    provider_timeouts_help: String,
+    default_secs: u64,
+    rows: Vec<ProviderTimeoutRow>,
     timeout_min: u64,
     timeout_max: u64,
     btn_save: String,
@@ -298,6 +324,56 @@ async fn fetch_setting_rows(
         map.insert(key, (value, version));
     }
     Ok(map)
+}
+
+/// CR #396 — fetch every `provider_timeout.<slug>` row, keyed by slug.
+/// Kept separate from `fetch_setting_rows` because the provider set is
+/// open-ended (one row per registered provider) while that function's
+/// `IN` list is a fixed-key contract policed by fix #406.
+async fn fetch_provider_timeout_rows(
+    pool: &DbPool,
+) -> Result<HashMap<String, (String, i32)>, AppError> {
+    let rows: Vec<(String, String, i32)> = sqlx::query_as(
+        "SELECT setting_key, setting_value, version FROM settings \
+         WHERE setting_key LIKE CONCAT(?, '%') AND deleted_at IS NULL",
+    )
+    .bind(PROVIDER_TIMEOUT_KEY_PREFIX)
+    .fetch_all(pool)
+    .await?;
+    let mut map = HashMap::new();
+    for (key, value, version) in rows {
+        if let Some(slug) = key.strip_prefix(PROVIDER_TIMEOUT_KEY_PREFIX) {
+            map.insert(slug.to_string(), (value, version));
+        }
+    }
+    Ok(map)
+}
+
+/// CR #396 — build the rendered rows from the registry (the source of
+/// truth for which providers exist) joined with the settings rows. A
+/// provider whose row is missing (registered after the seed migration,
+/// before its own row migration) renders with version 1 — the existing
+/// fallback shape used across this module.
+fn provider_timeout_rows(
+    registry: &crate::metadata::registry::ProviderRegistry,
+    rows: &HashMap<String, (String, i32)>,
+) -> Vec<ProviderTimeoutRow> {
+    registry
+        .iter()
+        .map(|p| {
+            let slug = crate::metadata::provider::provider_slug(p.name());
+            let (value, version) = rows
+                .get(&slug)
+                .cloned()
+                .unwrap_or_else(|| (String::new(), 1));
+            ProviderTimeoutRow {
+                label: p.name().to_string(),
+                slug,
+                value,
+                version,
+            }
+        })
+        .collect()
 }
 
 // ─── Render helpers ──────────────────────────────────────────────
@@ -487,6 +563,33 @@ fn render_timeouts_form(
     .map_err(|_| AppError::Internal("timeouts form render failed".to_string()))
 }
 
+// CR #396 — per-provider timeout overrides form renderer.
+fn render_provider_timeouts_form(
+    csrf: &str,
+    loc: &'static str,
+    default_secs: u64,
+    rows: Vec<ProviderTimeoutRow>,
+) -> Result<String, AppError> {
+    use crate::services::admin_system::{PROVIDER_TIMEOUT_MAX_SECS, PROVIDER_TIMEOUT_MIN_SECS};
+    AdminSystemProviderTimeoutsForm {
+        csrf_token: csrf.to_string(),
+        provider_timeouts_help: rust_i18n::t!(
+            "admin.system.provider_timeouts_help",
+            locale = loc,
+            default = default_secs
+        )
+        .to_string(),
+        default_secs,
+        rows,
+        timeout_min: PROVIDER_TIMEOUT_MIN_SECS,
+        timeout_max: PROVIDER_TIMEOUT_MAX_SECS,
+        btn_save: rust_i18n::t!("admin.system.btn_save_provider_timeouts", locale = loc)
+            .to_string(),
+    }
+    .render()
+    .map_err(|_| AppError::Internal("provider timeouts form render failed".to_string()))
+}
+
 // v1.7.1 fix #308 — Logging form renderer.
 fn render_log_form(
     csrf: &str,
@@ -579,6 +682,14 @@ pub async fn render_panel_html(
         probe_timeout,
         probe_timeout_version,
     )?;
+    // CR #396 — per-provider override rows below the scalar timeouts.
+    let override_rows = fetch_provider_timeout_rows(&state.pool).await?;
+    let provider_timeouts_form_html = render_provider_timeouts_form(
+        csrf,
+        loc,
+        chain_timeout,
+        provider_timeout_rows(&state.registry, &override_rows),
+    )?;
     let language_form_html = render_language_form(csrf, loc, &default_lang, lang_version)?;
     let valuation_form_html = render_valuation_form(
         csrf,
@@ -602,6 +713,7 @@ pub async fn render_panel_html(
         loans_form_html,
         providers_form_html,
         timeouts_form_html,
+        provider_timeouts_form_html,
         language_form_html,
         valuation_form_html,
         log_form_html,
@@ -1100,6 +1212,131 @@ pub async fn save_metadata_timeouts(
     .into_response())
 }
 
+// CR #396 — parse one submitted per-provider override input.
+// `Ok(None)` = empty field (no override — store ""), `Ok(Some(v))` =
+// validated override, `Err` = not a number or out of the 1..=60 range
+// (same localized message as the scalar timeouts form).
+fn parse_provider_timeout_input(
+    raw: &str,
+    loc: &'static str,
+) -> Result<Option<u64>, AppError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let v: u64 = trimmed.parse().map_err(|_| {
+        AppError::BadRequest(
+            rust_i18n::t!("error.system.provider_timeout_invalid", locale = loc).to_string(),
+        )
+    })?;
+    validate_provider_timeout_secs(v, loc)?;
+    Ok(Some(v))
+}
+
+// CR #396 — per-provider timeout overrides save handler. The field set
+// is dynamic (one pair per registered provider), so the form
+// deserializes into a plain map; the registry is the source of truth
+// for which fields to read. Writes are transactional and only issued
+// for rows whose value actually changed, so untouched providers never
+// burn a version (and never spuriously conflict).
+pub async fn save_provider_timeouts(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+    Form(form): Form<HashMap<String, String>>,
+) -> Result<Response, AppError> {
+    session.require_role_with_return(Role::Admin, "/admin?tab=system", locale.0)?;
+    let loc = locale.0;
+
+    let current_rows = fetch_provider_timeout_rows(&state.pool).await?;
+    let default_secs = state.metadata_chain_per_provider_timeout_secs();
+
+    // First pass: validate every submitted field and derive the writes.
+    // On the first invalid field, re-render the form with the submitted
+    // values (#91 pattern — preserve typed input + HX-Trigger so csrf.js
+    // opts the 400 swap in).
+    let mut writes: Vec<(String, String, i32)> = Vec::new(); // (key, new_value, version)
+    let mut submitted_rows: Vec<ProviderTimeoutRow> = Vec::new();
+    let mut validation_error: Option<String> = None;
+
+    for provider in state.registry.iter() {
+        let slug = crate::metadata::provider::provider_slug(provider.name());
+        let raw = form
+            .get(&format!("timeout_{slug}"))
+            .map(String::as_str)
+            .unwrap_or("");
+        let (current_value, current_version) = current_rows
+            .get(&slug)
+            .cloned()
+            .unwrap_or_else(|| (String::new(), 1));
+        let version = form
+            .get(&format!("timeout_{slug}_version"))
+            .and_then(|v| v.trim().parse::<i32>().ok())
+            .unwrap_or(current_version);
+
+        submitted_rows.push(ProviderTimeoutRow {
+            label: provider.name().to_string(),
+            slug: slug.clone(),
+            value: raw.trim().to_string(),
+            version,
+        });
+
+        if validation_error.is_some() {
+            continue; // keep collecting rows for the re-render
+        }
+        match parse_provider_timeout_input(raw, loc) {
+            Ok(parsed) => {
+                let new_value = parsed.map(|v| v.to_string()).unwrap_or_default();
+                if new_value != current_value {
+                    writes.push((provider_timeout_key(&slug), new_value, version));
+                }
+            }
+            Err(AppError::BadRequest(msg)) => validation_error = Some(msg),
+            Err(other) => return Err(other),
+        }
+    }
+
+    if let Some(error_msg) = validation_error {
+        return Ok(validation_error_response(
+            render_provider_timeouts_form(&session.csrf_token, loc, default_secs, submitted_rows)?,
+            error_msg,
+        ));
+    }
+
+    let any_change = !writes.is_empty();
+    if any_change {
+        let mut tx = state.pool.begin().await?;
+        for (key, new_value, version) in &writes {
+            save_setting(&mut *tx, key, new_value, *version).await?;
+        }
+        tx.commit().await?;
+        reload_settings_cache(&state).await?;
+    }
+
+    let fresh_rows = fetch_provider_timeout_rows(&state.pool).await?;
+    let main = render_provider_timeouts_form(
+        &session.csrf_token,
+        loc,
+        state.metadata_chain_per_provider_timeout_secs(),
+        provider_timeout_rows(&state.registry, &fresh_rows),
+    )?;
+    let feedback_key = if any_change {
+        "success.system.provider_timeouts_saved"
+    } else {
+        "success.system.no_changes"
+    };
+    let feedback = success_feedback(loc, feedback_key);
+    Ok(HtmxResponse {
+        main,
+        oob: vec![OobUpdate {
+            swap_mode: Default::default(),
+            target: "feedback-list".to_string(),
+            content: feedback,
+        }],
+    }
+    .into_response())
+}
+
 // ─── Provider-key action machinery ────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -1315,5 +1552,45 @@ mod tests {
     fn action_for_whitespace_input_is_no_change() {
         let a = action_for("   \t  ", 5, &None);
         assert!(matches!(a, ProviderKeyAction::NoChange));
+    }
+
+    // ─── CR #396 — parse_provider_timeout_input ───────────────────
+
+    #[test]
+    fn parse_provider_timeout_input_empty_means_no_override() {
+        assert!(matches!(parse_provider_timeout_input("", "en"), Ok(None)));
+        assert!(matches!(
+            parse_provider_timeout_input("   ", "en"),
+            Ok(None)
+        ));
+    }
+
+    #[test]
+    fn parse_provider_timeout_input_accepts_in_range() {
+        assert!(matches!(
+            parse_provider_timeout_input("1", "en"),
+            Ok(Some(1))
+        ));
+        assert!(matches!(
+            parse_provider_timeout_input(" 12 ", "en"),
+            Ok(Some(12))
+        ));
+        assert!(matches!(
+            parse_provider_timeout_input("60", "en"),
+            Ok(Some(60))
+        ));
+    }
+
+    #[test]
+    fn parse_provider_timeout_input_rejects_garbage_and_out_of_range() {
+        for raw in ["0", "61", "abc", "-3", "5.5"] {
+            assert!(
+                matches!(
+                    parse_provider_timeout_input(raw, "en"),
+                    Err(AppError::BadRequest(_))
+                ),
+                "{raw:?} should be rejected"
+            );
+        }
     }
 }

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -431,8 +431,7 @@ pub async fn handle_scan(
                             .read()
                             .map(|s| s.metadata_fetch_timeout_secs)
                             .unwrap_or(30);
-                        let per_provider_timeout_secs =
-                            state.metadata_chain_per_provider_timeout_secs();
+                        let per_provider_timeouts = state.metadata_chain_provider_timeouts();
 
                         let media_type = title
                             .media_type
@@ -455,7 +454,7 @@ pub async fn handle_scan(
                                 media_type,
                                 state.registry.clone(),
                                 timeout_secs,
-                                per_provider_timeout_secs,
+                                per_provider_timeouts.clone(),
                                 state.http_client.clone(),
                                 state.covers_dir.clone(),
                                 false,
@@ -952,8 +951,7 @@ pub async fn handle_scan(
                             .read()
                             .map(|s| s.metadata_fetch_timeout_secs)
                             .unwrap_or(30);
-                        let per_provider_timeout_secs =
-                            state.metadata_chain_per_provider_timeout_secs();
+                        let per_provider_timeouts = state.metadata_chain_provider_timeouts();
                         crate::tasks::metadata_fetch::spawn_fetch(
                             "catalog_issn_scan",
                             title.id,
@@ -965,7 +963,7 @@ pub async fn handle_scan(
                                 MediaType::Magazine,
                                 state.registry.clone(),
                                 timeout_secs,
-                                per_provider_timeout_secs,
+                                per_provider_timeouts.clone(),
                                 state.http_client.clone(),
                                 state.covers_dir.clone(),
                                 false,
@@ -1014,8 +1012,7 @@ pub async fn handle_scan(
                                 .read()
                                 .map(|s| s.metadata_fetch_timeout_secs)
                                 .unwrap_or(30);
-                            let per_provider_timeout_secs =
-                                state.metadata_chain_per_provider_timeout_secs();
+                            let per_provider_timeouts = state.metadata_chain_provider_timeouts();
                             crate::tasks::metadata_fetch::spawn_fetch(
                                 "catalog_upc_session_pref",
                                 title.id,
@@ -1027,7 +1024,7 @@ pub async fn handle_scan(
                                     media_type,
                                     state.registry.clone(),
                                     timeout_secs,
-                                    per_provider_timeout_secs,
+                                    per_provider_timeouts.clone(),
                                     state.http_client.clone(),
                                     state.covers_dir.clone(),
                                     false,
@@ -1245,8 +1242,7 @@ pub async fn handle_scan_with_type(
                     .read()
                     .map(|s| s.metadata_fetch_timeout_secs)
                     .unwrap_or(30);
-                let per_provider_timeout_secs =
-                    state.metadata_chain_per_provider_timeout_secs();
+                let per_provider_timeouts = state.metadata_chain_provider_timeouts();
                 crate::tasks::metadata_fetch::spawn_fetch(
                     "catalog_upc_post_media_select",
                     title.id,
@@ -1258,7 +1254,7 @@ pub async fn handle_scan_with_type(
                         media_type,
                         state.registry.clone(),
                         timeout_secs,
-                        per_provider_timeout_secs,
+                        per_provider_timeouts.clone(),
                         state.http_client.clone(),
                         state.covers_dir.clone(),
                         false,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -572,6 +572,13 @@ pub fn build_router(state: AppState) -> Router {
             "/admin/system/timeouts",
             axum::routing::post(admin_system::save_metadata_timeouts),
         )
+        // CR #396 — per-provider metadata-timeout overrides save
+        // endpoint. One field pair per registered provider; empty
+        // value = use the scalar default from /admin/system/timeouts.
+        .route(
+            "/admin/system/provider-timeouts",
+            axum::routing::post(admin_system::save_provider_timeouts),
+        )
         // CR #241 — Admin → API keys (v1.4.0). 4 routes: 1 GET panel +
         // 1 POST create + 1 GET revoke-modal + 1 POST revoke. All
         // Admin-gated. CSRF-protected via the 8-2 middleware.

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -915,7 +915,7 @@ pub async fn redownload_metadata(
         let settings = state.settings.read().unwrap();
         settings.metadata_fetch_timeout_secs
     };
-    let per_provider_timeout_secs = state.metadata_chain_per_provider_timeout_secs();
+    let per_provider_timeouts = state.metadata_chain_provider_timeouts();
 
     // Execute chain synchronously (user is waiting for result)
     let metadata_opt = ChainExecutor::execute(
@@ -925,7 +925,7 @@ pub async fn redownload_metadata(
         &code_type,
         &media_type,
         timeout_secs,
-        per_provider_timeout_secs,
+        &per_provider_timeouts,
     )
     .await;
 

--- a/src/routes/wishlist.rs
+++ b/src/routes/wishlist.rs
@@ -201,7 +201,7 @@ pub async fn wishlist_preview_isbn(
         .read()
         .map(|s| s.metadata_fetch_timeout_secs)
         .unwrap_or(30);
-    let per_provider_timeout_secs = state.metadata_chain_per_provider_timeout_secs();
+    let per_provider_timeouts = state.metadata_chain_provider_timeouts();
     let metadata = crate::metadata::chain::ChainExecutor::execute(
         &state.registry,
         pool,
@@ -209,7 +209,7 @@ pub async fn wishlist_preview_isbn(
         &CodeType::Isbn,
         &MediaType::Book,
         timeout_secs,
-        per_provider_timeout_secs,
+        &per_provider_timeouts,
     )
     .await;
 

--- a/src/services/admin_system.rs
+++ b/src/services/admin_system.rs
@@ -48,6 +48,18 @@ pub const KEY_LOG_LEVEL: &str = "log_level";
 pub const KEY_METADATA_CHAIN_TIMEOUT: &str = "metadata_chain_per_provider_timeout_secs";
 pub const KEY_PROVIDER_HEALTH_TIMEOUT: &str = "provider_health_probe_timeout_secs";
 
+// CR #396 — per-provider metadata-chain timeout overrides. One K/V row
+// per provider, keyed `provider_timeout.<slug>` where <slug> comes from
+// `metadata::provider::provider_slug`. Empty value = "use the scalar
+// default" (KEY_METADATA_CHAIN_TIMEOUT). Rows seeded by migration
+// 20260611000000; same 1..=60 bounds as the scalar.
+pub const PROVIDER_TIMEOUT_KEY_PREFIX: &str = "provider_timeout.";
+
+/// Build the settings row key for one provider's timeout override.
+pub fn provider_timeout_key(slug: &str) -> String {
+    format!("{PROVIDER_TIMEOUT_KEY_PREFIX}{slug}")
+}
+
 /// Inclusive bounds for both timeout settings. Below 1 s would race typical
 /// HTTPS handshakes; above 60 s a stalled provider would block the chain
 /// longer than any plausible user-facing latency budget.
@@ -355,5 +367,18 @@ mod tests {
             KEY_PROVIDER_HEALTH_TIMEOUT,
             "provider_health_probe_timeout_secs"
         );
+    }
+
+    // ─── CR #396 — per-provider timeout override keys ─────────────
+
+    #[test]
+    fn provider_timeout_override_key_matches_migration_strings() {
+        // Migration 20260611000000 seeds `provider_timeout.<slug>` rows.
+        assert_eq!(provider_timeout_key("bnf"), "provider_timeout.bnf");
+        assert_eq!(
+            provider_timeout_key("library_of_congress"),
+            "provider_timeout.library_of_congress"
+        );
+        assert_eq!(PROVIDER_TIMEOUT_KEY_PREFIX, "provider_timeout.");
     }
 }

--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -69,7 +69,7 @@ pub async fn fetch_metadata_chain(
     media_type: MediaType,
     registry: Arc<ProviderRegistry>,
     timeout_secs: u64,
-    per_provider_timeout_secs: u64,
+    per_provider_timeouts: crate::metadata::chain::ProviderTimeouts,
     http_client: reqwest::Client,
     covers_dir: PathBuf,
     force_refresh: bool,
@@ -106,7 +106,7 @@ pub async fn fetch_metadata_chain(
         &code_type,
         &media_type,
         timeout_secs,
-        per_provider_timeout_secs,
+        &per_provider_timeouts,
     )
     .await
     {

--- a/templates/fragments/admin_system_panel.html
+++ b/templates/fragments/admin_system_panel.html
@@ -17,6 +17,9 @@
            live in the same Metadata Providers section so admins find
            both knobs together. #}
         {{ timeouts_form_html|safe }}
+        {# CR #396 — per-provider overrides of the metadata-chain
+           timeout; empty field = use the scalar default above. #}
+        {{ provider_timeouts_form_html|safe }}
     </section>
 
     <section aria-labelledby="admin-system-language-heading">

--- a/templates/fragments/admin_system_provider_timeouts_form.html
+++ b/templates/fragments/admin_system_provider_timeouts_form.html
@@ -1,0 +1,41 @@
+{# Admin → System → Per-provider metadata-timeout overrides (CR #396).
+   One number input per registered provider; an EMPTY field means "use
+   the global default" (the scalar from the form above), so inputs are
+   NOT `required` and carry the default as placeholder. Provider names
+   are proper nouns — rendered verbatim, never translated (NFR41).
+   Mirrors the timeouts-form shape: CSRF first, hidden version per
+   field, hx-post to a dedicated endpoint, outerHTML swap on the form
+   id. min/max mirror the server-side 1..=60 bounds. #}
+<form id="admin-system-provider-timeouts-form"
+      method="POST"
+      action="/admin/system/provider-timeouts"
+      hx-post="/admin/system/provider-timeouts"
+      hx-target="#admin-system-provider-timeouts-form"
+      hx-swap="outerHTML"
+      class="border border-stone-200 dark:border-stone-700 rounded-lg p-4 bg-stone-50 dark:bg-stone-900 mt-4">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
+
+    <p class="text-xs text-stone-500 dark:text-stone-400 mb-3">{{ provider_timeouts_help }}</p>
+
+    {% for row in rows %}
+    <div class="mb-3 flex items-center gap-3">
+        <input type="hidden" name="timeout_{{ row.slug }}_version" value="{{ row.version }}">
+        <label for="admin-provider-timeout-{{ row.slug }}"
+               class="w-48 text-sm font-medium">{{ row.label }}</label>
+        <input id="admin-provider-timeout-{{ row.slug }}"
+               name="timeout_{{ row.slug }}"
+               type="number"
+               min="{{ timeout_min }}"
+               max="{{ timeout_max }}"
+               step="1"
+               value="{{ row.value }}"
+               placeholder="{{ default_secs }}"
+               class="w-32 rounded-md border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 px-3 py-2 text-sm">
+    </div>
+    {% endfor %}
+
+    <div>
+        <button type="submit"
+                class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm">{{ btn_save }}</button>
+    </div>
+</form>

--- a/tests/e2e/docker-compose.test.yml
+++ b/tests/e2e/docker-compose.test.yml
@@ -7,7 +7,12 @@ services:
       context: ../..
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
+      # Host port is overridable so a dev box with something else on 8080
+      # (e.g. another container) can still run the stack:
+      #   E2E_HOST_PORT=18080 ./scripts/e2e-reset.sh
+      #   BASE_URL=http://localhost:18080 npm test
+      # CI and the default dev loop keep 8080.
+      - "${E2E_HOST_PORT:-8080}:8080"
     environment:
       DATABASE_URL: mysql://mybibli:mybibli_test@db:3306/mybibli_test?charset=utf8mb4
       HOST: "0.0.0.0"

--- a/tests/e2e/specs/journeys/admin-provider-timeouts.spec.ts
+++ b/tests/e2e/specs/journeys/admin-provider-timeouts.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * CR #396 E2E — Admin per-provider metadata-timeout overrides.
+ *
+ * Real journey (Foundation Rule #3): blank browser → loginAs(admin) →
+ * /admin?tab=system → set an override → verify persistence → clear it
+ * back to "use default". Serial mode: these tests mutate the shared
+ * `provider_timeout.*` K/V rows, same rationale as the 8-5 spec.
+ *
+ * No other spec touches the provider_timeout rows, so this file is
+ * parallel-safe relative to the rest of the suite.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+const FORM = "form#admin-system-provider-timeouts-form";
+const SAVED_RE =
+  /Per-provider timeouts saved|Délais par fournisseur enregistrés/i;
+
+test.describe("CR #396 — Admin per-provider timeouts", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("form renders one input per registered provider with the default as placeholder", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    const form = page.locator(FORM);
+    await expect(form).toBeVisible();
+
+    // Spot-check a slugged display name ("BnF" → bnf) and a
+    // snake_case one — both seeded by migration 20260611000000.
+    const bnfInput = form.locator('input[name="timeout_bnf"]');
+    const gbInput = form.locator('input[name="timeout_google_books"]');
+    await expect(bnfInput).toBeVisible();
+    await expect(gbInput).toBeVisible();
+
+    // Empty = "use the global default"; the placeholder carries it.
+    await expect(gbInput).toHaveValue("");
+    await expect(gbInput).toHaveAttribute("placeholder", /^\d+$/);
+
+    // Provider labels are proper nouns, rendered verbatim (NFR41).
+    await expect(form.getByText("BnF", { exact: true })).toBeVisible();
+  });
+
+  test("override save persists, second save works (no stale-version 409), clear restores default", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    const gbInput = page.locator(`${FORM} input[name="timeout_google_books"]`);
+    const submit = page.locator(`${FORM} button[type="submit"]`);
+
+    // Set an override.
+    await gbInput.fill("3");
+    await submit.click();
+    await expect(
+      page.locator("#feedback-list").getByText(SAVED_RE),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Persistence proof: full reload re-renders the stored value.
+    await page.goto("/admin?tab=system");
+    await expect(gbInput).toHaveValue("3");
+
+    // Second consecutive save on the same row — guards against the #406
+    // stale-version class of bug (form must re-render fresh versions).
+    await gbInput.fill("7");
+    await submit.click();
+    await expect(
+      page.locator("#feedback-list").getByText(SAVED_RE).last(),
+    ).toBeVisible({ timeout: 10000 });
+    await page.goto("/admin?tab=system");
+    await expect(gbInput).toHaveValue("7");
+
+    // Clear back to "use default" (empty field) for test isolation.
+    await gbInput.fill("");
+    await submit.click();
+    await expect(
+      page.locator("#feedback-list").getByText(SAVED_RE).last(),
+    ).toBeVisible({ timeout: 10000 });
+    await page.goto("/admin?tab=system");
+    await expect(gbInput).toHaveValue("");
+  });
+
+  test("out-of-range override → 400 + localized inline error", async ({
+    page,
+    request,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+    const csrf = await page
+      .locator('meta[name="csrf-token"]')
+      .getAttribute("content");
+    expect(csrf).toBeTruthy();
+    const cookies = await page.context().cookies();
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+
+    // 99 is outside the 1..=60 bound the form's max attribute mirrors —
+    // bypass the client-side guard with a direct POST.
+    const resp = await request.post("/admin/system/provider-timeouts", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: cookieHeader,
+        "HX-Request": "true",
+      },
+      data: `timeout_google_books=99&timeout_google_books_version=1&_csrf_token=${encodeURIComponent(csrf!)}`,
+      maxRedirects: 0,
+    });
+    expect(resp.status()).toBe(400);
+  });
+
+  test("unchanged form save reports no changes instead of bumping versions", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    // Submit with every field untouched (all empty = all defaults).
+    await page.locator(`${FORM} button[type="submit"]`).click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(/No changes|Aucune modification/i),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary

Implements CR #396 (split out of #384): the metadata-chain per-provider timeout becomes configurable **per provider**, with the existing scalar (`metadata_chain_per_provider_timeout_secs`, v1.7.9 #334) as the fallback default.

- **Persistence** — one K/V row per registered provider, keyed `provider_timeout.<slug>` (slug via the new `metadata::provider::provider_slug`: `"BnF"` → `bnf`, `"Library of Congress"` → `library_of_congress`). Empty value = "no override". Seeded by migration `20260611000000`; same 1..=60 bounds as the scalar, out-of-range rows skipped with a warning at load.
- **Chain** — `ChainExecutor::execute` now takes a `ProviderTimeouts { default_secs, overrides }` struct; resolution per provider name, hot-reloaded per fetch via the new `AppState::metadata_chain_provider_timeouts()` accessor.
- **Admin UI** — new form in /admin > System > Metadata Providers, one number input per provider enumerated from `ProviderRegistry`, placeholder shows the global default. Change-only transactional writes (untouched rows never burn a version), #91-style validation re-render, #406-proof fresh-version re-render after save.
- **i18n** — 3 new keys in all 4 locales (de/en/fr/it); provider names rendered verbatim (NFR41).
- **Dev affordance** — `E2E_HOST_PORT` override for the E2E stack host port (default 8080 unchanged) so a dev box with something else on 8080 can still run the stack.

## Tests

- Unit: `provider_slug` contract vs migration keys, `ProviderTimeouts` resolution, `parse_provider_timeout_input`, settings clone/load coverage — full suite 53/53 green vs test DB.
- E2E: new `admin-provider-timeouts.spec.ts` (render, persist + second-save stale-version guard, 400 out-of-range, no-changes path) — full suite 290 passed / 0 failed at `CI=true --workers=2`.
- `cargo clippy -- -D warnings` clean; templates audit (CSP / CSRF-token coverage) green; locale parity green.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)