### PR TITLE
fix(#419): pace bulk cover-refetch, retry 429/503 with backoff, surface run summary

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -434,6 +434,7 @@ error:
     default_currency_invalid: "Die Standardwährung muss ein 3-Buchstaben-Code nach ISO 4217 sein (z. B. CHF, EUR)."
     log_level_invalid: "Die Protokollebene muss eine einfache Ebene (trace/debug/info/warn/error) oder eine Liste von tracing-subscriber EnvFilter-Direktiven sein (z. B. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Die Zeitüberschreitung muss zwischen 1 und 60 Sekunden liegen."
+    bulk_refetch_delay_invalid: "Die Pause beim Cover-Nachzug muss zwischen 0 und 60000 Millisekunden liegen."
     session_timeout_invalid: "Das Sitzungs-Zeitlimit muss zwischen 1 und 720 Stunden liegen."
     version_mismatch: "Die Einstellungen wurden durch einen anderen Administrator geändert — neu laden und erneut versuchen"
     provider_version_mismatch: "%{provider} wurde durch einen anderen Administrator geändert — neu laden und erneut versuchen"
@@ -812,7 +813,7 @@ admin:
       button: "Fehlende Cover erneut laden"
       idle: "Inaktiv"
       running: "Läuft: %{processed} / %{total} verarbeitet"
-      last_run: "Letzter Lauf: %{processed} / %{total} verarbeitet"
+      last_run: "Letzter Lauf: %{processed} / %{total} verarbeitet — %{recovered} Cover wiederhergestellt, %{provider_failed} Anbieterfehler, %{not_found} ohne verfügbares Cover"
       started: "Massenhafter Cover-Nachzug für %{total} Titel gestartet. Fortschritt steht im Log; aktualisieren Sie das Panel für Updates."
       empty: "Keine Titel benötigen einen Cover-Nachzug — alles, was abrufbar war, ist abgerufen."
       already_running: "Ein Cover-Nachzug läuft bereits. Bitte warten Sie auf den Abschluss."
@@ -933,6 +934,9 @@ admin:
     metadata_chain_timeout_help: "Maximale Wartezeit für einen Anbieter, bevor die Kette zum nächsten übergeht. Standard 5. Erhöhen Sie den Wert, wenn DNS oder TLS langsam sind (ländliches Glasfasernetz, VPN, Satellit). Grenzen 1–60. Beim nächsten Scan wirksam — kein Neustart."
     provider_health_timeout_label: "Zeitüberschreitung der Provider-Health-Sonde (Sekunden)"
     provider_health_timeout_help: "Maximale Wartezeit für die HEAD-Antwort jedes Anbieters beim Erreichbarkeits-Ping (alle 5 Minuten). Standard 10. Grenzen 1–60. In der nächsten Runde wirksam — kein Neustart."
+    # Issue #419 — Pause zwischen Titeln beim massenhaften Cover-Nachzug.
+    bulk_refetch_delay_label: "Pause beim Cover-Nachzug (Millisekunden)"
+    bulk_refetch_delay_help: "Pause zwischen den Titeln bei einem massenhaften Cover-Nachzug. Ein zu schnelles Tempo führt dazu, dass Anbieter den gesamten Lauf drosseln (Google Books beantwortet Anfragesalven mit Fehlern, und keine Cover kommen zurück). Standard 1000 ms — etwa 2 Minuten mehr pro 100 Titel. Grenzen 0–60000. Beim nächsten Lauf wirksam — kein Neustart."
     btn_save_timeouts: "Zeitüberschreitungen speichern"
     # CR #396 — Zeitüberschreitungs-Überschreibungen pro Anbieter.
     provider_timeouts_help: "Überschreiben Sie die Metadaten-Zeitüberschreitung für einzelne Anbieter. Lassen Sie ein Feld leer, um den globalen Standard (%{default} s) zu verwenden. Grenzen 1–60. Beim nächsten Scan wirksam — kein Neustart."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -441,6 +441,7 @@ error:
     default_currency_invalid: "Default currency must be a 3-letter ISO 4217 code (e.g. CHF, EUR)."
     log_level_invalid: "Log level must be a plain level (trace/debug/info/warn/error) or a tracing-subscriber EnvFilter directive list (e.g. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Timeout must be between 1 and 60 seconds."
+    bulk_refetch_delay_invalid: "Bulk re-fetch delay must be between 0 and 60000 milliseconds."
     session_timeout_invalid: "Session timeout must be between 1 and 720 hours."
     version_mismatch: "Settings were modified by another admin — reload and retry"
     provider_version_mismatch: "%{provider} was modified by another admin — reload and retry"
@@ -826,7 +827,7 @@ admin:
       button: "Re-fetch missing covers"
       idle: "Idle"
       running: "Running: %{processed} / %{total} processed"
-      last_run: "Last run: %{processed} / %{total} processed"
+      last_run: "Last run: %{processed} / %{total} processed — %{recovered} covers recovered, %{provider_failed} provider errors, %{not_found} with no cover available"
       started: "Bulk cover-refetch started for %{total} titles. Progress is logged; refresh the panel to see updates."
       empty: "No titles need a cover refetch — everything that can be fetched has been."
       already_running: "A bulk cover-refetch is already in progress. Please wait for it to complete."
@@ -947,6 +948,9 @@ admin:
     metadata_chain_timeout_help: "Maximum time the chain waits for one provider before falling through to the next. Default 5. Raise if your DNS or TLS handshake is slow (rural fiber, VPN, satellite). Bounded 1–60. Applied on the next scan — no restart."
     provider_health_timeout_label: "Provider-health probe timeout (seconds)"
     provider_health_timeout_help: "Maximum time the 5-min reachability ping waits for each provider HEAD response. Default 10. Bounded 1–60. Applied on the next round — no restart."
+    # Issue #419 — bulk cover-refetch inter-title delay.
+    bulk_refetch_delay_label: "Bulk cover-refetch delay (milliseconds)"
+    bulk_refetch_delay_help: "Pause between titles during a bulk cover re-fetch. Too fast a pace makes providers throttle the whole run (Google Books answers bursts with errors and no covers come back). Default 1000 ms — about 2 extra minutes per 100 titles. Bounded 0–60000. Applied on the next run — no restart."
     btn_save_timeouts: "Save timeout settings"
     # CR #396 — per-provider metadata-timeout overrides.
     provider_timeouts_help: "Override the metadata timeout for individual providers. Leave a field empty to use the global default (%{default} s). Bounded 1–60. Applied on the next scan — no restart."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -436,6 +436,7 @@ error:
     default_currency_invalid: "La devise par défaut doit être un code ISO 4217 à 3 lettres (ex. CHF, EUR)."
     log_level_invalid: "Le niveau doit être un niveau simple (trace/debug/info/warn/error) ou une liste de directives tracing-subscriber EnvFilter (ex. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Le délai doit être compris entre 1 et 60 secondes."
+    bulk_refetch_delay_invalid: "Le délai du re-fetch en lot doit être compris entre 0 et 60000 millisecondes."
     session_timeout_invalid: "Le délai de session doit être compris entre 1 et 720 heures."
     version_mismatch: "Les paramètres ont été modifiés par un autre administrateur — rechargez et réessayez"
     provider_version_mismatch: "%{provider} a été modifié par un autre administrateur — rechargez et réessayez"
@@ -821,7 +822,7 @@ admin:
       button: "Récupérer les couvertures manquantes"
       idle: "Au repos"
       running: "En cours : %{processed} / %{total} traités"
-      last_run: "Dernière exécution : %{processed} / %{total} traités"
+      last_run: "Dernière exécution : %{processed} / %{total} traités — %{recovered} couvertures récupérées, %{provider_failed} erreurs fournisseur, %{not_found} sans couverture disponible"
       started: "Récupération en lot lancée pour %{total} titres. La progression est journalisée ; rafraîchissez le panneau pour voir les mises à jour."
       empty: "Aucun titre n'a besoin d'être re-fetché — tout ce qui peut être récupéré l'a été."
       already_running: "Une récupération en lot est déjà en cours. Attendez sa fin."
@@ -942,6 +943,9 @@ admin:
     metadata_chain_timeout_help: "Temps maximal d'attente d'un fournisseur avant de passer au suivant dans la chaîne. Par défaut 5. Augmentez si votre DNS ou TLS est lent (fibre rurale, VPN, satellite). Bornes 1–60. Appliqué au prochain scan — sans redémarrage."
     provider_health_timeout_label: "Délai d'attente de la sonde provider-health (secondes)"
     provider_health_timeout_help: "Temps maximal d'attente de la réponse HEAD de chaque fournisseur lors du ping de joignabilité (toutes les 5 min). Par défaut 10. Bornes 1–60. Appliqué au prochain tour — sans redémarrage."
+    # Issue #419 — délai entre titres du re-fetch de couvertures en lot.
+    bulk_refetch_delay_label: "Délai du re-fetch de couvertures en lot (millisecondes)"
+    bulk_refetch_delay_help: "Pause entre chaque titre lors d'une récupération de couvertures en lot. Un rythme trop rapide fait bloquer toute l'exécution par les fournisseurs (Google Books répond aux rafales par des erreurs et aucune couverture ne revient). Par défaut 1000 ms — environ 2 minutes de plus pour 100 titres. Bornes 0–60000. Appliqué à la prochaine exécution — sans redémarrage."
     btn_save_timeouts: "Enregistrer les délais d'attente"
     # CR #396 — délais d'attente par fournisseur (surcharges).
     provider_timeouts_help: "Surchargez le délai d'attente des métadonnées pour chaque fournisseur. Laissez un champ vide pour utiliser la valeur globale par défaut (%{default} s). Bornes 1–60. Appliqué au prochain scan — sans redémarrage."

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -428,6 +428,7 @@ error:
     default_currency_invalid: "La valuta predefinita deve essere un codice ISO 4217 a 3 lettere (es. CHF, EUR)."
     log_level_invalid: "Il livello di log deve essere un livello semplice (trace/debug/info/warn/error) o un elenco di direttive tracing-subscriber EnvFilter (es. mybibli=debug,sqlx::query=warn)."
     provider_timeout_invalid: "Il timeout deve essere compreso tra 1 e 60 secondi."
+    bulk_refetch_delay_invalid: "La pausa del riscaricamento in blocco deve essere compresa tra 0 e 60000 millisecondi."
     session_timeout_invalid: "Il timeout di sessione deve essere compreso tra 1 e 720 ore."
     version_mismatch: "Le impostazioni sono state modificate da un altro amministratore — ricarica e riprova"
     provider_version_mismatch: "%{provider} è stato modificato da un altro amministratore — ricarica e riprova"
@@ -800,7 +801,7 @@ admin:
       button: "Riscarica copertine mancanti"
       idle: "Inattivo"
       running: "In corso: %{processed} / %{total} elaborati"
-      last_run: "Ultima esecuzione: %{processed} / %{total} elaborati"
+      last_run: "Ultima esecuzione: %{processed} / %{total} elaborati — %{recovered} copertine recuperate, %{provider_failed} errori del fornitore, %{not_found} senza copertina disponibile"
       started: "Riscaricamento delle copertine avviato per %{total} titoli. Il progresso è registrato nei log; aggiorna il pannello per vedere gli aggiornamenti."
       empty: "Nessun titolo ha bisogno di un nuovo recupero copertina — tutto ciò che era recuperabile è stato recuperato."
       already_running: "Un riscaricamento delle copertine è già in corso. Attendi il suo completamento."
@@ -920,6 +921,9 @@ admin:
     metadata_chain_timeout_help: "Tempo massimo di attesa per un fornitore prima che la catena passi al successivo. Predefinito 5. Aumenta se DNS o TLS sono lenti (fibra rurale, VPN, satellite). Intervallo 1–60. Applicato alla prossima scansione — nessun riavvio."
     provider_health_timeout_label: "Timeout della sonda provider-health (secondi)"
     provider_health_timeout_help: "Tempo massimo di attesa della risposta HEAD di ciascun fornitore al ping di raggiungibilità (ogni 5 minuti). Predefinito 10. Intervallo 1–60. Applicato al prossimo giro — nessun riavvio."
+    # Issue #419 — pausa tra i titoli nel riscaricamento copertine in blocco.
+    bulk_refetch_delay_label: "Pausa del riscaricamento copertine in blocco (millisecondi)"
+    bulk_refetch_delay_help: "Pausa tra un titolo e l'altro durante un riscaricamento copertine in blocco. Un ritmo troppo veloce fa sì che i fornitori blocchino l'intera esecuzione (Google Books risponde alle raffiche con errori e nessuna copertina viene recuperata). Predefinito 1000 ms — circa 2 minuti in più ogni 100 titoli. Intervallo 0–60000. Applicato alla prossima esecuzione — nessun riavvio."
     btn_save_timeouts: "Salva timeout"
     # CR #396 — timeout per fornitore (override).
     provider_timeouts_help: "Sovrascrivi il timeout dei metadati per i singoli fornitori. Lascia un campo vuoto per usare il valore globale predefinito (%{default} s). Intervallo 1–60. Applicato alla prossima scansione — nessun riavvio."

--- a/migrations/20260711000000_settings_bulk_refetch_delay.sql
+++ b/migrations/20260711000000_settings_bulk_refetch_delay.sql
@@ -1,0 +1,17 @@
+-- Issue #419 — configurable inter-request delay for the admin bulk
+-- cover-refetch loop (milliseconds between titles).
+--
+-- Prod evidence 2026-07-10: two back-to-back runs over ~113 titles at
+-- ~1.2s/title tripped Google Books' throttling (503 storm) and recovered
+-- ~0 covers. A 1000 ms default gap keeps a 113-title run at ~2 extra
+-- minutes — irrelevant for a background admin action — and lets the
+-- admin tune it from /admin > System without a restart.
+--
+-- Bounds 0..=60000 ms, validated by
+-- services::admin_system::validate_bulk_refetch_delay_ms and re-checked
+-- at load time in AppSettings::load_from_db (out-of-range rows fall back
+-- to the default with a warning).
+
+INSERT INTO settings (setting_key, setting_value, version) VALUES
+('bulk_refetch_delay_ms', '1000', 1)
+ON DUPLICATE KEY UPDATE setting_key = setting_key;

--- a/src/config.rs
+++ b/src/config.rs
@@ -391,6 +391,14 @@ pub struct AppSettings {
     /// without a restart, and the task reads through `Arc<RwLock<AppSettings>>`
     /// on each ping round.
     pub provider_health_probe_timeout_secs: u64,
+    // === Issue #419 — bulk cover-refetch pacing ===
+    /// Inter-title delay (milliseconds) in the admin bulk cover-refetch
+    /// loop. Was hardcoded 500 ms until #419; prod evidence (2026-07-10)
+    /// showed back-to-back runs over 113 titles tripping Google Books'
+    /// throttling (503 storm, ~0 covers recovered). Bounds 0..=60000,
+    /// default 1000. Read once per bulk run — the run in flight keeps
+    /// its snapshot; the next run picks up an admin change.
+    pub bulk_refetch_delay_ms: u64,
     // === CR #396 — per-provider metadata-chain timeout overrides ===
     /// Overrides for `metadata_chain_per_provider_timeout_secs`, keyed by
     /// provider slug (see `metadata::provider::provider_slug`). Loaded from
@@ -429,6 +437,10 @@ impl Default for AppSettings {
             // installs behave identically until the admin tunes them.
             metadata_chain_per_provider_timeout_secs: 5,
             provider_health_probe_timeout_secs: 10,
+            // Issue #419: 1s inter-title gap — doubles the pre-#419
+            // hardcoded 500 ms; keeps a 100+-title run clear of the
+            // Google Books 503 storm observed in prod.
+            bulk_refetch_delay_ms: 1000,
             // CR #396: no overrides — every provider uses the scalar above.
             metadata_chain_provider_timeout_overrides: std::collections::HashMap::new(),
         }
@@ -643,6 +655,22 @@ impl AppSettings {
                         value = %value,
                         parsed = v,
                         "provider_health_probe_timeout_secs out of range (1..=60), using default"
+                    ),
+                    Err(_) => tracing::warn!(
+                        key = %key,
+                        value = %value,
+                        "Invalid setting value, using default"
+                    ),
+                },
+                // Issue #419: bulk cover-refetch inter-title delay. Same
+                // 0..=60000 bounds as the admin form validation.
+                "bulk_refetch_delay_ms" => match value.parse::<u64>() {
+                    Ok(v) if v <= 60_000 => settings.bulk_refetch_delay_ms = v,
+                    Ok(v) => tracing::warn!(
+                        key = %key,
+                        value = %value,
+                        parsed = v,
+                        "bulk_refetch_delay_ms out of range (0..=60000), using default"
                     ),
                     Err(_) => tracing::warn!(
                         key = %key,
@@ -910,6 +938,40 @@ mod tests {
         assert_eq!(settings.session_timeout_secs, 8 * 3600);
     }
 
+    /// #419 — bulk_refetch_delay_ms: in-range value takes effect, the
+    /// migration seed (1000) is the default, and an out-of-range row
+    /// falls back to the default rather than stretching a 100-title
+    /// run past 100 minutes.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn load_from_db_bulk_refetch_delay_valid_and_clamped(pool: DbPool) {
+        // Migration seed: default 1000.
+        let settings = AppSettings::load_from_db(&pool).await.expect("load ok");
+        assert_eq!(settings.bulk_refetch_delay_ms, 1000);
+
+        // Valid custom value (0 = explicit no-pacing opt-out).
+        sqlx::query(
+            "UPDATE settings SET setting_value = '0' WHERE setting_key = 'bulk_refetch_delay_ms'",
+        )
+        .execute(&pool)
+        .await
+        .expect("update setting");
+        let settings = AppSettings::load_from_db(&pool).await.expect("load ok");
+        assert_eq!(settings.bulk_refetch_delay_ms, 0);
+
+        // Out-of-range row → default.
+        sqlx::query(
+            "UPDATE settings SET setting_value = '999999' WHERE setting_key = 'bulk_refetch_delay_ms'",
+        )
+        .execute(&pool)
+        .await
+        .expect("update setting");
+        let settings = AppSettings::load_from_db(&pool).await.expect("load ok");
+        assert_eq!(
+            settings.bulk_refetch_delay_ms, 1000,
+            "out-of-range value must fall back to the default"
+        );
+    }
+
     #[test]
     fn test_config_with_all_vars() {
         let vars = HashMap::from([
@@ -992,6 +1054,7 @@ mod tests {
             log_level: "info".to_string(),
             metadata_chain_per_provider_timeout_secs: 7,
             provider_health_probe_timeout_secs: 15,
+            bulk_refetch_delay_ms: 2000,
             metadata_chain_provider_timeout_overrides: HashMap::from([(
                 "bnf".to_string(),
                 12_u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,4 +206,14 @@ impl AppState {
             .map(|s| s.provider_health_probe_timeout_secs)
             .unwrap_or_else(|_| AppSettings::default().provider_health_probe_timeout_secs)
     }
+
+    /// Issue #419: inter-title delay (milliseconds) for the admin bulk
+    /// cover-refetch loop. Snapshotted once per bulk run — the run in
+    /// flight keeps its value; the next run picks up an admin change.
+    pub fn bulk_refetch_delay_ms(&self) -> u64 {
+        self.settings
+            .read()
+            .map(|s| s.bulk_refetch_delay_ms)
+            .unwrap_or_else(|_| AppSettings::default().bulk_refetch_delay_ms)
+    }
 }

--- a/src/metadata/chain.rs
+++ b/src/metadata/chain.rs
@@ -38,6 +38,17 @@ impl ProviderTimeouts {
     }
 }
 
+/// #419 — result of a chain run plus the throttle signal the bulk
+/// cover-refetch loop retries on. `throttled` is true when at least one
+/// provider answered 429/503 during the run — only meaningful for
+/// retry decisions when `result` is `None` (a successful result from a
+/// later provider supersedes an earlier throttle).
+#[derive(Debug, Default)]
+pub struct ChainOutcome {
+    pub result: Option<MetadataResult>,
+    pub throttled: bool,
+}
+
 /// Executes metadata lookups through a chain of providers with fallback.
 pub struct ChainExecutor;
 
@@ -49,6 +60,9 @@ impl ChainExecutor {
     /// 3. Call appropriate lookup method based on code_type (isbn vs upc)
     /// 4. Cache first successful result
     /// 5. Return None if all providers fail/return nothing
+    ///
+    /// Thin wrapper over [`Self::execute_detailed`] for call sites that
+    /// don't care about the throttle signal.
     pub async fn execute(
         registry: &ProviderRegistry,
         pool: &DbPool,
@@ -58,13 +72,42 @@ impl ChainExecutor {
         timeout_secs: u64,
         per_provider_timeouts: &ProviderTimeouts,
     ) -> Option<MetadataResult> {
+        Self::execute_detailed(
+            registry,
+            pool,
+            code,
+            code_type,
+            media_type,
+            timeout_secs,
+            per_provider_timeouts,
+        )
+        .await
+        .result
+    }
+
+    /// #419 — same as [`Self::execute`] but also reports whether any
+    /// provider answered with a transient throttle (429/503) during the
+    /// run, so the bulk cover-refetch loop can back off and retry
+    /// instead of writing the title off as "no cover exists".
+    pub async fn execute_detailed(
+        registry: &ProviderRegistry,
+        pool: &DbPool,
+        code: &str,
+        code_type: &CodeType,
+        media_type: &MediaType,
+        timeout_secs: u64,
+        per_provider_timeouts: &ProviderTimeouts,
+    ) -> ChainOutcome {
         tracing::info!(code = %code, code_type = %code_type, media_type = %media_type, "Starting metadata chain");
 
         // 1. Check cache first
         match MetadataCacheModel::find_by_isbn(pool, code).await {
             Ok(Some(cached)) => {
                 tracing::info!(code = %code, "Metadata chain: cache hit");
-                return Some(cached);
+                return ChainOutcome {
+                    result: Some(cached),
+                    throttled: false,
+                };
             }
             Ok(None) => {
                 tracing::debug!(code = %code, "Metadata chain: cache miss");
@@ -78,9 +121,13 @@ impl ChainExecutor {
         let chain = registry.chain_for(media_type);
         if chain.is_empty() {
             tracing::info!(code = %code, media_type = %media_type, "No providers for media type");
-            return None;
+            return ChainOutcome::default();
         }
 
+        // #419 — set as soon as any provider answers 429/503; survives
+        // the global-timeout Err arm because it lives outside the
+        // timed future.
+        let mut throttled = false;
         let global_timeout = Duration::from_secs(timeout_secs);
         let chain_result = tokio::time::timeout(global_timeout, async {
             for provider in &chain {
@@ -131,11 +178,25 @@ impl ChainExecutor {
                         // moment a provider changes its error message;
                         // now we read the typed variant straight off the
                         // provider's return.
+                        throttled = true;
                         tracing::warn!(
                             code = %code,
                             provider = provider_name,
                             duration_ms = duration_ms,
                             "Provider rate limited (HTTP 429), skipping"
+                        );
+                    }
+                    Ok(Err(MetadataError::Unavailable)) => {
+                        // #419 — Google Books answers burst load with
+                        // 503 storms; same skip-to-next-provider flow as
+                        // 429, but the typed signal lets the bulk
+                        // refetch loop back off and retry the title.
+                        throttled = true;
+                        tracing::warn!(
+                            code = %code,
+                            provider = provider_name,
+                            duration_ms = duration_ms,
+                            "Provider temporarily unavailable (HTTP 503), skipping"
                         );
                     }
                     Ok(Err(e)) => {
@@ -162,7 +223,7 @@ impl ChainExecutor {
         })
         .await;
 
-        match chain_result {
+        let result = match chain_result {
             Ok(Some(metadata)) => {
                 // Cache the successful result
                 match serde_json::to_value(&metadata) {
@@ -186,7 +247,9 @@ impl ChainExecutor {
                 tracing::warn!(code = %code, timeout_secs = timeout_secs, "Metadata chain global timeout");
                 None
             }
-        }
+        };
+
+        ChainOutcome { result, throttled }
     }
 }
 
@@ -293,6 +356,126 @@ mod tests {
         ) -> Result<Option<MetadataResult>, MetadataError> {
             Err(MetadataError::RateLimited)
         }
+    }
+
+    struct UnavailableProvider;
+
+    #[async_trait]
+    impl MetadataProvider for UnavailableProvider {
+        fn name(&self) -> &str {
+            "unavailable_provider"
+        }
+        fn supports_media_type(&self, _media_type: &MediaType) -> bool {
+            true
+        }
+        async fn lookup_by_isbn(
+            &self,
+            _isbn: &str,
+        ) -> Result<Option<MetadataResult>, MetadataError> {
+            Err(MetadataError::Unavailable)
+        }
+    }
+
+    // ─── #419 — ChainOutcome.throttled propagation ────────────────
+
+    /// A chain that comes back empty-handed after a 503 storm must
+    /// carry `throttled = true` so the bulk refetch loop retries the
+    /// title instead of writing it off as "no cover exists".
+    #[sqlx::test(migrations = "./migrations")]
+    async fn execute_detailed_throttled_true_when_503_and_no_result(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(UnavailableProvider));
+
+        let outcome = ChainExecutor::execute_detailed(
+            &registry,
+            &pool,
+            "9799999990013",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await;
+        assert!(outcome.result.is_none());
+        assert!(outcome.throttled, "503 with no fallback result must set throttled");
+    }
+
+    /// 429 sets the flag through the same path.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn execute_detailed_throttled_true_when_429_and_no_result(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(RateLimitProvider));
+
+        let outcome = ChainExecutor::execute_detailed(
+            &registry,
+            &pool,
+            "9799999990020",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await;
+        assert!(outcome.result.is_none());
+        assert!(outcome.throttled);
+    }
+
+    /// A genuinely empty chain (providers answer, nothing found) is
+    /// NOT throttled — the bulk loop must not retry it.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn execute_detailed_not_throttled_on_genuine_no_result(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(EmptyProvider));
+        registry.register(Box::new(FailProvider));
+
+        let outcome = ChainExecutor::execute_detailed(
+            &registry,
+            &pool,
+            "9799999990037",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await;
+        assert!(outcome.result.is_none());
+        assert!(
+            !outcome.throttled,
+            "no-result + generic network error must not classify as throttle"
+        );
+    }
+
+    /// A later provider's success supersedes an earlier throttle: the
+    /// result lands AND the flag still reports the 503 (callers only
+    /// consult it when result is None).
+    #[sqlx::test(migrations = "./migrations")]
+    async fn execute_detailed_success_after_throttle_returns_result(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(UnavailableProvider));
+        registry.register(Box::new(SuccessProvider { name: "fallback" }));
+
+        let outcome = ChainExecutor::execute_detailed(
+            &registry,
+            &pool,
+            "9799999990044",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await;
+        assert_eq!(
+            outcome.result.and_then(|m| m.title).as_deref(),
+            Some("Test Title")
+        );
     }
 
     // ─── CR #396 — ProviderTimeouts resolution ────────────────────

--- a/src/metadata/google_books.rs
+++ b/src/metadata/google_books.rs
@@ -157,6 +157,12 @@ impl MetadataProvider for GoogleBooksProvider {
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
             return Err(MetadataError::RateLimited);
         }
+        // #419 — Google Books signals burst throttling with 503 storms
+        // (prod evidence 2026-07-10), not 429. Typed so the bulk
+        // cover-refetch loop can back off and retry.
+        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            return Err(MetadataError::Unavailable);
+        }
         if !status.is_success() {
             return Err(MetadataError::Network(format!(
                 "Google Books API returned status {status}"

--- a/src/metadata/provider.rs
+++ b/src/metadata/provider.rs
@@ -149,6 +149,25 @@ pub enum MetadataError {
     /// the tracing span) and so a future "back off and retry the next
     /// provider in the chain" policy has a structured signal to gate on.
     RateLimited,
+    /// #419 — typed transient-unavailability signal (HTTP 503). Google
+    /// Books answers a request burst with 503 Service Unavailable
+    /// storms rather than 429; providers that detect 503 MUST return
+    /// this variant so the bulk cover-refetch loop can back off and
+    /// retry instead of burning the title's only chance for the run.
+    Unavailable,
+}
+
+impl MetadataError {
+    /// #419 — true for the transient throttle signals (429 / 503) that
+    /// the bulk cover-refetch loop retries with backoff. Timeouts and
+    /// generic network errors are NOT throttles: retrying them
+    /// back-to-back against a struggling provider makes things worse.
+    pub fn is_throttle(&self) -> bool {
+        matches!(
+            self,
+            MetadataError::RateLimited | MetadataError::Unavailable
+        )
+    }
 }
 
 impl std::fmt::Display for MetadataError {
@@ -159,6 +178,9 @@ impl std::fmt::Display for MetadataError {
             MetadataError::Timeout => write!(f, "Request timed out"),
             MetadataError::RateLimited => {
                 write!(f, "Rate limited by provider (HTTP 429)")
+            }
+            MetadataError::Unavailable => {
+                write!(f, "Provider temporarily unavailable (HTTP 503)")
             }
         }
     }
@@ -180,6 +202,21 @@ mod tests {
         // The pre-#23 chain matched `err_str.contains("429")`. The new
         // Display still includes 429 so logs stay grep-friendly.
         assert!(s.contains("429"), "Display should still mention HTTP 429 for log grep: got {s:?}");
+    }
+
+    /// #419 — Unavailable (503) mirrors the RateLimited (429) contract:
+    /// grep-friendly Display, and both classify as transient throttles;
+    /// timeouts and generic network errors do not.
+    #[test]
+    fn metadata_error_unavailable_display_and_throttle_classification() {
+        let s = MetadataError::Unavailable.to_string();
+        assert!(s.contains("503"), "Display should mention HTTP 503 for log grep: got {s:?}");
+
+        assert!(MetadataError::RateLimited.is_throttle());
+        assert!(MetadataError::Unavailable.is_throttle());
+        assert!(!MetadataError::Timeout.is_throttle());
+        assert!(!MetadataError::Network("connection refused".into()).is_throttle());
+        assert!(!MetadataError::Parse("bad json".into()).is_throttle());
     }
 
     #[test]

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -349,6 +349,9 @@ pub async fn admin_bulk_cover_refetch(
             .unwrap_or(30)
     };
     let per_provider_timeouts = state.metadata_chain_provider_timeouts();
+    // #419 — inter-title pacing, admin-configurable (was hardcoded
+    // 500 ms). Snapshotted once per run; the next run picks up changes.
+    let delay_ms = state.bulk_refetch_delay_ms();
 
     tokio::spawn(async move {
         for title in titles {
@@ -361,32 +364,69 @@ pub async fn admin_bulk_cover_refetch(
             // and the only "try harder" step left is the OpenLibrary
             // Covers ISBN fallback — which 404s for most French /
             // Swiss / academic titles.
-            crate::tasks::metadata_fetch::fetch_metadata_chain(
-                pool_clone.clone(),
-                title.id,
-                title.code.clone(),
-                title.code_type,
-                title
-                    .media_type
-                    .parse::<crate::models::media_type::MediaType>()
-                    .unwrap_or(crate::models::media_type::MediaType::Book),
-                registry_clone.clone(),
-                timeout_secs,
-                per_provider_timeouts.clone(),
-                http_client_clone.clone(),
-                covers_dir_clone.clone(),
-                true,
-            )
-            .await;
+            //
+            // #419 — a Throttled outcome (chain empty-handed with a
+            // provider answering 429/503) is retried per the
+            // THROTTLE_RETRY_BACKOFF schedule (5 s → 20 s) so a
+            // transient storm doesn't burn the title's only chance
+            // for the run.
+            let mut attempts_done = 0usize;
+            let outcome = loop {
+                let outcome = crate::tasks::metadata_fetch::fetch_metadata_chain_outcome(
+                    pool_clone.clone(),
+                    title.id,
+                    title.code.clone(),
+                    title.code_type,
+                    title
+                        .media_type
+                        .parse::<crate::models::media_type::MediaType>()
+                        .unwrap_or(crate::models::media_type::MediaType::Book),
+                    registry_clone.clone(),
+                    timeout_secs,
+                    per_provider_timeouts.clone(),
+                    http_client_clone.clone(),
+                    covers_dir_clone.clone(),
+                    true,
+                )
+                .await;
+
+                attempts_done += 1;
+                if outcome != crate::tasks::metadata_fetch::FetchOutcome::Throttled {
+                    break outcome;
+                }
+                match crate::services::bulk_cover_fetch::retry_backoff(attempts_done) {
+                    Some(backoff) => {
+                        tracing::info!(
+                            title_id = title.id,
+                            attempt = attempts_done,
+                            backoff_secs = backoff.as_secs(),
+                            "Bulk cover-refetch: provider throttled (429/503), backing off before retry"
+                        );
+                        tokio::time::sleep(backoff).await;
+                    }
+                    None => break outcome,
+                }
+            };
+
+            crate::services::bulk_cover_fetch::record_outcome(&status_clone, outcome);
             crate::services::bulk_cover_fetch::increment_processed(&status_clone);
             // Politeness toward external metadata providers. The
-            // chain has its own per-provider rate limiters, but a
-            // small inter-title gap helps when the chain runs short
-            // (e.g. cached BnF hits).
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            // chain has its own per-provider rate limiters, but the
+            // inter-title gap is what keeps a 100+-title run clear of
+            // Google Books' burst throttling (#419 prod evidence).
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
         }
+        let summary = crate::services::bulk_cover_fetch::snapshot(&status_clone);
         crate::services::bulk_cover_fetch::mark_complete(&status_clone);
-        tracing::info!("Bulk cover-refetch completed");
+        tracing::info!(
+            recovered = summary.recovered,
+            provider_failed = summary.provider_failed,
+            not_found = summary.not_found,
+            total = summary.total,
+            "Bulk cover-refetch completed"
+        );
     });
 
     let message = rust_i18n::t!(
@@ -1025,11 +1065,18 @@ async fn render_health_panel(state: &AppState, loc: &'static str) -> Result<Stri
         )
         .to_string()
     } else if bulk_status.last_completed_at.is_some() {
+        // #419 — completion summary: recovered / provider-failed /
+        // not-found, so "run finished with 0 covers because the
+        // provider throttled" is distinguishable from "no covers
+        // exist for these titles".
         rust_i18n::t!(
             "admin.health.bulk_cover_fetch.last_run",
             locale = loc,
             processed = bulk_status.processed,
-            total = bulk_status.total
+            total = bulk_status.total,
+            recovered = bulk_status.recovered,
+            provider_failed = bulk_status.provider_failed,
+            not_found = bulk_status.not_found
         )
         .to_string()
     } else {

--- a/src/routes/admin_system.rs
+++ b/src/routes/admin_system.rs
@@ -34,9 +34,10 @@ use crate::utils::feedback_html;
 // `save_setting` / `reload_settings_cache` / `validate_*` definitions have
 // been deleted in favour of the canonical implementations.
 use crate::services::admin_system::{
-    KEY_DEFAULT_CURRENCY, KEY_DEFAULT_LANGUAGE, KEY_GOOGLE_BOOKS, KEY_LOG_LEVEL,
-    KEY_METADATA_CHAIN_TIMEOUT, KEY_OMDB, KEY_OVERDUE_THRESHOLD, KEY_PROVIDER_HEALTH_TIMEOUT,
-    KEY_SESSION_TIMEOUT_HOURS, KEY_SHOW_VALUE_INDICATORS, KEY_TMDB, PROVIDER_TIMEOUT_KEY_PREFIX,
+    KEY_BULK_REFETCH_DELAY, KEY_DEFAULT_CURRENCY, KEY_DEFAULT_LANGUAGE, KEY_GOOGLE_BOOKS,
+    KEY_LOG_LEVEL, KEY_METADATA_CHAIN_TIMEOUT, KEY_OMDB, KEY_OVERDUE_THRESHOLD,
+    KEY_PROVIDER_HEALTH_TIMEOUT, KEY_SESSION_TIMEOUT_HOURS, KEY_SHOW_VALUE_INDICATORS, KEY_TMDB,
+    PROVIDER_TIMEOUT_KEY_PREFIX,
     provider_timeout_key, reload_settings_cache, save_setting, validate_default_currency,
     validate_default_language, validate_log_level, validate_overdue_threshold,
     validate_provider_timeout_secs, validate_session_timeout_hours,
@@ -108,12 +109,17 @@ pub struct LogLevelSettingsForm {
 // v1.7.9 fix #334 — Metadata-chain + provider-health timeouts. Two
 // settings on one form so admins flip both in a single round-trip.
 // Validation 1..=60 per `validate_provider_timeout_secs`.
+// Issue #419 adds the bulk cover-refetch inter-title delay (ms,
+// 0..=60000 per `validate_bulk_refetch_delay_ms`) to the same form —
+// all three knobs pace the same provider surface.
 #[derive(Deserialize)]
 pub struct MetadataTimeoutsForm {
     pub metadata_chain_timeout_secs: u64,
     pub metadata_chain_timeout_version: i32,
     pub provider_health_timeout_secs: u64,
     pub provider_health_timeout_version: i32,
+    pub bulk_refetch_delay_ms: u64,
+    pub bulk_refetch_delay_version: i32,
     pub _csrf_token: String,
 }
 
@@ -234,8 +240,14 @@ struct AdminSystemTimeoutsForm {
     provider_health_help: String,
     provider_health_value: u64,
     provider_health_version: i32,
+    bulk_refetch_delay_label: String,
+    bulk_refetch_delay_help: String,
+    bulk_refetch_delay_value: u64,
+    bulk_refetch_delay_version: i32,
     timeout_min: u64,
     timeout_max: u64,
+    bulk_delay_min: u64,
+    bulk_delay_max: u64,
     btn_save: String,
 }
 
@@ -333,7 +345,7 @@ async fn fetch_setting_rows(
 ) -> Result<HashMap<String, (String, i32)>, AppError> {
     let rows: Vec<(String, String, i32)> = sqlx::query_as(
         "SELECT setting_key, setting_value, version FROM settings \
-         WHERE setting_key IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND deleted_at IS NULL",
+         WHERE setting_key IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AND deleted_at IS NULL",
     )
     .bind(KEY_OVERDUE_THRESHOLD)
     .bind(KEY_DEFAULT_LANGUAGE)
@@ -346,6 +358,7 @@ async fn fetch_setting_rows(
     .bind(KEY_METADATA_CHAIN_TIMEOUT)
     .bind(KEY_PROVIDER_HEALTH_TIMEOUT)
     .bind(KEY_SESSION_TIMEOUT_HOURS)
+    .bind(KEY_BULK_REFETCH_DELAY)
     .fetch_all(pool)
     .await?;
     let mut map = HashMap::new();
@@ -562,8 +575,13 @@ fn render_timeouts_form(
     metadata_chain_version: i32,
     provider_health_value: u64,
     provider_health_version: i32,
+    bulk_refetch_delay_value: u64,
+    bulk_refetch_delay_version: i32,
 ) -> Result<String, AppError> {
-    use crate::services::admin_system::{PROVIDER_TIMEOUT_MAX_SECS, PROVIDER_TIMEOUT_MIN_SECS};
+    use crate::services::admin_system::{
+        BULK_REFETCH_DELAY_MAX_MS, BULK_REFETCH_DELAY_MIN_MS, PROVIDER_TIMEOUT_MAX_SECS,
+        PROVIDER_TIMEOUT_MIN_SECS,
+    };
     AdminSystemTimeoutsForm {
         csrf_token: csrf.to_string(),
         metadata_chain_label: rust_i18n::t!("admin.system.metadata_chain_timeout_label", locale = loc)
@@ -584,8 +602,22 @@ fn render_timeouts_form(
         .to_string(),
         provider_health_value,
         provider_health_version,
+        bulk_refetch_delay_label: rust_i18n::t!(
+            "admin.system.bulk_refetch_delay_label",
+            locale = loc
+        )
+        .to_string(),
+        bulk_refetch_delay_help: rust_i18n::t!(
+            "admin.system.bulk_refetch_delay_help",
+            locale = loc
+        )
+        .to_string(),
+        bulk_refetch_delay_value,
+        bulk_refetch_delay_version,
         timeout_min: PROVIDER_TIMEOUT_MIN_SECS,
         timeout_max: PROVIDER_TIMEOUT_MAX_SECS,
+        bulk_delay_min: BULK_REFETCH_DELAY_MIN_MS,
+        bulk_delay_max: BULK_REFETCH_DELAY_MAX_MS,
         btn_save: rust_i18n::t!("admin.system.btn_save_timeouts", locale = loc).to_string(),
     }
     .render()
@@ -724,6 +756,13 @@ pub async fn render_panel_html(
         .cloned()
         .unwrap_or_else(|| (probe_timeout.to_string(), 1));
 
+    // Issue #419 — bulk cover-refetch inter-title delay row.
+    let bulk_delay = state.bulk_refetch_delay_ms();
+    let (_, bulk_delay_version) = rows
+        .get(KEY_BULK_REFETCH_DELAY)
+        .cloned()
+        .unwrap_or_else(|| (bulk_delay.to_string(), 1));
+
     // Issue #418 — session timeout row. The form edits the HOURS key
     // directly (the E2E-only `session_inactivity_timeout_seconds`
     // override is deliberately not surfaced), so read the row value
@@ -744,6 +783,8 @@ pub async fn render_panel_html(
         chain_timeout_version,
         probe_timeout,
         probe_timeout_version,
+        bulk_delay,
+        bulk_delay_version,
     )?;
     // CR #396 — per-provider override rows below the scalar timeouts.
     let override_rows = fetch_provider_timeout_rows(&state.pool).await?;
@@ -1261,7 +1302,15 @@ pub async fn save_metadata_timeouts(
     // submitted values (preserve the typed input) + HX-Trigger so
     // csrf.js opts the 400 swap in. Validate both fields up-front
     // so the user sees a single error per save attempt.
-    if let Err(e) = validate_provider_timeout_secs(form.metadata_chain_timeout_secs, loc) {
+    let validation_result = validate_provider_timeout_secs(form.metadata_chain_timeout_secs, loc)
+        .and_then(|_| validate_provider_timeout_secs(form.provider_health_timeout_secs, loc))
+        .and_then(|_| {
+            crate::services::admin_system::validate_bulk_refetch_delay_ms(
+                form.bulk_refetch_delay_ms,
+                loc,
+            )
+        });
+    if let Err(e) = validation_result {
         let error_msg = match e {
             AppError::BadRequest(msg) => msg,
             other => return Err(other),
@@ -1274,23 +1323,8 @@ pub async fn save_metadata_timeouts(
                 form.metadata_chain_timeout_version,
                 form.provider_health_timeout_secs,
                 form.provider_health_timeout_version,
-            )?,
-            error_msg,
-        ));
-    }
-    if let Err(e) = validate_provider_timeout_secs(form.provider_health_timeout_secs, loc) {
-        let error_msg = match e {
-            AppError::BadRequest(msg) => msg,
-            other => return Err(other),
-        };
-        return Ok(validation_error_response(
-            render_timeouts_form(
-                &session.csrf_token,
-                loc,
-                form.metadata_chain_timeout_secs,
-                form.metadata_chain_timeout_version,
-                form.provider_health_timeout_secs,
-                form.provider_health_timeout_version,
+                form.bulk_refetch_delay_ms,
+                form.bulk_refetch_delay_version,
             )?,
             error_msg,
         ));
@@ -1311,6 +1345,13 @@ pub async fn save_metadata_timeouts(
         form.provider_health_timeout_version,
     )
     .await?;
+    save_setting(
+        &mut *tx,
+        KEY_BULK_REFETCH_DELAY,
+        &form.bulk_refetch_delay_ms.to_string(),
+        form.bulk_refetch_delay_version,
+    )
+    .await?;
     tx.commit().await?;
     reload_settings_cache(&state).await?;
 
@@ -1323,6 +1364,10 @@ pub async fn save_metadata_timeouts(
         .get(KEY_PROVIDER_HEALTH_TIMEOUT)
         .cloned()
         .unwrap_or_else(|| (form.provider_health_timeout_secs.to_string(), 2));
+    let (bulk_delay_value, bulk_delay_version) = rows
+        .get(KEY_BULK_REFETCH_DELAY)
+        .cloned()
+        .unwrap_or_else(|| (form.bulk_refetch_delay_ms.to_string(), 2));
     let main = render_timeouts_form(
         &session.csrf_token,
         loc,
@@ -1330,6 +1375,8 @@ pub async fn save_metadata_timeouts(
         chain_version,
         probe_value.parse().unwrap_or(form.provider_health_timeout_secs),
         probe_version,
+        bulk_delay_value.parse().unwrap_or(form.bulk_refetch_delay_ms),
+        bulk_delay_version,
     )?;
     let feedback = success_feedback(loc, "success.system.timeouts_saved");
     Ok(HtmxResponse {

--- a/src/services/admin_system.rs
+++ b/src/services/admin_system.rs
@@ -80,6 +80,30 @@ pub fn validate_provider_timeout_secs(value: u64, loc: &'static str) -> Result<(
     }
 }
 
+// Issue #419 — inter-title delay for the admin bulk cover-refetch loop
+// (milliseconds). Seeded by migration 20260711000000, default '1000'.
+// Surfaced in the same /admin > System "Metadata Providers" timeouts
+// block as the #334 scalars.
+pub const KEY_BULK_REFETCH_DELAY: &str = "bulk_refetch_delay_ms";
+
+/// Inclusive bounds for the bulk-refetch inter-title delay (ms). 0 is
+/// allowed (explicit "no pacing" opt-out); the 60 s ceiling keeps a
+/// fat-fingered value from stretching a 100-title run past 100 minutes.
+pub const BULK_REFETCH_DELAY_MIN_MS: u64 = 0;
+pub const BULK_REFETCH_DELAY_MAX_MS: u64 = 60_000;
+
+/// Validate the bulk-refetch inter-title delay (ms). Returns
+/// `BadRequest` with a localized message if out of range.
+pub fn validate_bulk_refetch_delay_ms(value: u64, loc: &'static str) -> Result<(), AppError> {
+    if (BULK_REFETCH_DELAY_MIN_MS..=BULK_REFETCH_DELAY_MAX_MS).contains(&value) {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(
+            rust_i18n::t!("error.system.bulk_refetch_delay_invalid", locale = loc).to_string(),
+        ))
+    }
+}
+
 // Issue #418 — admin-configurable session inactivity timeout. The row
 // (seeded by the initial-schema migration, default '4') was already
 // parsed by `AppSettings::load_from_db` into `session_timeout_secs`;

--- a/src/services/bulk_cover_fetch.rs
+++ b/src/services/bulk_cover_fetch.rs
@@ -28,8 +28,30 @@
 //! an `.await`.
 
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+
+use crate::tasks::metadata_fetch::FetchOutcome;
+
+/// #419 — backoff schedule for retrying a title whose chain run came
+/// back [`FetchOutcome::Throttled`] (429/503). Two retries per title:
+/// 5 s then 20 s. v1 freeze (mirrors `RECENT_ACTIVITY_DAYS` /
+/// `SCAN_UNDO_WINDOW_SECS`); a unit test locks the values.
+pub const THROTTLE_RETRY_BACKOFF: &[Duration] =
+    &[Duration::from_secs(5), Duration::from_secs(20)];
+
+/// #419 — backoff delay before retry attempt `attempts_done` (the
+/// number of attempts already burned for this title). `None` once the
+/// schedule is exhausted — the title is then recorded as
+/// provider-failed for the run.
+pub fn retry_backoff(attempts_done: usize) -> Option<Duration> {
+    // First attempt is not a retry — index 1 maps to the first backoff.
+    attempts_done
+        .checked_sub(1)
+        .and_then(|i| THROTTLE_RETRY_BACKOFF.get(i))
+        .copied()
+}
 
 /// Snapshot of where the bulk-cover-refetch currently is. Stored in
 /// `AppState.bulk_cover_fetch` as `Arc<RwLock<BulkCoverFetchStatus>>`.
@@ -47,6 +69,14 @@ pub struct BulkCoverFetchStatus {
     pub processed: usize,
     pub started_at: Option<DateTime<Utc>>,
     pub last_completed_at: Option<DateTime<Utc>>,
+    /// #419 — completion-summary counters. Reset by [`try_start`],
+    /// bumped per title via [`record_outcome`], kept after
+    /// [`mark_complete`] so the Health panel can render "what happened
+    /// last time". Invariant: recovered + provider_failed + not_found
+    /// == processed once the run completes.
+    pub recovered: usize,
+    pub provider_failed: usize,
+    pub not_found: usize,
 }
 
 /// Returned by [`try_start`] when a bulk fetch is already in flight.
@@ -75,6 +105,9 @@ pub fn try_start(
     guard.running = true;
     guard.total = total;
     guard.processed = 0;
+    guard.recovered = 0;
+    guard.provider_failed = 0;
+    guard.not_found = 0;
     guard.started_at = Some(Utc::now());
     Ok(())
 }
@@ -84,6 +117,25 @@ pub fn try_start(
 pub fn increment_processed(status: &Arc<RwLock<BulkCoverFetchStatus>>) {
     if let Ok(mut guard) = status.write() {
         guard.processed = guard.processed.saturating_add(1);
+    }
+}
+
+/// #419 — bucket a title's final [`FetchOutcome`] into the completion
+/// summary. Called once per title, after retries are exhausted:
+/// a still-`Throttled` outcome counts as provider-failed.
+pub fn record_outcome(status: &Arc<RwLock<BulkCoverFetchStatus>>, outcome: FetchOutcome) {
+    if let Ok(mut guard) = status.write() {
+        match outcome {
+            FetchOutcome::CoverRecovered => {
+                guard.recovered = guard.recovered.saturating_add(1)
+            }
+            FetchOutcome::Throttled | FetchOutcome::Failed => {
+                guard.provider_failed = guard.provider_failed.saturating_add(1)
+            }
+            FetchOutcome::NotFound => {
+                guard.not_found = guard.not_found.saturating_add(1)
+            }
+        }
     }
 }
 
@@ -160,6 +212,55 @@ mod tests {
         assert_eq!(snap.total, 5);
         assert_eq!(snap.processed, 2);
         assert!(snap.last_completed_at.is_some());
+    }
+
+    /// #419 — v1 freeze of the throttle-retry schedule: 2 retries,
+    /// 5 s then 20 s. Deliberate value lock, mirrors the
+    /// `RECENT_ACTIVITY_DAYS` test pattern.
+    #[test]
+    fn throttle_retry_backoff_schedule_is_locked() {
+        assert_eq!(
+            THROTTLE_RETRY_BACKOFF,
+            &[Duration::from_secs(5), Duration::from_secs(20)]
+        );
+        // Attempt 1 (nothing burned yet) is not a retry.
+        assert_eq!(retry_backoff(0), None);
+        // After the 1st failed attempt → wait 5 s; after the 2nd → 20 s.
+        assert_eq!(retry_backoff(1), Some(Duration::from_secs(5)));
+        assert_eq!(retry_backoff(2), Some(Duration::from_secs(20)));
+        // Schedule exhausted — the title is written off for this run.
+        assert_eq!(retry_backoff(3), None);
+        assert_eq!(retry_backoff(usize::MAX), None);
+    }
+
+    /// #419 — outcome bucketing: recovered / provider-failed (throttled
+    /// + failed) / not-found, and try_start resets all three.
+    #[test]
+    fn record_outcome_buckets_and_try_start_resets() {
+        let s = Arc::new(RwLock::new(BulkCoverFetchStatus::default()));
+        try_start(&s, 4).unwrap();
+        record_outcome(&s, FetchOutcome::CoverRecovered);
+        record_outcome(&s, FetchOutcome::Throttled);
+        record_outcome(&s, FetchOutcome::Failed);
+        record_outcome(&s, FetchOutcome::NotFound);
+
+        let snap = snapshot(&s);
+        assert_eq!(snap.recovered, 1);
+        assert_eq!(snap.provider_failed, 2, "Throttled + Failed share the bucket");
+        assert_eq!(snap.not_found, 1);
+
+        mark_complete(&s);
+        // Summary survives completion for the "last run" panel render…
+        let snap = snapshot(&s);
+        assert_eq!(snap.recovered, 1);
+        assert!(snap.last_completed_at.is_some());
+
+        // …and the next start wipes it.
+        try_start(&s, 2).unwrap();
+        let snap = snapshot(&s);
+        assert_eq!(snap.recovered, 0);
+        assert_eq!(snap.provider_failed, 0);
+        assert_eq!(snap.not_found, 0);
     }
 
     #[test]

--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -39,6 +39,27 @@ where
     });
 }
 
+/// #419 — per-title outcome of a metadata-fetch run, consumed by the
+/// bulk cover-refetch loop for retry decisions and the completion
+/// summary. The scan-time call sites go through [`fetch_metadata_chain`]
+/// and discard it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchOutcome {
+    /// Metadata resolved AND a cover was downloaded + stored.
+    CoverRecovered,
+    /// Chain exhausted with providers answering 429/503 — transient;
+    /// the bulk loop retries this title with backoff.
+    Throttled,
+    /// A provider-side or internal error consumed the attempt (cover
+    /// download failed, DB update failed). Not retried within the run.
+    Failed,
+    /// Providers answered but no cover exists for this title (or the
+    /// chain genuinely found no metadata). The "legitimately nothing
+    /// there" bucket — per the 2026-05 audit most FR/CH/DE tech
+    /// publishers land here.
+    NotFound,
+}
+
 /// Fetch metadata asynchronously for a title using the provider chain.
 /// This function is meant to be called via `tokio::spawn`.
 ///
@@ -60,6 +81,9 @@ where
 /// `routes::titles::admin_redownload_metadata`, which already calls
 /// `TitleService::invalidate_metadata_cache` before its synchronous
 /// `ChainExecutor::execute` call.
+///
+/// Thin wrapper over [`fetch_metadata_chain_outcome`] for the
+/// scan-time call sites that don't consume the outcome.
 #[allow(clippy::too_many_arguments)]
 pub async fn fetch_metadata_chain(
     pool: DbPool,
@@ -74,6 +98,39 @@ pub async fn fetch_metadata_chain(
     covers_dir: PathBuf,
     force_refresh: bool,
 ) {
+    let _ = fetch_metadata_chain_outcome(
+        pool,
+        title_id,
+        code,
+        code_type,
+        media_type,
+        registry,
+        timeout_secs,
+        per_provider_timeouts,
+        http_client,
+        covers_dir,
+        force_refresh,
+    )
+    .await;
+}
+
+/// #419 — same as [`fetch_metadata_chain`] but reports the per-title
+/// [`FetchOutcome`] so the bulk cover-refetch loop can retry throttled
+/// titles and build its completion summary.
+#[allow(clippy::too_many_arguments)]
+pub async fn fetch_metadata_chain_outcome(
+    pool: DbPool,
+    title_id: u64,
+    code: String,
+    code_type: CodeType,
+    media_type: MediaType,
+    registry: Arc<ProviderRegistry>,
+    timeout_secs: u64,
+    per_provider_timeouts: crate::metadata::chain::ProviderTimeouts,
+    http_client: reqwest::Client,
+    covers_dir: PathBuf,
+    force_refresh: bool,
+) -> FetchOutcome {
     tracing::info!(
         title_id = title_id,
         code = %code,
@@ -99,7 +156,7 @@ pub async fn fetch_metadata_chain(
         );
     }
 
-    match ChainExecutor::execute(
+    let chain_outcome = ChainExecutor::execute_detailed(
         &registry,
         &pool,
         &code,
@@ -108,21 +165,22 @@ pub async fn fetch_metadata_chain(
         timeout_secs,
         &per_provider_timeouts,
     )
-    .await
-    {
+    .await;
+
+    match chain_outcome.result {
         Some(metadata) => {
             tracing::info!(title_id = title_id, code = %code, "Metadata fetch completed successfully");
             if let Err(e) = update_title_from_metadata(&pool, title_id, &metadata).await {
                 tracing::warn!(title_id = title_id, error = %e, "Failed to update title from metadata");
                 mark_failed(&pool, title_id).await;
-                return;
+                return FetchOutcome::Failed;
             }
 
             // Resolve cover URL via the shared fallback helper (fix #225 + #228).
             let cover_url =
                 resolve_cover_url_with_fallback(&http_client, &metadata, &code, &code_type).await;
 
-            if let Some(cover_url) = cover_url.as_deref() {
+            let outcome = if let Some(cover_url) = cover_url.as_deref() {
                 match CoverService::download_and_resize(
                     &http_client,
                     cover_url,
@@ -136,6 +194,9 @@ pub async fn fetch_metadata_chain(
                             update_cover_image_url(&pool, title_id, Some(&local_path)).await
                         {
                             tracing::warn!(title_id = title_id, error = %e, "Failed to update cover_image_url");
+                            FetchOutcome::Failed
+                        } else {
+                            FetchOutcome::CoverRecovered
                         }
                     }
                     Err(e) => {
@@ -143,15 +204,28 @@ pub async fn fetch_metadata_chain(
                         if let Err(db_err) = update_cover_image_url(&pool, title_id, None).await {
                             tracing::warn!(title_id = title_id, error = %db_err, "Failed to clear cover_image_url after download failure");
                         }
+                        FetchOutcome::Failed
                     }
                 }
-            }
+            } else {
+                // Metadata exists but no provider offers a cover — the
+                // "legitimately nothing there" bucket.
+                FetchOutcome::NotFound
+            };
 
             mark_resolved(&pool, title_id).await;
+            outcome
         }
         None => {
-            tracing::info!(title_id = title_id, code = %code, "No metadata found from providers");
-            mark_failed(&pool, title_id).await;
+            if chain_outcome.throttled {
+                tracing::info!(title_id = title_id, code = %code, "Metadata chain throttled (429/503), no result");
+                mark_failed(&pool, title_id).await;
+                FetchOutcome::Throttled
+            } else {
+                tracing::info!(title_id = title_id, code = %code, "No metadata found from providers");
+                mark_failed(&pool, title_id).await;
+                FetchOutcome::NotFound
+            }
         }
     }
 }

--- a/templates/fragments/admin_system_timeouts_form.html
+++ b/templates/fragments/admin_system_timeouts_form.html
@@ -1,9 +1,12 @@
-{# Admin → System → Metadata-chain + provider-health timeouts (v1.7.9 fix #334).
-   Two settings on one form so the admin flips both in a single round-trip.
-   Mirrors the loans-form shape: CSRF first, hidden version per field, hx-post
-   to a dedicated endpoint, outerHTML swap on the form id. Both inputs are
-   number-typed with min/max attributes that mirror the server-side
-   `validate_provider_timeout_secs` bounds (1..=60). #}
+{# Admin → System → Metadata-chain + provider-health timeouts (v1.7.9 fix #334)
+   + bulk cover-refetch inter-title delay (#419).
+   Settings paced against the same provider surface share one form so the
+   admin flips them in a single round-trip. Mirrors the loans-form shape:
+   CSRF first, hidden version per field, hx-post to a dedicated endpoint,
+   outerHTML swap on the form id. All inputs are number-typed with min/max
+   attributes that mirror the server-side bounds
+   (`validate_provider_timeout_secs` 1..=60 s,
+   `validate_bulk_refetch_delay_ms` 0..=60000 ms). #}
 <form id="admin-system-timeouts-form"
       method="POST"
       action="/admin/system/timeouts"
@@ -14,6 +17,7 @@
     <input type="hidden" name="_csrf_token" value="{{ csrf_token|e }}">
     <input type="hidden" name="metadata_chain_timeout_version" value="{{ metadata_chain_version }}">
     <input type="hidden" name="provider_health_timeout_version" value="{{ provider_health_version }}">
+    <input type="hidden" name="bulk_refetch_delay_version" value="{{ bulk_refetch_delay_version }}">
 
     <div class="mb-4">
         <label for="admin-system-metadata-chain-timeout" class="block text-sm font-medium mb-1">{{ metadata_chain_label }}</label>
@@ -39,6 +43,20 @@
                max="{{ timeout_max }}"
                step="1"
                value="{{ provider_health_value }}"
+               required
+               class="w-32 rounded-md border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 px-3 py-2 text-sm">
+    </div>
+
+    <div class="mb-4">
+        <label for="admin-system-bulk-refetch-delay" class="block text-sm font-medium mb-1">{{ bulk_refetch_delay_label }}</label>
+        <p class="text-xs text-stone-500 dark:text-stone-400 mb-2">{{ bulk_refetch_delay_help }}</p>
+        <input id="admin-system-bulk-refetch-delay"
+               name="bulk_refetch_delay_ms"
+               type="number"
+               min="{{ bulk_delay_min }}"
+               max="{{ bulk_delay_max }}"
+               step="100"
+               value="{{ bulk_refetch_delay_value }}"
                required
                class="w-32 rounded-md border border-stone-300 dark:border-stone-600 bg-white dark:bg-stone-800 px-3 py-2 text-sm">
     </div>

--- a/tests/admin_system_integration.rs
+++ b/tests/admin_system_integration.rs
@@ -845,6 +845,145 @@ async fn load_from_db_clamps_out_of_range_timeouts_to_default(pool: DbPool) {
     );
 }
 
+// ─── Issue #419 — bulk cover-refetch delay on the timeouts form ──
+
+/// POST /admin/system/timeouts with the three fields (chain timeout,
+/// probe timeout, bulk-refetch delay): the new delay row is persisted
+/// and the AppSettings cache reloads it.
+#[sqlx::test(migrations = "./migrations")]
+async fn save_metadata_timeouts_persists_bulk_refetch_delay(pool: DbPool) {
+    let username = seed_admin(&pool).await;
+    let state = state_with_pool(pool.clone());
+    let cache = state.settings.clone();
+    let router = app(state);
+    let (cookie, csrf) = login_and_extract(&router, &username, "librarian").await;
+
+    // Pre: migration seed (1000) in cache after first load — the test
+    // state starts from Default (1000) anyway; assert to lock the base.
+    assert_eq!(cache.read().unwrap().bulk_refetch_delay_ms, 1000);
+
+    let body = format!(
+        "metadata_chain_timeout_secs=5&metadata_chain_timeout_version=1\
+         &provider_health_timeout_secs=10&provider_health_timeout_version=1\
+         &bulk_refetch_delay_ms=2500&bulk_refetch_delay_version=1\
+         &_csrf_token={}",
+        csrf
+    );
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/admin/system/timeouts")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "save_timeouts returns 200");
+
+    let row: (String, i32) = sqlx::query_as(
+        "SELECT setting_value, version FROM settings WHERE setting_key = 'bulk_refetch_delay_ms'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "2500");
+    let version_after_first_save = row.1;
+
+    assert_eq!(
+        cache.read().unwrap().bulk_refetch_delay_ms,
+        2500,
+        "AppSettings cache must reflect the new value"
+    );
+
+    // Second save with the versions the re-rendered form carries — the
+    // fetch_setting_rows key list must include the new row, otherwise
+    // the form falls back to version 1 and every save after the first
+    // 409s forever (the log_level bug shape, #406). The first save also
+    // bumped the two sibling rows, so read all current versions.
+    let chain_v: (i32,) = sqlx::query_as(
+        "SELECT version FROM settings WHERE setting_key = 'metadata_chain_per_provider_timeout_secs'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let probe_v: (i32,) = sqlx::query_as(
+        "SELECT version FROM settings WHERE setting_key = 'provider_health_probe_timeout_secs'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let body = format!(
+        "metadata_chain_timeout_secs=5&metadata_chain_timeout_version={}\
+         &provider_health_timeout_secs=10&provider_health_timeout_version={}\
+         &bulk_refetch_delay_ms=3000&bulk_refetch_delay_version={}\
+         &_csrf_token={}",
+        chain_v.0, probe_v.0, version_after_first_save, csrf
+    );
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/admin/system/timeouts")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "second save with the re-rendered version must not 409"
+    );
+    let row: (String,) = sqlx::query_as(
+        "SELECT setting_value FROM settings WHERE setting_key = 'bulk_refetch_delay_ms'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "3000");
+}
+
+/// Out-of-range delay (60001 > 60000) is rejected with 400 and the row
+/// keeps its seeded value.
+#[sqlx::test(migrations = "./migrations")]
+async fn save_metadata_timeouts_rejects_out_of_range_bulk_delay(pool: DbPool) {
+    let username = seed_admin(&pool).await;
+    let state = state_with_pool(pool.clone());
+    let router = app(state);
+    let (cookie, csrf) = login_and_extract(&router, &username, "librarian").await;
+
+    let body = format!(
+        "metadata_chain_timeout_secs=5&metadata_chain_timeout_version=1\
+         &provider_health_timeout_secs=10&provider_health_timeout_version=1\
+         &bulk_refetch_delay_ms=60001&bulk_refetch_delay_version=1\
+         &_csrf_token={}",
+        csrf
+    );
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/admin/system/timeouts")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={}", cookie))
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    let row: (String,) = sqlx::query_as(
+        "SELECT setting_value FROM settings WHERE setting_key = 'bulk_refetch_delay_ms'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(row.0, "1000", "rejected save must not touch the row");
+}
+
 #[allow(clippy::await_holding_lock)]
 #[sqlx::test(migrations = "./migrations")]
 async fn migrate_legacy_env_vars_copies_timeout_env_vars_when_row_is_seeded_default(

--- a/tests/e2e/specs/journeys/bulk-cover-refetch.spec.ts
+++ b/tests/e2e/specs/journeys/bulk-cover-refetch.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+
+/**
+ * Issue #419 — bulk cover-refetch pacing + completion summary.
+ *
+ * Prod evidence (2026-07-10): two back-to-back runs over ~113 titles at
+ * ~1.2 s/title tripped Google Books' throttling (503 storm) and both
+ * runs "completed" silently with ~0 covers — indistinguishable from
+ * "no covers exist". This spec covers the two admin-visible halves of
+ * the fix:
+ *   1. the new inter-title delay knob on the /admin > System timeouts
+ *      form (save, re-render, server-side validation), and
+ *   2. the Health-panel completion summary (recovered / provider
+ *      errors / no cover available) after a real bulk run.
+ *
+ * Serial: both tests mutate the global `bulk_refetch_delay_ms` K/V row,
+ * and the bulk run itself is single-instance stack-wide.
+ */
+test.describe("Issue #419 — bulk cover-refetch pacing + summary", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const delayInput = 'form#admin-system-timeouts-form input[name="bulk_refetch_delay_ms"]';
+  const timeoutsSubmit = 'form#admin-system-timeouts-form button[type="submit"]';
+  const timeoutsSaved = /Timeouts saved|Délais d'attente enregistrés/i;
+
+  test("bulk refetch delay saves, re-renders, and rejects out-of-range", async ({
+    page,
+    request,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=system");
+
+    const input = page.locator(delayInput);
+    await expect(input).toBeVisible();
+    // No seed-value assertion here: the shared E2E DB persists across
+    // runs, so the row may hold whatever the previous invocation saved.
+    // The save → reload → re-render cycle below is the real contract.
+
+    await input.fill("2500");
+    await page.locator(timeoutsSubmit).click();
+    await expect(
+      page.locator("#feedback-list").getByText(timeoutsSaved),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Persisted value re-renders on a fresh page load.
+    await page.goto("/admin?tab=system");
+    await expect(page.locator(delayInput)).toHaveValue("2500");
+
+    // Server-side validation: 60001 > 60000 → 400. Direct POST because
+    // the browser input's max attribute blocks the UI path.
+    const realToken = await page
+      .locator('meta[name="csrf-token"]')
+      .getAttribute("content");
+    expect(realToken).toBeTruthy();
+    const cookies = await page.context().cookies();
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+    const chainVersion = await page
+      .locator('form#admin-system-timeouts-form input[name="metadata_chain_timeout_version"]')
+      .getAttribute("value");
+    const probeVersion = await page
+      .locator('form#admin-system-timeouts-form input[name="provider_health_timeout_version"]')
+      .getAttribute("value");
+    const delayVersion = await page
+      .locator('form#admin-system-timeouts-form input[name="bulk_refetch_delay_version"]')
+      .getAttribute("value");
+    const resp = await request.post("/admin/system/timeouts", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: cookieHeader,
+        "HX-Request": "true",
+      },
+      data:
+        `metadata_chain_timeout_secs=5&metadata_chain_timeout_version=${chainVersion}` +
+        `&provider_health_timeout_secs=10&provider_health_timeout_version=${probeVersion}` +
+        `&bulk_refetch_delay_ms=60001&bulk_refetch_delay_version=${delayVersion}` +
+        `&_csrf_token=${encodeURIComponent(realToken!)}`,
+      maxRedirects: 0,
+    });
+    expect(resp.status()).toBe(400);
+
+    // Prep for the journey test: 0 ms = no pacing, so the bulk run over
+    // the shared E2E DB's accumulated cover-less titles stays fast.
+    await page.goto("/admin?tab=system");
+    const prepInput = page.locator(delayInput);
+    await prepInput.fill("0");
+    await page.locator(timeoutsSubmit).click();
+    await expect(
+      page.locator("#feedback-list").getByText(timeoutsSaved).last(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("bulk refetch run completes with a summary on the Health panel", async ({
+    page,
+  }) => {
+    // The run iterates every missing-cover title in the shared E2E DB
+    // (synthetic BnF catch-all titles never get covers), so give the
+    // whole journey a generous budget even at 0 ms pacing.
+    test.setTimeout(300_000);
+
+    await loginAs(page, "admin");
+
+    // Guarantee at least one missing-cover title exists regardless of
+    // suite composition: the BnF catch-all resolves this unique ISBN
+    // with metadata but no cover URL.
+    await page.goto("/catalog");
+    const scanField = page.locator("#scan-field");
+    await scanField.fill(specIsbn("BF", 1));
+    await scanField.press("Enter");
+    await page.waitForSelector(".feedback-skeleton, .feedback-entry", {
+      timeout: 10000,
+    });
+
+    await page.goto("/admin?tab=health");
+    const refetchButton = page.getByRole("button", {
+      name: /Re-fetch missing covers|Récupérer les couvertures manquantes/i,
+    });
+    await expect(refetchButton).toBeEnabled();
+    await refetchButton.click();
+    await expect(
+      page.getByText(
+        /Bulk cover-refetch started|Récupération en lot lancée/i,
+      ),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Poll the Health panel until the run completes and the #419
+    // summary label lands. Counts are non-deterministic (shared DB) —
+    // assert the shape, not the numbers.
+    const summaryPattern =
+      /(covers recovered|couvertures récupérées).*(provider errors|erreurs fournisseur)/i;
+    await expect(async () => {
+      await page.goto("/admin?tab=health");
+      await expect(page.getByText(summaryPattern)).toBeVisible({
+        timeout: 2000,
+      });
+    }).toPass({ timeout: 240_000, intervals: [5_000] });
+
+    // Reset the shared delay row to the seeded default so the knob does
+    // not leak into other suites/runs.
+    await page.goto("/admin?tab=system");
+    const input = page.locator(delayInput);
+    await input.fill("1000");
+    await page.locator(timeoutsSubmit).click();
+    await expect(
+      page.locator("#feedback-list").getByText(timeoutsSaved).last(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
Closes #419

## Problem

Two prod bulk cover-refetch runs (2026-07-10) over ~113 titles at ~1.2 s/title tripped Google Books' burst throttling — 503 Service Unavailable on essentially every call despite a valid API key — and recovered 1 then 0 covers. Both runs "completed" silently, indistinguishable from "no covers exist for these titles".

## Fix (three parts, per the issue proposal)

**1. Configurable inter-request delay.** New `bulk_refetch_delay_ms` K/V setting (default 1000 ms, bounds 0–60000, seed migration `20260711000000`), exposed on the Admin → System timeouts form (story 8-5 pattern: own version field, partitioned optimistic locking, validation server-side + input min/max). Snapshotted once per run; at 113 titles the default costs ~2 extra minutes — irrelevant for a background admin action.

**2. Retry with exponential backoff on 429/503.** New typed `MetadataError::Unavailable` (Google Books now maps 503 to it; 429 was already typed per #23), propagated through `ChainExecutor::execute_detailed` → `ChainOutcome.throttled` → `FetchOutcome::Throttled`. The bulk loop retries a throttled title on the frozen `THROTTLE_RETRY_BACKOFF` schedule (5 s → 20 s, 2 retries) before writing it off, so a transient storm no longer burns the title's only chance for the run. Scan-time call sites are untouched (`fetch_metadata_chain` / `execute` are now thin wrappers).

**3. Completion summary.** `BulkCoverFetchStatus` gains `recovered` / `provider_failed` / `not_found` counters, rendered in the Health panel's "Last run" label (all 4 locales) and logged at run end. Per the 2026-05 cover-miss audit, most remaining misses will legitimately land in `not_found` — the summary is what makes that visible.

**Bonus latent-bug fix:** the new settings key is added to `fetch_setting_rows`' IN list — without it the form falls back to version 1 and every save after the first 409s forever (same shape as the log_level #406 bug). A save-twice integration test now locks the contract.

## Tests

- Unit: throttle classification (`is_throttle`), `ChainOutcome.throttled` propagation (503 / 429 / genuine-no-result / success-after-throttle, `#[sqlx::test]`), backoff schedule value-lock, outcome bucketing + reset, `load_from_db` clamp.
- Integration: timeouts-form save persists + reloads cache, save-twice version round-trip, out-of-range → 400 leaves row untouched.
- E2E (`bulk-cover-refetch.spec.ts`, serial): settings save/re-render/validation round-trip, then a full journey — seed a cover-less title via scan, run the refetch, assert the Health-panel completion summary; resets the shared delay row afterwards.
- Local: full `cargo test` green, clippy `--all-targets -D warnings` clean, full Playwright suite at CI shape green except one **pre-existing, data-dependent** WCAG contrast failure unrelated to this diff — filed as #424 (the offending span dates from 2026-05-19; CI passes it by spec-ordering luck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)