### PR TITLE
refactor(#403): sweep inline-form.js + mybibli.js onto the #i18n-bundle pattern

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -356,6 +356,10 @@ series:
   omnibus_help_text: "Aktivieren, wenn das Buch mehrere Bände der Serie bündelt (z. B. ein Sammelband mit den Bänden 1–3). Das Formular zeigt dann ein Feld \"Endposition\", damit der Titel einen Bereich von Serienpositionen abdeckt anstatt nur einer."
   select_series: "Eine Serie auswählen…"
 error:
+  # Issue #403 — über die #i18n-bundle-Dateninsel an den Client
+  # geliefert, gelesen von static/js/mybibli.js (htmx:responseError-
+  # Feedback). %{status} wird clientseitig ersetzt.
+  server_error_retry: "Serverfehler (%{status}) — bitte versuchen Sie es erneut."
   internal: "Auf unserer Seite ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut; wenn das Problem weiterhin besteht, wenden Sie sich an Ihren Administrator."
   not_found: "Wir konnten nicht finden, wonach Sie gesucht haben — es wurde möglicherweise verschoben oder gelöscht."
   already_deleted_by_another_session: "Dieser Eintrag wurde bereits von einer anderen Sitzung gelöscht — laden Sie die Seite neu, um den aktuellen Stand zu sehen."
@@ -717,6 +721,10 @@ loan:
   return_modal_confirm: "Als zurückgegeben markieren"
   not_found: "Ausleihe nicht gefunden."
   col_action: Aktion
+inline_form:
+  # Issue #403 — über die #i18n-bundle-Dateninsel an den Client
+  # geliefert, gelesen von static/js/inline-form.js (Ein-Modal-Slot-Wache).
+  modal_busy: "Bitte schließen Sie den aktuellen Dialog, bevor Sie einen weiteren öffnen."
 session:
   expiry_soon: "Ihre Sitzung läuft bald ab."
   expiry_in_minutes: "Ihre Sitzung läuft in %{minutes} Min. ab."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -360,6 +360,10 @@ series:
   omnibus_help_text: "Check this when the book bundles multiple volumes of the series (e.g. an omnibus collecting volumes 1–3). The form then reveals an 'End position' field so the title covers a range of series positions instead of just one."
   select_series: "Select a series..."
 error:
+  # Issue #403 — emitted to the client via the #i18n-bundle data
+  # island and read by static/js/mybibli.js (htmx:responseError
+  # feedback). %{status} substituted client-side.
+  server_error_retry: "Server error (%{status}) — please try again."
   internal: "Something went wrong on our end. Please try again; if the problem continues, contact your administrator."
   not_found: "We couldn't find what you were looking for — it may have been moved or deleted."
   # CR #136 — friendly "your tab is stale" message surfaced when a
@@ -725,6 +729,11 @@ loan:
   return_modal_confirm: "Mark as returned"
   not_found: "Loan not found."
   col_action: Action
+inline_form:
+  # Issue #403 — emitted to the client via the #i18n-bundle data
+  # island and read by static/js/inline-form.js (single-modal-slot
+  # guard, see polish-1 modal lifecycle).
+  modal_busy: "Please close the current dialog before opening another."
 session:
   # Emitted to the client via the #i18n-bundle data island
   # (utils::build_js_i18n_bundle, issue #386) and read by

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -358,6 +358,10 @@ series:
   omnibus_help_text: "Cochez quand le livre regroupe plusieurs volumes de la série (par ex. une intégrale tomes 1–3). Le formulaire révèle alors un champ 'Position de fin' pour que le titre couvre une plage de positions au lieu d'une seule."
   select_series: "Sélectionner une série..."
 error:
+  # Issue #403 — émis vers le client via le data island #i18n-bundle
+  # et lu par static/js/mybibli.js (feedback htmx:responseError).
+  # %{status} substitué côté client.
+  server_error_retry: "Erreur serveur (%{status}) — veuillez réessayer."
   internal: "Une erreur est survenue de notre côté. Réessayez ; si le problème persiste, contactez votre administrateur."
   not_found: "Introuvable — l'élément a peut-être été déplacé ou supprimé."
   already_deleted_by_another_session: "Cet élément a déjà été supprimé par une autre session — rafraîchissez la page pour voir l'état actuel."
@@ -721,6 +725,10 @@ loan:
   return_modal_confirm: "Marquer comme retourné"
   not_found: "Prêt introuvable."
   col_action: Action
+inline_form:
+  # Issue #403 — émis vers le client via le data island #i18n-bundle
+  # et lu par static/js/inline-form.js (garde du slot modal unique).
+  modal_busy: "Veuillez fermer la fenêtre en cours avant d'en ouvrir une autre."
 session:
   # Transmis au client via l'îlot de données #i18n-bundle
   # (utils::build_js_i18n_bundle, issue #386) et lu par

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -350,6 +350,10 @@ series:
   omnibus_help_text: "Seleziona questa casella quando il libro raggruppa più volumi della serie (es. un omnibus che raccoglie i volumi 1–3). Il modulo mostrerà allora un campo «Posizione finale» in modo che il titolo copra un intervallo di posizioni invece di una sola."
   select_series: "Seleziona una serie…"
 error:
+  # Issue #403 — inviato al client tramite la data island #i18n-bundle
+  # e letto da static/js/mybibli.js (feedback htmx:responseError).
+  # %{status} sostituito lato client.
+  server_error_retry: "Errore del server (%{status}) — riprova."
   internal: "Si è verificato un errore dalla nostra parte. Riprova; se il problema persiste, contatta il tuo amministratore."
   not_found: "Impossibile trovare ciò che cercavi — potrebbe essere stato spostato o eliminato."
   already_deleted_by_another_session: "Questo elemento è già stato eliminato da un'altra sessione — aggiorna la pagina per vedere lo stato attuale."
@@ -705,6 +709,10 @@ loan:
   return_modal_confirm: "Segna come restituito"
   not_found: "Prestito non trovato."
   col_action: Azione
+inline_form:
+  # Issue #403 — inviato al client tramite la data island #i18n-bundle
+  # e letto da static/js/inline-form.js (guardia dello slot modale unico).
+  modal_busy: "Chiudi la finestra di dialogo corrente prima di aprirne un'altra."
 session:
   expiry_soon: "La tua sessione sta per scadere."
   expiry_in_minutes: "La tua sessione scadrà tra %{minutes} min."

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -351,6 +351,16 @@ pub fn build_js_i18n_bundle(locale: &str) -> String {
             "expiry_in_minutes": rust_i18n::t!("session.expiry_in_minutes", locale = locale).to_string(),
             "stay_connected": rust_i18n::t!("session.stay_connected", locale = locale).to_string(),
             "dismiss_aria": rust_i18n::t!("session.dismiss_aria", locale = locale).to_string(),
+        },
+        // Issue #403 — the two modules that still carried hand-synced
+        // {en, fr} objects after the #386 PoC. `%{status}` is preserved
+        // verbatim for client-side substitution (same contract as
+        // `%{minutes}` above).
+        "inline_form": {
+            "modal_busy": rust_i18n::t!("inline_form.modal_busy", locale = locale).to_string(),
+        },
+        "errors": {
+            "server_error_retry": rust_i18n::t!("error.server_error_retry", locale = locale).to_string(),
         }
     });
     serde_json::to_string(&bundle)
@@ -738,6 +748,56 @@ mod tests {
             en_v["session"]["stay_connected"], de_v["session"]["stay_connected"],
             "de bundle must carry the German string, not the English fallback"
         );
+    }
+
+    // ─── #403 — i18n-bundle sweep (inline-form.js + mybibli.js) ───
+
+    #[test]
+    fn js_i18n_bundle_carries_403_sweep_keys() {
+        let json = build_js_i18n_bundle("en");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("bundle must be valid JSON");
+        assert!(
+            parsed["inline_form"]["modal_busy"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "inline_form.modal_busy must be a non-empty string in the bundle"
+        );
+        let retry = parsed["errors"]["server_error_retry"]
+            .as_str()
+            .expect("errors.server_error_retry must be a string");
+        assert!(!retry.is_empty());
+        // The parameterized string keeps its client-substituted placeholder.
+        assert!(
+            retry.contains("%{status}"),
+            "server_error_retry must preserve the %{{status}} placeholder for client-side substitution"
+        );
+    }
+
+    #[test]
+    fn js_i18n_bundle_403_keys_resolve_in_de_and_it() {
+        // de/it copy is the net-new content of #403 — prove both resolve
+        // to a translated string, not the English fallback or the raw key.
+        let en: serde_json::Value =
+            serde_json::from_str(&build_js_i18n_bundle("en")).unwrap();
+        for loc in ["de", "it"] {
+            let v: serde_json::Value =
+                serde_json::from_str(&build_js_i18n_bundle(loc)).unwrap();
+            for (a, b) in [
+                (&v["inline_form"]["modal_busy"], &en["inline_form"]["modal_busy"]),
+                (
+                    &v["errors"]["server_error_retry"],
+                    &en["errors"]["server_error_retry"],
+                ),
+            ] {
+                assert_ne!(a, b, "{loc} bundle must differ from en");
+                assert!(
+                    !a.as_str().unwrap().contains("inline_form.")
+                        && !a.as_str().unwrap().contains("error."),
+                    "{loc} value must not be a raw i18n key: {a}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/static/js/inline-form.js
+++ b/static/js/inline-form.js
@@ -25,15 +25,19 @@
     // `#admin-modal-slot` is a single global slot; opening modal B while A
     // is open silently destroyed A's state (incl. typed delete-confirmation
     // text). We block the second request at htmx:beforeRequest level and
-    // surface a localized feedback message. Localized strings follow the
-    // CLAUDE.md "read <html lang> and use embedded string map" idiom.
-    var MODAL_BUSY_MESSAGES = {
-        en: "Please close the current dialog before opening another.",
-        fr: "Veuillez fermer la fenêtre en cours avant d'en ouvrir une autre.",
-    };
+    // surface a localized feedback message. Issue #403 — the string comes
+    // from the server-rendered #i18n-bundle data island (resolved in the
+    // request locale, en/fr/de/it), replacing the hand-synced {en, fr}
+    // object that drifted from locales/*.yml. Degrades to "" if the data
+    // island is missing/malformed, same contract as session-timeout.js.
     function getModalBusyMessage() {
-        var lang = (document.documentElement.lang || "en").toLowerCase();
-        return MODAL_BUSY_MESSAGES[lang] || MODAL_BUSY_MESSAGES.en;
+        try {
+            var el = document.getElementById("i18n-bundle");
+            var bundle = el ? JSON.parse(el.textContent) : {};
+            return (bundle.inline_form || {}).modal_busy || "";
+        } catch (e) {
+            return "";
+        }
     }
     function modalSlotIsOccupied() {
         var slot = document.getElementById("admin-modal-slot");

--- a/static/js/mybibli.js
+++ b/static/js/mybibli.js
@@ -134,9 +134,19 @@
             if (target) target.classList.add("htmx-opacity-reset");
 
             var status = e.detail.xhr ? e.detail.xhr.status : "unknown";
-            var message = document.documentElement.lang === "fr"
-                ? "Erreur serveur (" + status + ") — veuillez réessayer."
-                : "Server error (" + status + ") — please try again.";
+            // Issue #403 — template comes from the #i18n-bundle data island
+            // (request locale, en/fr/de/it); %{status} substituted here.
+            // Degrades to "" if the island is missing, same contract as
+            // session-timeout.js.
+            var template = "";
+            try {
+                var bundleEl = document.getElementById("i18n-bundle");
+                var bundle = bundleEl ? JSON.parse(bundleEl.textContent) : {};
+                template = (bundle.errors || {}).server_error_retry || "";
+            } catch (err) {
+                template = "";
+            }
+            var message = template.replace("%{status}", String(status));
             injectErrorFeedback(message);
             restoreScanField();
         });

--- a/tests/e2e/specs/journeys/i18n-bundle-sweep.spec.ts
+++ b/tests/e2e/specs/journeys/i18n-bundle-sweep.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * #403 E2E — i18n-bundle sweep (inline-form.js + mybibli.js).
+ *
+ * The de/it copy is the net-new content of #403: the two strings that
+ * used to live as hand-synced {en, fr} objects in JS now come from the
+ * server-rendered #i18n-bundle data island, resolved in the request
+ * locale. Assert end-to-end (real browser, real locale negotiation)
+ * that the island carries localized, non-fallback values for all four
+ * locales — a regression here silently re-opens the de/it gap.
+ *
+ * Read-only spec (no DB writes) — parallel-safe.
+ */
+import { test, expect } from "@playwright/test";
+
+async function bundleFor(
+  browser: import("@playwright/test").Browser,
+  locale: string,
+): Promise<{ modalBusy: string; serverErrorRetry: string }> {
+  const ctx = await browser.newContext({ locale });
+  const page = await ctx.newPage();
+  await page.goto("/");
+  const raw = await page.locator("script#i18n-bundle").textContent();
+  await ctx.close();
+  expect(raw, `#i18n-bundle island must render for locale ${locale}`).toBeTruthy();
+  const parsed = JSON.parse(raw!);
+  return {
+    modalBusy: parsed?.inline_form?.modal_busy ?? "",
+    serverErrorRetry: parsed?.errors?.server_error_retry ?? "",
+  };
+}
+
+test.describe("#403 — i18n-bundle sweep keys", () => {
+  test("island carries the two #403 strings localized in en/fr/de/it", async ({
+    browser,
+  }) => {
+    const en = await bundleFor(browser, "en-US");
+
+    // Baseline: non-empty EN values, %{status} preserved for client-side
+    // substitution (mybibli.js replaces it with the real HTTP status).
+    expect(en.modalBusy.length).toBeGreaterThan(0);
+    expect(en.serverErrorRetry).toContain("%{status}");
+
+    for (const locale of ["fr", "de", "it"]) {
+      const v = await bundleFor(browser, locale);
+      expect(v.modalBusy.length, `${locale} modal_busy`).toBeGreaterThan(0);
+      expect(v.serverErrorRetry, `${locale} server_error_retry`).toContain(
+        "%{status}",
+      );
+      // Translated copy, not the EN fallback — the exact gap #403 closes.
+      expect(v.modalBusy, `${locale} modal_busy must differ from en`).not.toBe(
+        en.modalBusy,
+      );
+      expect(
+        v.serverErrorRetry,
+        `${locale} server_error_retry must differ from en`,
+      ).not.toBe(en.serverErrorRetry);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Sole scope of **v1.9.1** (planning decision recorded on #403). Completes the #386 follow-up: the last two JS modules carrying hand-synced `{en, fr}` i18n objects now read the server-rendered `#i18n-bundle` data island, so both strings localize in de/it for the first time.

- `static/js/inline-form.js` — modal-busy guard message → `bundle.inline_form.modal_busy`
- `static/js/mybibli.js` — htmx:responseError feedback → `bundle.errors.server_error_retry` (`%{status}` substituted client-side, same contract as `%{minutes}` in the #386 PoC)
- `utils::build_js_i18n_bundle()` extended with the two subtrees; keys added to **all four** locales (de/it copy is the net-new content #386 deferred)
- Degradation contract matches session-timeout.js: missing/malformed island → empty string, never a throw

## Tests

- Unit: bundle carries both keys, `%{status}` preserved, de/it resolve to translated (non-fallback, non-raw-key) copy — utils suite 34/34
- `cargo test --test locale_parity` green (the 4-file gate)
- New E2E `i18n-bundle-sweep.spec.ts`: real-browser locale negotiation for en/fr/de/it, asserts the island carries localized values
- Full local suite at `CI=true --workers=2`: 290 passed / 0 failed; clippy clean; tsc clean

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)