### PR TITLE
fix(#418): persistent session cookie + admin-configurable inactivity timeout

### DIFF
--- a/docs/auth-threat-model.md
+++ b/docs/auth-threat-model.md
@@ -81,6 +81,7 @@ An attacker gains LAN access (e.g., compromised guest device) and tries to escal
 | **CSRF synchronizer token** on every state-changing method | `src/middleware/csrf.rs` | `src/templates_audit.rs::forms_include_csrf_token` (every `<form method="POST">` in Askama templates carries `_csrf_token`); `csrf_exempt_routes_frozen` (allowlist is `[("POST", "/login")]` and nothing else) |
 | **SameSite=Lax** session cookie | `src/middleware/auth.rs` | Unit test on cookie attributes; rationale in CLAUDE.md (downgraded from Strict in 7-3 so the language-toggle POST works) |
 | **HttpOnly** session cookie | `src/middleware/auth.rs` | Same |
+| **Server-authoritative session expiry** — the cookie's `Max-Age` (issue #418, see § 5.5) is a browser-retention hint only; expiry is enforced by `SessionModel::is_expired` on `sessions.last_activity` | `src/middleware/auth.rs::resolve_or_mint` | `tests/session_cookie_collision.rs` (cookie attributes + rolling refresh) |
 | **Session rotation on login** — pre-login session token is invalidated, a fresh row is issued | `src/services/auth::authenticate_session` | Unit test in `services/auth.rs` |
 | **Last-active-admin guard** — refuses to deactivate the last admin or self-deactivate the current session's user | `src/services/users.rs` | Unit + DB-integration tests; defense against admin lockout via UI |
 | **Scanner-guard** — captures `keydown` while a modal is open to prevent USB scanner bursts from leaking into the modal's default-focused button | `static/js/scanner-guard.js` | Documented as story-7-5 invariant; no specific unit test (browser-side) |
@@ -123,7 +124,15 @@ The only ownership-style guard is the **self-deactivate** + **last-active-admin*
 
 Login throttling is delegated to the operator's reverse proxy (or absent if the proxy is also absent). Rationale: brute-forcing argon2id with `m=19456, t=2, p=1` parameters is computationally prohibitive at NAS-scale traffic; adding a token-bucket in Axum middleware would add complexity for marginal benefit and risk locking out the legitimate single user.
 
-### 5.5 No CSRF on `POST /login`
+### 5.5 Persistent (Max-Age) authenticated session cookie
+
+Since issue #418 the authenticated session cookie carries `Max-Age` equal to the configured inactivity timeout (`session_inactivity_timeout_hours`, default 4 h, admin-editable in `/admin?tab=system`), re-issued on every authenticated response (rolling window). Before #418 it was a pure session cookie (no `Max-Age`), and iPadOS Safari discards those on screen-lock — the reference operator was logged out between two barcode-scanning batches while the server-side session was still fresh.
+
+Accepted trade-off: a persistent cookie survives browser restarts within the timeout window, so a shared/stolen device stays signed in slightly longer than a pure session cookie would allow. This is acceptable for the single-tenant LAN shape because (a) the server remains authoritative — `SessionModel::is_expired` checks `sessions.last_activity` on every request, and an admin-side deactivation or timeout reduction takes effect on the next request regardless of what the browser holds; (b) the pure-session-cookie behavior it replaces was itself inconsistent across browsers (desktop browsers with "restore tabs" resurrect session cookies anyway); (c) the timeout ceiling is clamped to 720 h by `validate_session_timeout_hours`.
+
+Anonymous-session cookies are unaffected: they keep their fixed 7-day `Max-Age` aligned with the anonymous purge window (story 8-2) and do NOT roll.
+
+### 5.6 No CSRF on `POST /login`
 
 `POST /login` is the *only* member of the `CSRF_EXEMPT_ROUTES` allowlist. The freeze is policed by `csrf_exempt_routes_frozen`. Rationale: a pre-auth user has no session row yet, hence no token to validate; the login form is the bootstrap surface for the token chain. The token is rotated immediately on successful authentication.
 
@@ -148,7 +157,7 @@ A PR that touches any of the following must:
 
 - `src/middleware/auth.rs` or `csrf.rs` — re-read § 3 and § 4 of this doc and update if the threat surface changes
 - `src/services/auth.rs` — update § 4 row "Session rotation on login" if behavior shifts
-- The `CSRF_EXEMPT_ROUTES` constant — update § 5.5 with the new entry's rationale
+- The `CSRF_EXEMPT_ROUTES` constant — update § 5.6 with the new entry's rationale
 - The cookie attribute set in `auth.rs` or `csrf.rs` — update § 5.1 / § 5.2 if the default changes
 - The CSP header in `csrf.rs::csp` — update § 4 "Strict CSP" row
 

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -434,6 +434,7 @@ error:
     default_currency_invalid: "Die Standardwährung muss ein 3-Buchstaben-Code nach ISO 4217 sein (z. B. CHF, EUR)."
     log_level_invalid: "Die Protokollebene muss eine einfache Ebene (trace/debug/info/warn/error) oder eine Liste von tracing-subscriber EnvFilter-Direktiven sein (z. B. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Die Zeitüberschreitung muss zwischen 1 und 60 Sekunden liegen."
+    session_timeout_invalid: "Das Sitzungs-Zeitlimit muss zwischen 1 und 720 Stunden liegen."
     version_mismatch: "Die Einstellungen wurden durch einen anderen Administrator geändert — neu laden und erneut versuchen"
     provider_version_mismatch: "%{provider} wurde durch einen anderen Administrator geändert — neu laden und erneut versuchen"
   code:
@@ -922,6 +923,11 @@ admin:
     log_level_label: "Protokollebene"
     log_level_help: "Akzeptiert eine einfache Ebene (trace / debug / info / warn / error) oder eine Liste von tracing-subscriber EnvFilter-Direktiven (z. B. mybibli=debug,sqlx::query=warn). Sofort wirksam — kein Neustart. Standardmäßig „info“, produktionssicher."
     btn_save_log_level: "Protokollierungseinstellungen speichern"
+    # Issue #418 — Schlüssel des Abschnitts Sitzungen.
+    section_sessions: Sitzungen
+    session_timeout_label: "Inaktivitäts-Zeitlimit der Sitzung (Stunden)"
+    session_timeout_help: "Wie lange eine angemeldete Sitzung ohne Aktivität bestehen bleibt, von 1 Stunde bis 720 (30 Tage). Bestimmt auch die Lebensdauer des Sitzungs-Cookies im Browser. Wirksam ab der nächsten Anfrage — bereits offene Sitzungen werden nicht rückwirkend beendet. Standard: 4 Stunden."
+    btn_save_sessions: "Sitzungseinstellungen speichern"
     # v1.7.9 fix #334 — Metadata-Chain + Provider-Health Zeitüberschreitungen.
     metadata_chain_timeout_label: "Zeitüberschreitung pro Metadaten-Anbieter (Sekunden)"
     metadata_chain_timeout_help: "Maximale Wartezeit für einen Anbieter, bevor die Kette zum nächsten übergeht. Standard 5. Erhöhen Sie den Wert, wenn DNS oder TLS langsam sind (ländliches Glasfasernetz, VPN, Satellit). Grenzen 1–60. Beim nächsten Scan wirksam — kein Neustart."
@@ -1020,6 +1026,7 @@ success:
     log_level_saved: "Protokollebene gespeichert — sofort wirksam, kein Neustart erforderlich"
     timeouts_saved: "Zeitüberschreitungen gespeichert — beim nächsten Scan / Ping wirksam, kein Neustart erforderlich"
     provider_timeouts_saved: "Zeitüberschreitungen pro Anbieter gespeichert — beim nächsten Scan wirksam, kein Neustart erforderlich"
+    sessions_saved: "Sitzungseinstellungen gespeichert — ab der nächsten Anfrage wirksam, kein Neustart erforderlich"
     no_changes: "Keine Änderungen"
     provider_set: "%{provider}-Schlüssel gespeichert"
     provider_cleared: "%{provider}-Schlüssel gelöscht"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -441,6 +441,7 @@ error:
     default_currency_invalid: "Default currency must be a 3-letter ISO 4217 code (e.g. CHF, EUR)."
     log_level_invalid: "Log level must be a plain level (trace/debug/info/warn/error) or a tracing-subscriber EnvFilter directive list (e.g. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Timeout must be between 1 and 60 seconds."
+    session_timeout_invalid: "Session timeout must be between 1 and 720 hours."
     version_mismatch: "Settings were modified by another admin — reload and retry"
     provider_version_mismatch: "%{provider} was modified by another admin — reload and retry"
   code:
@@ -936,6 +937,11 @@ admin:
     log_level_label: "Log level"
     log_level_help: "Accepts a plain level (trace / debug / info / warn / error) or a tracing-subscriber EnvFilter directive list (e.g. mybibli=debug,sqlx::query=warn). Applied immediately — no redeploy. Default 'info' is production-safe."
     btn_save_log_level: "Save logging settings"
+    # Issue #418 — Sessions section keys.
+    section_sessions: Sessions
+    session_timeout_label: "Session inactivity timeout (hours)"
+    session_timeout_help: "How long a signed-in session stays alive without activity, from 1 hour to 720 (30 days). Also sets the lifetime of the session cookie in the browser. Applied on the next request — already open sessions are not cut off retroactively. Default: 4 hours."
+    btn_save_sessions: "Save session settings"
     # v1.7.9 fix #334 — Metadata-chain + provider-health timeouts.
     metadata_chain_timeout_label: "Per-provider metadata timeout (seconds)"
     metadata_chain_timeout_help: "Maximum time the chain waits for one provider before falling through to the next. Default 5. Raise if your DNS or TLS handshake is slow (rural fiber, VPN, satellite). Bounded 1–60. Applied on the next scan — no restart."
@@ -1034,6 +1040,7 @@ success:
     log_level_saved: "Log level saved — applied immediately, no restart required"
     timeouts_saved: "Timeouts saved — applied on the next chain run / ping round, no restart required"
     provider_timeouts_saved: "Per-provider timeouts saved — applied on the next chain run, no restart required"
+    sessions_saved: "Session settings saved — applied on the next request, no restart required"
     no_changes: "No changes"
     provider_set: "%{provider} key saved"
     provider_cleared: "%{provider} key cleared"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -436,6 +436,7 @@ error:
     default_currency_invalid: "La devise par défaut doit être un code ISO 4217 à 3 lettres (ex. CHF, EUR)."
     log_level_invalid: "Le niveau doit être un niveau simple (trace/debug/info/warn/error) ou une liste de directives tracing-subscriber EnvFilter (ex. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Le délai doit être compris entre 1 et 60 secondes."
+    session_timeout_invalid: "Le délai de session doit être compris entre 1 et 720 heures."
     version_mismatch: "Les paramètres ont été modifiés par un autre administrateur — rechargez et réessayez"
     provider_version_mismatch: "%{provider} a été modifié par un autre administrateur — rechargez et réessayez"
   code:
@@ -931,6 +932,11 @@ admin:
     log_level_label: "Niveau de journalisation"
     log_level_help: "Accepte un niveau simple (trace / debug / info / warn / error) ou une liste de directives tracing-subscriber EnvFilter (ex. mybibli=debug,sqlx::query=warn). Appliqué immédiatement — pas de redémarrage. Par défaut « info », sûr en production."
     btn_save_log_level: "Enregistrer la journalisation"
+    # Issue #418 — clés de la section Sessions.
+    section_sessions: Sessions
+    session_timeout_label: "Délai d'inactivité de session (heures)"
+    session_timeout_help: "Durée pendant laquelle une session connectée reste active sans activité, de 1 heure à 720 (30 jours). Définit aussi la durée de vie du cookie de session dans le navigateur. Appliqué à la prochaine requête — les sessions déjà ouvertes ne sont pas coupées rétroactivement. Par défaut : 4 heures."
+    btn_save_sessions: "Enregistrer les préférences de session"
     # v1.7.9 fix #334 — Délais d'attente metadata-chain + provider-health.
     metadata_chain_timeout_label: "Délai d'attente par fournisseur de métadonnées (secondes)"
     metadata_chain_timeout_help: "Temps maximal d'attente d'un fournisseur avant de passer au suivant dans la chaîne. Par défaut 5. Augmentez si votre DNS ou TLS est lent (fibre rurale, VPN, satellite). Bornes 1–60. Appliqué au prochain scan — sans redémarrage."
@@ -1029,6 +1035,7 @@ success:
     log_level_saved: "Niveau de journalisation enregistré — appliqué immédiatement, pas de redémarrage requis"
     timeouts_saved: "Délais d'attente enregistrés — appliqués au prochain scan / tour de ping, pas de redémarrage requis"
     provider_timeouts_saved: "Délais par fournisseur enregistrés — appliqués au prochain scan, pas de redémarrage requis"
+    sessions_saved: "Préférences de session enregistrées — appliquées à la prochaine requête, pas de redémarrage requis"
     no_changes: "Aucune modification"
     provider_set: "Clé %{provider} enregistrée"
     provider_cleared: "Clé %{provider} effacée"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -428,6 +428,7 @@ error:
     default_currency_invalid: "La valuta predefinita deve essere un codice ISO 4217 a 3 lettere (es. CHF, EUR)."
     log_level_invalid: "Il livello di log deve essere un livello semplice (trace/debug/info/warn/error) o un elenco di direttive tracing-subscriber EnvFilter (es. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Il timeout deve essere compreso tra 1 e 60 secondi."
+    session_timeout_invalid: "Il timeout di sessione deve essere compreso tra 1 e 720 ore."
     version_mismatch: "Le impostazioni sono state modificate da un altro amministratore — ricarica e riprova"
     provider_version_mismatch: "%{provider} è stato modificato da un altro amministratore — ricarica e riprova"
   code:
@@ -909,6 +910,11 @@ admin:
     log_level_label: "Livello di log"
     log_level_help: "Accetta un livello semplice (trace / debug / info / warn / error) o un elenco di direttive tracing-subscriber EnvFilter (es. mybibli=debug,sqlx::query=warn). Applicato immediatamente — nessun riavvio. Predefinito «info», sicuro per la produzione."
     btn_save_log_level: "Salva impostazioni di registrazione"
+    # Issue #418 — chiavi della sezione Sessioni.
+    section_sessions: Sessioni
+    session_timeout_label: "Timeout di inattività della sessione (ore)"
+    session_timeout_help: "Per quanto tempo una sessione connessa resta attiva senza attività, da 1 ora a 720 (30 giorni). Definisce anche la durata del cookie di sessione nel browser. Applicato alla prossima richiesta — le sessioni già aperte non vengono chiuse retroattivamente. Predefinito: 4 ore."
+    btn_save_sessions: "Salva impostazioni di sessione"
     # v1.7.9 fix #334 — timeout metadata-chain + provider-health.
     metadata_chain_timeout_label: "Timeout per fornitore di metadati (secondi)"
     metadata_chain_timeout_help: "Tempo massimo di attesa per un fornitore prima che la catena passi al successivo. Predefinito 5. Aumenta se DNS o TLS sono lenti (fibra rurale, VPN, satellite). Intervallo 1–60. Applicato alla prossima scansione — nessun riavvio."
@@ -1006,6 +1012,7 @@ success:
     log_level_saved: "Livello di log salvato — applicato immediatamente, nessun riavvio richiesto"
     timeouts_saved: "Timeout salvati — applicati alla prossima scansione / giro di ping, nessun riavvio richiesto"
     provider_timeouts_saved: "Timeout per fornitore salvati — applicati alla prossima scansione, nessun riavvio richiesto"
+    sessions_saved: "Impostazioni di sessione salvate — applicate alla prossima richiesta, nessun riavvio richiesto"
     no_changes: "Nessuna modifica"
     provider_set: "Chiave %{provider} salvata"
     provider_cleared: "Chiave %{provider} cancellata"

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -135,6 +135,51 @@ pub(crate) fn should_skip_session_resolve(uri_path: &str) -> bool {
         || path.starts_with("/logo/")
 }
 
+/// Build the authenticated-session cookie. Shared by the login handler
+/// (`routes/auth.rs::login`), the setup wizard's Step 1
+/// (`routes/setup.rs::step_1_submit`), and the rolling refresh in
+/// `session_resolve_middleware`.
+///
+/// Issue #418: the cookie carries `Max-Age` aligned with the configured
+/// inactivity timeout. Before the fix it was a pure session cookie (no
+/// `Max-Age`), which iPadOS Safari discards on screen-lock — the
+/// librarian was logged out between two scanning batches even though
+/// the server-side session was still fresh. The server stays
+/// authoritative (`SessionModel::is_expired` on `last_activity`); the
+/// `Max-Age` only stops the browser from evaporating the cookie early.
+/// Each authenticated response re-issues the cookie (rolling window),
+/// mirroring the server-side sliding `last_activity` semantics.
+pub fn authenticated_session_cookie(token: String, timeout_secs: u64) -> Cookie<'static> {
+    Cookie::build(("session", token))
+        .http_only(true)
+        .path("/")
+        .same_site(SameSite::Lax)
+        .max_age(time::Duration::seconds(
+            timeout_secs.min(i64::MAX as u64) as i64
+        ))
+        .secure(crate::config::cookie_secure())
+        .build()
+}
+
+/// Issue #81 guard, shared by the anonymous-mint and rolling-refresh
+/// branches of `session_resolve_middleware`: true when the handler
+/// already emitted a `session=` Set-Cookie via its own CookieJar
+/// (login, logout, setup step 1, …). Without this guard the
+/// middleware's cookie lands AFTER the handler's in the response, and
+/// clients (per RFC 6265 §5.4 "later cookie wins for same
+/// name/domain/path") pick up the wrong one.
+fn handler_set_session_cookie(response: &Response) -> bool {
+    response
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .any(|v| {
+            v.to_str()
+                .map(|s| s.starts_with("session=") || s.starts_with("session ="))
+                .unwrap_or(false)
+        })
+}
+
 pub async fn session_resolve_middleware(
     State(state): State<AppState>,
     mut request: Request,
@@ -161,30 +206,28 @@ pub async fn session_resolve_middleware(
         .as_ref()
         .map(|_| session.csrf_token.clone());
 
+    // Issue #418 — rolling cookie refresh: when the request resolved to
+    // an existing AUTHENTICATED session (no mint), re-issue the session
+    // cookie with a fresh `Max-Age` so the browser-side lifetime slides
+    // alongside the server-side `last_activity` window. Captured before
+    // the session moves into request extensions.
+    let refresh_cookie_token = if new_cookie_token.is_none() && session.user_id.is_some() {
+        session.token.clone()
+    } else {
+        None
+    };
+
     request.extensions_mut().insert(session);
     let mut response = next.run(request).await;
 
     if let Some(new_token) = new_cookie_token {
         // Issue #81 fix: skip the anonymous cookie append if the handler
         // already emitted a `session=` Set-Cookie via its own CookieJar
-        // (login, logout, etc.). Without this guard the middleware's anon
-        // cookie lands AFTER the handler's auth cookie in the response,
-        // and clients (browsers + curl, per RFC 6265 §5.4 "later cookie
-        // wins for same name/domain/path") pick up the anon one — pointing
-        // at a session row the login handler just soft-deleted, so every
-        // subsequent request resolves as anonymous and authentication
-        // appears to silently fail.
-        let handler_already_set_session_cookie = response
-            .headers()
-            .get_all(axum::http::header::SET_COOKIE)
-            .iter()
-            .any(|v| {
-                v.to_str()
-                    .map(|s| s.starts_with("session=") || s.starts_with("session ="))
-                    .unwrap_or(false)
-            });
-
-        if !handler_already_set_session_cookie {
+        // (login, logout, etc.) — see `handler_set_session_cookie`. The
+        // anon cookie would otherwise point at a session row the login
+        // handler just soft-deleted, so every subsequent request would
+        // resolve as anonymous and authentication would silently fail.
+        if !handler_set_session_cookie(&response) {
             // Match cookie lifetime to the 7-day anonymous-purge window so
             // the browser discards a cookie whose DB row the purge task
             // will have deleted. Without Max-Age the cookie persists until
@@ -232,6 +275,21 @@ pub async fn session_resolve_middleware(
                     token_header,
                 );
             }
+        }
+    } else if let Some(token) = refresh_cookie_token
+        && !handler_set_session_cookie(&response)
+    {
+        // Issue #418 — rolling refresh of the authenticated cookie.
+        // Same #81 guard as the mint branch: login/logout/setup already
+        // emit their own `session=` cookie and must win. `.encoded()`
+        // (not `.to_string()`) so the value is byte-identical to what
+        // the login handler's CookieJar emitted — base64 tokens carry
+        // `/` and `=`, which the jar percent-encodes.
+        let cookie = authenticated_session_cookie(token, timeout_secs);
+        if let Ok(value) = cookie.encoded().to_string().parse() {
+            response
+                .headers_mut()
+                .append(axum::http::header::SET_COOKIE, value);
         }
     }
 

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -257,15 +257,12 @@ impl TitleModel {
                 let issn: Option<String> = r.try_get("issn").ok().flatten();
                 let upc: Option<String> = r.try_get("upc").ok().flatten();
                 let media_type: String = r.try_get("media_type").ok()?;
-                let (code, code_type) = if let Some(c) = isbn {
-                    (c, crate::models::media_type::CodeType::Isbn)
-                } else if let Some(c) = upc {
-                    (c, crate::models::media_type::CodeType::Upc)
-                } else if let Some(c) = issn {
-                    (c, crate::models::media_type::CodeType::Issn)
-                } else {
-                    return None;
-                };
+                // Priority order: ISBN first (best provider coverage),
+                // then UPC, then ISSN.
+                let (code, code_type) = isbn
+                    .map(|c| (c, crate::models::media_type::CodeType::Isbn))
+                    .or_else(|| upc.map(|c| (c, crate::models::media_type::CodeType::Upc)))
+                    .or_else(|| issn.map(|c| (c, crate::models::media_type::CodeType::Issn)))?;
                 Some(MissingCoverTitle {
                     id,
                     code,

--- a/src/routes/admin_system.rs
+++ b/src/routes/admin_system.rs
@@ -36,9 +36,10 @@ use crate::utils::feedback_html;
 use crate::services::admin_system::{
     KEY_DEFAULT_CURRENCY, KEY_DEFAULT_LANGUAGE, KEY_GOOGLE_BOOKS, KEY_LOG_LEVEL,
     KEY_METADATA_CHAIN_TIMEOUT, KEY_OMDB, KEY_OVERDUE_THRESHOLD, KEY_PROVIDER_HEALTH_TIMEOUT,
-    KEY_SHOW_VALUE_INDICATORS, KEY_TMDB, PROVIDER_TIMEOUT_KEY_PREFIX, provider_timeout_key,
-    reload_settings_cache, save_setting, validate_default_currency, validate_default_language,
-    validate_log_level, validate_overdue_threshold, validate_provider_timeout_secs,
+    KEY_SESSION_TIMEOUT_HOURS, KEY_SHOW_VALUE_INDICATORS, KEY_TMDB, PROVIDER_TIMEOUT_KEY_PREFIX,
+    provider_timeout_key, reload_settings_cache, save_setting, validate_default_currency,
+    validate_default_language, validate_log_level, validate_overdue_threshold,
+    validate_provider_timeout_secs, validate_session_timeout_hours,
 };
 
 // ─── Form structs ─────────────────────────────────────────────────
@@ -116,6 +117,16 @@ pub struct MetadataTimeoutsForm {
     pub _csrf_token: String,
 }
 
+// Issue #418 — Sessions section. Single setting: the inactivity
+// timeout in hours. Drives both the server-side expiry check and the
+// authenticated cookie's Max-Age.
+#[derive(Deserialize)]
+pub struct SessionsSettingsForm {
+    pub session_timeout_hours: u64,
+    pub session_timeout_version: i32,
+    pub _csrf_token: String,
+}
+
 // ─── Template structs ────────────────────────────────────────────
 
 #[derive(Template)]
@@ -127,6 +138,7 @@ pub(crate) struct AdminSystemPanel {
     pub section_language: String,
     pub section_valuation: String,
     pub section_logging: String,
+    pub section_sessions: String,
     pub loans_form_html: String,
     pub providers_form_html: String,
     pub timeouts_form_html: String,
@@ -134,6 +146,7 @@ pub(crate) struct AdminSystemPanel {
     pub language_form_html: String,
     pub valuation_form_html: String,
     pub log_form_html: String,
+    pub sessions_form_html: String,
 }
 
 #[derive(Template)]
@@ -188,6 +201,21 @@ struct AdminSystemLogForm {
     log_level_help: String,
     log_level_value: String,
     log_level_version: i32,
+    btn_save: String,
+}
+
+// Issue #418 — Sessions form. Single integer input (hours) for the
+// inactivity timeout.
+#[derive(Template)]
+#[template(path = "fragments/admin_system_sessions_form.html")]
+struct AdminSystemSessionsForm {
+    csrf_token: String,
+    session_timeout_label: String,
+    session_timeout_help: String,
+    session_timeout_value: u64,
+    session_timeout_version: i32,
+    timeout_hours_min: u64,
+    timeout_hours_max: u64,
     btn_save: String,
 }
 
@@ -305,7 +333,7 @@ async fn fetch_setting_rows(
 ) -> Result<HashMap<String, (String, i32)>, AppError> {
     let rows: Vec<(String, String, i32)> = sqlx::query_as(
         "SELECT setting_key, setting_value, version FROM settings \
-         WHERE setting_key IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND deleted_at IS NULL",
+         WHERE setting_key IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND deleted_at IS NULL",
     )
     .bind(KEY_OVERDUE_THRESHOLD)
     .bind(KEY_DEFAULT_LANGUAGE)
@@ -317,6 +345,7 @@ async fn fetch_setting_rows(
     .bind(KEY_LOG_LEVEL)
     .bind(KEY_METADATA_CHAIN_TIMEOUT)
     .bind(KEY_PROVIDER_HEALTH_TIMEOUT)
+    .bind(KEY_SESSION_TIMEOUT_HOURS)
     .fetch_all(pool)
     .await?;
     let mut map = HashMap::new();
@@ -590,6 +619,30 @@ fn render_provider_timeouts_form(
     .map_err(|_| AppError::Internal("provider timeouts form render failed".to_string()))
 }
 
+// Issue #418 — Sessions form renderer.
+fn render_sessions_form(
+    csrf: &str,
+    loc: &'static str,
+    timeout_hours: u64,
+    version: i32,
+) -> Result<String, AppError> {
+    use crate::services::admin_system::{SESSION_TIMEOUT_HOURS_MAX, SESSION_TIMEOUT_HOURS_MIN};
+    AdminSystemSessionsForm {
+        csrf_token: csrf.to_string(),
+        session_timeout_label: rust_i18n::t!("admin.system.session_timeout_label", locale = loc)
+            .to_string(),
+        session_timeout_help: rust_i18n::t!("admin.system.session_timeout_help", locale = loc)
+            .to_string(),
+        session_timeout_value: timeout_hours,
+        session_timeout_version: version,
+        timeout_hours_min: SESSION_TIMEOUT_HOURS_MIN,
+        timeout_hours_max: SESSION_TIMEOUT_HOURS_MAX,
+        btn_save: rust_i18n::t!("admin.system.btn_save_sessions", locale = loc).to_string(),
+    }
+    .render()
+    .map_err(|_| AppError::Internal("sessions form render failed".to_string()))
+}
+
 // v1.7.1 fix #308 — Logging form renderer.
 fn render_log_form(
     csrf: &str,
@@ -671,6 +724,16 @@ pub async fn render_panel_html(
         .cloned()
         .unwrap_or_else(|| (probe_timeout.to_string(), 1));
 
+    // Issue #418 — session timeout row. The form edits the HOURS key
+    // directly (the E2E-only `session_inactivity_timeout_seconds`
+    // override is deliberately not surfaced), so read the row value
+    // rather than deriving from the cached seconds.
+    let (session_timeout_value, session_timeout_version) = rows
+        .get(KEY_SESSION_TIMEOUT_HOURS)
+        .cloned()
+        .unwrap_or_else(|| ("4".to_string(), 1));
+    let session_timeout_hours = session_timeout_value.parse::<u64>().unwrap_or(4);
+
     let csrf = session.csrf_token.as_str();
     let loans_form_html = render_loans_form(csrf, loc, threshold, threshold_version)?;
     let providers_form_html = render_providers_form(csrf, loc, &rows)?;
@@ -700,6 +763,8 @@ pub async fn render_panel_html(
         indicators_version,
     )?;
     let log_form_html = render_log_form(csrf, loc, &log_level, log_level_version)?;
+    let sessions_form_html =
+        render_sessions_form(csrf, loc, session_timeout_hours, session_timeout_version)?;
 
     AdminSystemPanel {
         panel_heading: rust_i18n::t!("admin.system.panel_heading", locale = loc).to_string(),
@@ -710,6 +775,7 @@ pub async fn render_panel_html(
         section_valuation: rust_i18n::t!("admin.system.section_valuation", locale = loc)
             .to_string(),
         section_logging: rust_i18n::t!("admin.system.section_logging", locale = loc).to_string(),
+        section_sessions: rust_i18n::t!("admin.system.section_sessions", locale = loc).to_string(),
         loans_form_html,
         providers_form_html,
         timeouts_form_html,
@@ -717,6 +783,7 @@ pub async fn render_panel_html(
         language_form_html,
         valuation_form_html,
         log_form_html,
+        sessions_form_html,
     }
     .render()
     .map_err(|_| AppError::Internal("admin system panel render failed".to_string()))
@@ -814,6 +881,69 @@ pub async fn save_loans_settings(
     Ok(HtmxResponse {
         main,
         oob: vec![OobUpdate { swap_mode: Default::default(),
+            target: "feedback-list".to_string(),
+            content: feedback,
+        }],
+    }
+    .into_response())
+}
+
+// Issue #418 — Sessions save handler. Same shape as
+// `save_loans_settings`: validate → optimistic-lock UPDATE → cache
+// reload → re-render form + OOB success FeedbackEntry. Takes effect on
+// the very next request: the resolver middleware reads
+// `state.session_timeout_secs()` per request for both the expiry check
+// and the rolling cookie Max-Age.
+pub async fn save_sessions_settings(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+    Form(form): Form<SessionsSettingsForm>,
+) -> Result<Response, AppError> {
+    session.require_role_with_return(Role::Admin, "/admin?tab=system", locale.0)?;
+    let loc = locale.0;
+
+    if let Err(e) = validate_session_timeout_hours(form.session_timeout_hours, loc) {
+        let error_msg = match e {
+            AppError::BadRequest(msg) => msg,
+            other => return Err(other),
+        };
+        return Ok(validation_error_response(
+            render_sessions_form(
+                &session.csrf_token,
+                loc,
+                form.session_timeout_hours,
+                form.session_timeout_version,
+            )?,
+            error_msg,
+        ));
+    }
+
+    save_setting(
+        &state.pool,
+        KEY_SESSION_TIMEOUT_HOURS,
+        &form.session_timeout_hours.to_string(),
+        form.session_timeout_version,
+    )
+    .await?;
+    reload_settings_cache(&state).await?;
+
+    let rows = fetch_setting_rows(&state.pool).await?;
+    let (_, version) = rows
+        .get(KEY_SESSION_TIMEOUT_HOURS)
+        .cloned()
+        .unwrap_or_else(|| (form.session_timeout_hours.to_string(), 2));
+    let main = render_sessions_form(
+        &session.csrf_token,
+        loc,
+        form.session_timeout_hours,
+        version,
+    )?;
+    let feedback = success_feedback(loc, "success.system.sessions_saved");
+    Ok(HtmxResponse {
+        main,
+        oob: vec![OobUpdate {
+            swap_mode: Default::default(),
             target: "feedback-list".to_string(),
             content: feedback,
         }],

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -175,13 +175,15 @@ pub async fn login(
 
     tracing::info!(username = %username, role = %role, "Login successful");
 
-    // Set session cookie
-    let session_cookie = Cookie::build(("session", token))
-        .http_only(true)
-        .path("/")
-        .same_site(SameSite::Lax)
-        .secure(crate::config::cookie_secure())
-        .build();
+    // Set session cookie. Issue #418: carries Max-Age aligned with the
+    // configured inactivity timeout (rolling-refreshed by the resolver
+    // middleware on every authenticated request) so mobile browsers —
+    // iPadOS Safari discards pure session cookies on screen-lock —
+    // keep the session alive across scanning batches.
+    let session_cookie = crate::middleware::auth::authenticated_session_cookie(
+        token,
+        state.session_timeout_secs(),
+    );
 
     // Honor ?next= if safe and same-origin, else default to /catalog.
     let redirect_target = if is_safe_next(&form.next) {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -584,6 +584,13 @@ pub fn build_router(state: AppState) -> Router {
             "/admin/system/provider-timeouts",
             axum::routing::post(admin_system::save_provider_timeouts),
         )
+        // Issue #418 — Sessions section save endpoint (inactivity
+        // timeout, hours). Hot-reloads: the resolver middleware reads
+        // the cached value per request for expiry + cookie Max-Age.
+        .route(
+            "/admin/system/sessions",
+            axum::routing::post(admin_system::save_sessions_settings),
+        )
         // CR #241 — Admin → API keys (v1.4.0). 4 routes: 1 GET panel +
         // 1 POST create + 1 GET revoke-modal + 1 POST revoke. All
         // Admin-gated. CSRF-protected via the 8-2 middleware.

--- a/src/routes/setup.rs
+++ b/src/routes/setup.rs
@@ -28,7 +28,7 @@ use axum::Extension;
 use axum::extract::{Form, State};
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Redirect, Response};
-use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use axum_extra::extract::cookie::{Cookie, CookieJar};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -878,16 +878,14 @@ pub async fn step_1_submit(
     let (new_token, _csrf) = authenticate_session(&state.pool, new_user_id, prev).await?;
 
     // Match the login flow's authenticated-session cookie semantics
-    // (`routes/auth.rs::login`): no Max-Age ⇒ session cookie that expires
-    // when the browser closes. Anonymous-session cookies get 7 days
-    // (`session_resolve_middleware`); authenticated sessions do NOT.
-    // Story 8-8 review P5.
-    let cookie = Cookie::build(("session", new_token))
-        .http_only(true)
-        .path("/")
-        .same_site(SameSite::Lax)
-        .secure(crate::config::cookie_secure())
-        .build();
+    // (`routes/auth.rs::login`): Max-Age aligned with the configured
+    // inactivity timeout (issue #418 — was a pure session cookie until
+    // then; story 8-8 review P5 documented the old shape). Anonymous
+    // cookies keep their own 7-day window in `session_resolve_middleware`.
+    let cookie = crate::middleware::auth::authenticated_session_cookie(
+        new_token,
+        state.session_timeout_secs(),
+    );
     let jar = jar.add(cookie);
 
     refresh_gate(&state.setup_gate, &state.pool).await;

--- a/src/services/admin_system.rs
+++ b/src/services/admin_system.rs
@@ -80,6 +80,33 @@ pub fn validate_provider_timeout_secs(value: u64, loc: &'static str) -> Result<(
     }
 }
 
+// Issue #418 — admin-configurable session inactivity timeout. The row
+// (seeded by the initial-schema migration, default '4') was already
+// parsed by `AppSettings::load_from_db` into `session_timeout_secs`;
+// this surfaces it in /admin > System. Also drives the authenticated
+// session cookie's `Max-Age` (`middleware::auth::authenticated_session_cookie`).
+pub const KEY_SESSION_TIMEOUT_HOURS: &str = "session_inactivity_timeout_hours";
+
+/// Inclusive bounds for the session inactivity timeout (hours). The
+/// floor mirrors `load_from_db`'s ">= 1" guard (#23 — a 0-hour timeout
+/// expires every session on its very next request). The ceiling of 30
+/// days keeps a fat-fingered value from making sessions effectively
+/// immortal on a shared device.
+pub const SESSION_TIMEOUT_HOURS_MIN: u64 = 1;
+pub const SESSION_TIMEOUT_HOURS_MAX: u64 = 720;
+
+/// Validate the session inactivity timeout (hours). Returns `BadRequest`
+/// with a localized message if out of range.
+pub fn validate_session_timeout_hours(value: u64, loc: &'static str) -> Result<(), AppError> {
+    if (SESSION_TIMEOUT_HOURS_MIN..=SESSION_TIMEOUT_HOURS_MAX).contains(&value) {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(
+            rust_i18n::t!("error.system.session_timeout_invalid", locale = loc).to_string(),
+        ))
+    }
+}
+
 /// Validate the log-level setting. Accepts:
 ///   - a plain level: `trace`, `debug`, `info`, `warn`, `error`
 ///   - a `tracing-subscriber` `EnvFilter` directive list, e.g.
@@ -251,6 +278,41 @@ mod tests {
         assert!(validate_default_language("en", "en").is_ok());
         assert!(validate_default_language("de", "en").is_ok());
         assert!(validate_default_language("it", "en").is_ok());
+    }
+
+    // ─── Issue #418 — validate_session_timeout_hours ──────────────
+
+    #[test]
+    fn validate_session_timeout_hours_rejects_zero() {
+        // Mirrors #23's load_from_db guard: a 0-hour timeout expires
+        // every session on its next request.
+        assert!(matches!(
+            validate_session_timeout_hours(0, "en"),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn validate_session_timeout_hours_rejects_above_720() {
+        assert!(matches!(
+            validate_session_timeout_hours(721, "en"),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn validate_session_timeout_hours_accepts_in_range() {
+        assert!(validate_session_timeout_hours(1, "en").is_ok());
+        assert!(validate_session_timeout_hours(4, "en").is_ok());
+        assert!(validate_session_timeout_hours(720, "en").is_ok());
+    }
+
+    /// The form edits the same row `AppSettings::load_from_db` reads —
+    /// a key drift here silently disconnects the admin UI from the
+    /// runtime value.
+    #[test]
+    fn session_timeout_key_matches_load_from_db() {
+        assert_eq!(KEY_SESSION_TIMEOUT_HOURS, "session_inactivity_timeout_hours");
     }
 
     // ─── Fix #308 (v1.7.1) — validate_log_level ───────────────────

--- a/templates/fragments/admin_system_panel.html
+++ b/templates/fragments/admin_system_panel.html
@@ -42,4 +42,11 @@
         <h3 id="admin-system-log-heading" class="text-lg font-semibold mb-3">{{ section_logging }}</h3>
         {{ log_form_html|safe }}
     </section>
+
+    {# Issue #418 — Sessions section. Inactivity timeout in hours; also
+       drives the authenticated cookie's Max-Age (rolling refresh). #}
+    <section aria-labelledby="admin-system-sessions-heading">
+        <h3 id="admin-system-sessions-heading" class="text-lg font-semibold mb-3">{{ section_sessions }}</h3>
+        {{ sessions_form_html|safe }}
+    </section>
 </section>

--- a/templates/fragments/admin_system_sessions_form.html
+++ b/templates/fragments/admin_system_sessions_form.html
@@ -1,0 +1,30 @@
+{# Admin → System → Sessions form (issue #418). Single integer input for
+   the inactivity timeout in hours. Drives both the server-side expiry
+   check and the authenticated session cookie's Max-Age. CSRF token is
+   the FIRST input (audit invariant). #}
+<form id="admin-system-sessions-form"
+      method="POST"
+      action="/admin/system/sessions"
+      hx-post="/admin/system/sessions"
+      hx-target="#admin-system-sessions-form"
+      hx-swap="outerHTML"
+      class="border border-stone-200 dark:border-stone-700 rounded-lg p-4 bg-stone-50 dark:bg-stone-900">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
+    <input type="hidden" name="session_timeout_version" value="{{ session_timeout_version }}">
+    <label class="block">
+        <span class="block text-sm font-medium mb-1">{{ session_timeout_label }}</span>
+        <input type="number"
+               name="session_timeout_hours"
+               min="{{ timeout_hours_min }}"
+               max="{{ timeout_hours_max }}"
+               step="1"
+               required
+               value="{{ session_timeout_value }}"
+               class="w-32 px-3 py-2 border border-stone-300 dark:border-stone-700 rounded-md dark:bg-stone-800">
+        <span class="block text-xs text-stone-500 dark:text-stone-400 mt-1">{{ session_timeout_help }}</span>
+    </label>
+    <div class="mt-3">
+        <button type="submit"
+                class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-sm">{{ btn_save }}</button>
+    </div>
+</form>

--- a/tests/admin_system_integration.rs
+++ b/tests/admin_system_integration.rs
@@ -951,3 +951,103 @@ async fn migrate_legacy_env_vars_ignores_out_of_range_timeout_env_var(pool: DbPo
     );
     assert_eq!(s.provider_health_probe_timeout_secs, 10);
 }
+
+// ─── Issue #418 — Sessions section (inactivity timeout) ────────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn save_sessions_settings_updates_row_and_reloads_cache(pool: DbPool) {
+    let username = seed_admin(&pool).await;
+    let state = state_with_pool(pool.clone());
+    let cache = state.settings.clone();
+    let router = app(state);
+    let (cookie, csrf) = login_and_extract(&router, &username, "librarian").await;
+
+    // Pre: cache holds the compiled default (4h = 14400s) until first save.
+    assert_eq!(cache.read().unwrap().session_timeout_secs, 14400);
+
+    let body = format!(
+        "session_timeout_hours=12&session_timeout_version=1&_csrf_token={}",
+        csrf
+    );
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/admin/system/sessions")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "save_sessions returns 200");
+
+    // DB updated.
+    let row: (String, i32) = sqlx::query_as(
+        "SELECT setting_value, version FROM settings \
+         WHERE setting_key = 'session_inactivity_timeout_hours'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "12");
+    assert_eq!(row.1, 2, "optimistic-lock version bumps on save");
+
+    // Cache reloaded — the resolver middleware reads this per request
+    // for both the expiry check and the cookie Max-Age.
+    assert_eq!(
+        cache.read().unwrap().session_timeout_secs,
+        12 * 3600,
+        "AppSettings cache must reflect the new value without restart"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn save_sessions_settings_rejects_out_of_range(pool: DbPool) {
+    let username = seed_admin(&pool).await;
+    let state = state_with_pool(pool.clone());
+    let router = app(state);
+    let (cookie, csrf) = login_and_extract(&router, &username, "librarian").await;
+
+    for bad in ["0", "721"] {
+        let body = format!(
+            "session_timeout_hours={}&session_timeout_version=1&_csrf_token={}",
+            bad, csrf
+        );
+        let res = router
+            .clone()
+            .oneshot(
+                Request::post("/admin/system/sessions")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("cookie", format!("session={}", cookie))
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::BAD_REQUEST,
+            "out-of-range value {bad} must 400"
+        );
+        // #91 contract: validation errors carry HX-Trigger so csrf.js
+        // opts the swap in despite HTMX's 4xx no-swap default.
+        assert_eq!(
+            res.headers()
+                .get("hx-trigger")
+                .and_then(|v| v.to_str().ok()),
+            Some("validation-error")
+        );
+    }
+
+    // Row untouched: seeded default '4', version 1.
+    let row: (String, i32) = sqlx::query_as(
+        "SELECT setting_value, version FROM settings \
+         WHERE setting_key = 'session_inactivity_timeout_hours'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "4");
+    assert_eq!(row.1, 1);
+}

--- a/tests/e2e/specs/journeys/admin-system-settings.spec.ts
+++ b/tests/e2e/specs/journeys/admin-system-settings.spec.ts
@@ -511,4 +511,103 @@ test.describe("Story 8-5 — Admin System Settings", () => {
       await ctxB.close();
     }
   });
+
+  // ─── Issue #418 — Sessions section (inactivity timeout) ──────────
+
+  test("session cookie is persistent with Max-Age = configured timeout (#418)", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    const cookies = await page.context().cookies();
+    const session = cookies.find((c) => c.name === "session");
+    expect(session, "session cookie present after login").toBeTruthy();
+    // A pure session cookie has expires === -1. #418: the cookie must
+    // carry Max-Age (persistent) so iPadOS Safari keeps it across
+    // screen-locks. Default timeout is 4h; the E2E stack may configure
+    // a different value, so assert "persistent and in the future"
+    // rather than an exact horizon.
+    expect(
+      session!.expires,
+      "authenticated session cookie must be persistent (Max-Age set), not a browser-session cookie",
+    ).toBeGreaterThan(Date.now() / 1000);
+  });
+
+  test("save session timeout persists and re-renders (#418)", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    await expect(
+      page.getByRole("heading", { name: /Sessions|Sitzungen|Sessioni/i, level: 3 }),
+    ).toBeVisible();
+
+    const input = page.locator(
+      'form#admin-system-sessions-form input[name="session_timeout_hours"]',
+    );
+    await expect(input).toBeVisible();
+    await input.fill("6");
+    await page
+      .locator('form#admin-system-sessions-form button[type="submit"]')
+      .click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(
+          /Session settings saved|Préférences de session enregistrées/i,
+        ),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Persisted value re-renders on a fresh page load.
+    await page.goto("/admin?tab=system");
+    await expect(
+      page.locator(
+        'form#admin-system-sessions-form input[name="session_timeout_hours"]',
+      ),
+    ).toHaveValue("6");
+
+    // Reset to the seeded default (4h) so the shared settings row does
+    // not leak into other specs (this describe is serial, but the
+    // settings table is stack-global).
+    const resetInput = page.locator(
+      'form#admin-system-sessions-form input[name="session_timeout_hours"]',
+    );
+    await resetInput.fill("4");
+    await page
+      .locator('form#admin-system-sessions-form button[type="submit"]')
+      .click();
+    await expect(
+      page
+        .locator("#feedback-list")
+        .getByText(
+          /Session settings saved|Préférences de session enregistrées/i,
+        )
+        .last(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("session timeout validation: 0 → 400 (#418)", async ({
+    page,
+    request,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+    const realToken = await page
+      .locator('meta[name="csrf-token"]')
+      .getAttribute("content");
+    expect(realToken).toBeTruthy();
+    const cookies = await page.context().cookies();
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+
+    const resp = await request.post("/admin/system/sessions", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Cookie": cookieHeader,
+        "HX-Request": "true",
+      },
+      data: `session_timeout_hours=0&session_timeout_version=1&_csrf_token=${encodeURIComponent(realToken!)}`,
+      maxRedirects: 0,
+    });
+    expect(resp.status()).toBe(400);
+  });
 });

--- a/tests/session_cookie_collision.rs
+++ b/tests/session_cookie_collision.rs
@@ -142,6 +142,145 @@ async fn login_emits_exactly_one_session_set_cookie(pool: DbPool) {
     );
 }
 
+// ─── Issue #418 — authenticated cookie Max-Age + rolling refresh ───
+//
+// The authenticated session cookie was a pure session cookie (no
+// Max-Age), which iPadOS Safari discards on screen-lock — the librarian
+// was logged out between two scanning batches. The cookie now carries
+// Max-Age aligned with the configured inactivity timeout (default 4h =
+// 14400s from `AppSettings::default().session_timeout_secs`), and the
+// resolver middleware re-issues it on every authenticated request so
+// the browser-side lifetime slides with the server-side
+// `last_activity` window.
+
+fn find_session_set_cookie(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .find(|s| s.starts_with("session="))
+        .map(|s| s.to_string())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn login_session_cookie_carries_max_age(pool: DbPool) {
+    let username = seed_user(&pool).await;
+    let app = app(state_with_pool(pool.clone()));
+
+    let body = format!("username={}&password=librarian", username);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+
+    let cookie = find_session_set_cookie(resp.headers()).expect("session Set-Cookie");
+    assert!(
+        cookie.contains("Max-Age=14400"),
+        "authenticated cookie must carry Max-Age = session timeout (4h default); got {cookie}"
+    );
+    assert!(cookie.contains("HttpOnly"), "cookie stays HttpOnly: {cookie}");
+    assert!(
+        cookie.to_lowercase().contains("samesite=lax"),
+        "cookie stays SameSite=Lax: {cookie}"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn authenticated_request_rolls_session_cookie_max_age(pool: DbPool) {
+    let username = seed_user(&pool).await;
+    let app = app(state_with_pool(pool.clone()));
+
+    // Login to obtain the authenticated cookie.
+    let body = format!("username={}&password=librarian", username);
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let token = extract_session_cookie_value(resp.headers()).expect("login cookie value");
+
+    // A plain authenticated GET must re-issue the SAME token with a
+    // fresh Max-Age (rolling window).
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .header("cookie", format!("session={token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let count = count_session_set_cookies(resp.headers());
+    assert_eq!(count, 1, "authenticated GET re-issues exactly 1 session cookie");
+    let cookie = find_session_set_cookie(resp.headers()).unwrap();
+    assert!(
+        cookie.contains("Max-Age=14400"),
+        "rolled cookie carries a fresh Max-Age: {cookie}"
+    );
+    let rolled_token = extract_session_cookie_value(resp.headers()).unwrap();
+    assert_eq!(
+        rolled_token, token,
+        "rolling refresh must NOT rotate the token — same session, fresh lifetime"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn anonymous_repeat_request_does_not_reissue_cookie(pool: DbPool) {
+    // The rolling refresh is authenticated-only: an anonymous session
+    // resolved from an existing cookie must NOT re-emit Set-Cookie
+    // (its 7-day Max-Age is aligned with the anonymous purge window
+    // and does not slide).
+    let app = app(state_with_pool(pool.clone()));
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let anon_token = extract_session_cookie_value(resp.headers()).expect("anon mint cookie");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/")
+                .header("cookie", format!("session={anon_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        count_session_set_cookies(resp.headers()),
+        0,
+        "resolved anonymous session must not re-issue the cookie"
+    );
+}
+
 #[sqlx::test(migrations = "./migrations")]
 async fn anonymous_first_hit_still_emits_exactly_one_session_cookie(pool: DbPool) {
     // Sanity: when no handler sets its own cookie, the middleware's anon


### PR DESCRIPTION
## Problem

Sessions died mid-cataloging on iPad (#418): the authenticated session cookie had no `Max-Age`, and iPadOS Safari discards pure session cookies on screen-lock. Prod evidence (2026-07-10): **6 logins in 90 minutes** against a 4h server-side inactivity timeout.

## Fix

1. **Persistent cookie** — the authenticated session cookie now carries `Max-Age` equal to the configured inactivity timeout, built by the new shared helper `middleware::auth::authenticated_session_cookie` (used by login, setup wizard step 1, and the resolver middleware).
2. **Rolling refresh** — `session_resolve_middleware` re-issues the cookie on every authenticated response, so the browser-side lifetime slides with the server-side `last_activity` window. The server stays authoritative (`SessionModel::is_expired`); the same #81 guard skips the refresh when a handler (login/logout/setup) already set its own `session=` cookie. Anonymous cookies keep their fixed 7-day `Max-Age` and do not roll.
3. **Admin → System → Sessions section** — edits the existing `session_inactivity_timeout_hours` K/V row (bounds 1..=720 h), following the story 8-5 form pattern (optimistic-lock save, cache hot-reload, #91 validation-error re-render, #406 version round-trip).
4. **Threat model** — `docs/auth-threat-model.md` § 5.5 documents the persistent-cookie trade-off; § 4 gains the server-authoritative-expiry row.

## Deviation from the issue

`session_warning_minutes_before_expiry` is seeded in the DB but **read nowhere in the codebase** (vestigial) — exposing a knob that does nothing would mislead, so it is deliberately NOT surfaced. Follow-up welcome if an expiry-warning UX ever lands.

## Tests

- `tests/session_cookie_collision.rs`: Max-Age on login cookie, rolling refresh (token-stable, fresh Max-Age, exactly 1 Set-Cookie), anonymous no-reissue.
- `tests/admin_system_integration.rs`: save round-trip (DB row + version bump + cache reload), out-of-range 400 with `HX-Trigger: validation-error`.
- `src/services/admin_system.rs`: validator bounds + key-drift lock.
- E2E (`admin-system-settings.spec.ts`): persistent-cookie assertion after real login, Sessions form save/re-render/reset journey, 400 validation.

Local: `cargo clippy -D warnings` clean, full `cargo test` green (1060 lib + all integration suites), full Playwright suite at CI shape: **299 passed, 1 flaky (unrelated catalog-title manual form, passed on retry)**.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbUn44d1ffooL26Hem7Px6