### PR TITLE
feat(#428): show highest used V-code / L-code on /catalog for label printing

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -146,6 +146,8 @@ home:
 catalog:
   title: Katalog
   scan_placeholder: "Scannen oder eingeben: ISBN, V-Code, L-Code oder Suche…"
+  # #428 — Hilfszeile für den Etikettendruck (höchste V/L-Codes).
+  highest_codes: "Etiketten in Gebrauch bis %{codes} — drucken Sie neue Etikettenbögen ab den folgenden Nummern."
   scan_label: Barcode scannen oder Code eingeben
   scan_received: "Scan empfangen: %{code}"
   new_title_button: Neuer Titel

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -146,6 +146,8 @@ home:
 catalog:
   title: Catalog
   scan_placeholder: "Scan or type: ISBN, V-code, L-code, or search..."
+  # #428 — label-printing helper line (V/L high-water marks).
+  highest_codes: "Labels in use up to %{codes} — print new label sheets starting after these numbers."
   scan_label: Scan barcode or type code
   scan_received: "Scan received: %{code}"
   new_title_button: New title

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -147,6 +147,8 @@ home:
 catalog:
   title: Catalogue
   scan_placeholder: "Scanner ou taper : ISBN, code V, code L, ou recherche..."
+  # #428 — ligne d'aide impression d'étiquettes (plus hauts codes V/L).
+  highest_codes: "Étiquettes utilisées jusqu'à %{codes} — imprimez les nouvelles planches à partir des numéros suivants."
   scan_label: Scanner un code-barres ou taper un code
   scan_received: "Scan reçu : %{code}"
   new_title_button: Nouveau titre

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -143,6 +143,8 @@ home:
 catalog:
   title: Catalogo
   scan_placeholder: "Scansiona o digita: ISBN, codice V, codice L, o ricerca…"
+  # #428 — riga di aiuto per la stampa di etichette (codici V/L più alti).
+  highest_codes: "Etichette in uso fino a %{codes} — stampa i nuovi fogli di etichette a partire dai numeri successivi."
   scan_label: Scansiona codice a barre o digita codice
   scan_received: "Scansione ricevuta: %{code}"
   new_title_button: Nuovo titolo

--- a/src/models/location.rs
+++ b/src/models/location.rs
@@ -35,6 +35,21 @@ impl std::fmt::Display for LocationModel {
 }
 
 impl LocationModel {
+    /// #428 — highest L-code ever used, for the label-printing info line
+    /// on /catalog. DELIBERATELY no `deleted_at IS NULL` filter (a printed
+    /// sticker on a shelf outlives the row's trash state) — intentionally
+    /// ASYMMETRIC with `LocationService::get_next_available_lcode`, which
+    /// proposes creation codes over live rows only. Same fixed-width
+    /// CHAR(5) reasoning as `VolumeModel::highest_label_any`.
+    pub async fn highest_label_any(pool: &DbPool) -> Result<Option<String>, AppError> {
+        let label = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT MAX(label) FROM storage_locations WHERE label REGEXP '^L[0-9]{4}$'",
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(label)
+    }
+
     pub async fn find_by_id(pool: &DbPool, id: u64) -> Result<Option<LocationModel>, AppError> {
         tracing::debug!(id = id, "Looking up location by ID");
 
@@ -347,6 +362,32 @@ impl LocationModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #428 — highest L-code includes soft-deleted rows, deliberately
+    /// ASYMMETRIC with `LocationService::get_next_available_lcode`
+    /// (which proposes creation codes over live rows only).
+    #[sqlx::test(migrations = "./migrations")]
+    async fn highest_label_any_includes_soft_deleted(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        sqlx::query(
+            "INSERT INTO storage_locations (name, node_type, label) VALUES \
+             ('Salon', 'room', 'L0007'), ('Cave', 'room', 'L0042')",
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query("UPDATE storage_locations SET deleted_at = NOW() WHERE label = 'L0042'")
+            .execute(&pool)
+            .await?;
+
+        assert_eq!(
+            LocationModel::highest_label_any(&pool).await?.as_deref(),
+            Some("L0042"),
+            "soft-deleted L-codes stay in the high-water mark"
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn test_location_model_display() {

--- a/src/models/volume.rs
+++ b/src/models/volume.rs
@@ -37,6 +37,29 @@ impl std::fmt::Display for VolumeModel {
 }
 
 impl VolumeModel {
+    /// #428 — highest V-code ever used, for the label-printing info line
+    /// on /catalog ("print new sheets starting after this number").
+    ///
+    /// DELIBERATELY no `deleted_at IS NULL` filter (exception to the
+    /// project-wide rule): a label physically printed and stuck on a book
+    /// that later went to trash must never be re-proposed for a fresh
+    /// sheet — the sticker still exists in the real world. Known
+    /// limitation: once the 30-day auto-purge hard-deletes the row, its
+    /// number silently becomes reusable again (a durable high-water-mark
+    /// counter is out of scope at household scale).
+    ///
+    /// Labels are CHAR(5) `V` + 4 zero-padded digits (validated at
+    /// creation), so lexicographic MAX equals numeric MAX; the REGEXP is
+    /// belt-and-braces against any legacy free-form row.
+    pub async fn highest_label_any(pool: &DbPool) -> Result<Option<String>, AppError> {
+        let label = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT MAX(label) FROM volumes WHERE label REGEXP '^V[0-9]{4}$'",
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(label)
+    }
+
     /// Story 9-9 — narrow lookup returning ONLY the volume id for a
     /// given label. Used by the home-page scan-to-navigate handler
     /// (`/scan?code=…`) which only needs to redirect to `/volume/:id`.
@@ -803,6 +826,48 @@ impl VolumeModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #428 — highest V-code for the label-printing line: numeric order
+    /// via the fixed zero-padded width, and soft-deleted rows COUNT (a
+    /// printed sticker outlives the row's trash state).
+    #[sqlx::test(migrations = "./migrations")]
+    async fn highest_label_any_includes_soft_deleted(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Empty catalog → None.
+        assert_eq!(VolumeModel::highest_label_any(&pool).await?, None);
+
+        let title_id: u64 = sqlx::query(
+            "INSERT INTO titles (title, media_type, genre_id) VALUES ('T428', 'book', 1)",
+        )
+        .execute(&pool)
+        .await?
+        .last_insert_id();
+        sqlx::query("INSERT INTO volumes (title_id, label) VALUES (?, 'V0009'), (?, 'V0010')")
+            .bind(title_id)
+            .bind(title_id)
+            .execute(&pool)
+            .await?;
+
+        assert_eq!(
+            VolumeModel::highest_label_any(&pool).await?.as_deref(),
+            Some("V0010"),
+            "zero-padded width makes lexicographic MAX the numeric MAX"
+        );
+
+        // Soft-delete the max — it must STILL be reported (never reissue
+        // a printed number).
+        sqlx::query("UPDATE volumes SET deleted_at = NOW() WHERE label = 'V0010'")
+            .execute(&pool)
+            .await?;
+        assert_eq!(
+            VolumeModel::highest_label_any(&pool).await?.as_deref(),
+            Some("V0010"),
+            "soft-deleted labels stay in the high-water mark"
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn test_volume_model_display() {

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -147,6 +147,29 @@ pub struct CatalogTemplate {
     pub audio_enable: String,
     pub audio_disable: String,
     pub catalog_scan_help: crate::utils::TooltipData,
+    /// #428 — "labels in use up to V0142 · L0037" info line for printing
+    /// fresh label sheets. Empty string = hidden (no codes yet, or the
+    /// best-effort lookup failed). Rendered for Librarian+ only.
+    pub highest_codes_line: String,
+}
+
+/// #428 — build the "labels in use up to …" info line. Best-effort: any
+/// lookup error degrades to an empty string (line hidden) — the catalog
+/// page must never fail to render because of a label-stat query.
+async fn build_highest_codes_line(pool: &crate::db::DbPool, loc: &str) -> String {
+    let v = crate::models::volume::VolumeModel::highest_label_any(pool)
+        .await
+        .unwrap_or_default();
+    let l = crate::models::location::LocationModel::highest_label_any(pool)
+        .await
+        .unwrap_or_default();
+    let codes = match (v, l) {
+        (Some(v), Some(l)) => format!("{v} · {l}"),
+        (Some(v), None) => v,
+        (None, Some(l)) => l,
+        (None, None) => return String::new(),
+    };
+    rust_i18n::t!("catalog.highest_codes", locale = loc, codes = codes).to_string()
 }
 
 impl CatalogTemplate {
@@ -156,6 +179,7 @@ impl CatalogTemplate {
         session_timeout_secs: u64,
         loc: &str,
         current_url_value: String,
+        highest_codes_line: String,
     ) -> Self {
         // CR #354: shared page-template fields built via base_context. The
         // builder keeps the pre-computed `current_url_value` string (some
@@ -181,6 +205,7 @@ impl CatalogTemplate {
                 "tip-catalog-scan-text",
                 &rust_i18n::t!("help.catalog.scan_field_text", locale = loc),
             ),
+            highest_codes_line,
         }
     }
 }
@@ -225,12 +250,14 @@ pub async fn catalog_page(
     // AC #1: catalog browsing is Anonymous-accessible. Template-layer gates edit affordances.
     let loc = locale.0;
     let guide = compute_guide_message(&state.pool, &session, loc).await;
+    let highest_codes = build_highest_codes_line(&state.pool, loc).await;
     let template = CatalogTemplate::new(
         &session,
         &guide,
         state.session_timeout_secs(),
         loc,
         crate::utils::current_url(&uri),
+        highest_codes,
     );
     match template.render() {
         Ok(html) => Ok(Html(html).into_response()),
@@ -1177,6 +1204,7 @@ pub async fn handle_scan(
             state.session_timeout_secs(),
             loc,
             "/catalog".to_string(),
+            build_highest_codes_line(&state.pool, loc).await,
         );
         // Silence unused — `uri` is kept on the handler signature for
         // future non-fallback branches that may need it.
@@ -1492,6 +1520,7 @@ pub async fn title_form_page(
                     state.session_timeout_secs(),
                     loc,
                     crate::utils::current_url(&uri),
+                    build_highest_codes_line(&state.pool, loc).await,
                 );
                 match catalog.render() {
                     Ok(page_html) => Ok(Html(page_html).into_response()),
@@ -2801,6 +2830,7 @@ mod tests {
             crate::config::AppSettings::default().session_timeout_secs,
             "en",
             "/catalog".to_string(),
+            String::new(),
         );
         let rendered = template.render().unwrap();
         assert!(rendered.contains("scan-field"));
@@ -2825,6 +2855,7 @@ mod tests {
             crate::config::AppSettings::default().session_timeout_secs,
             "en",
             "/catalog".to_string(),
+            String::new(),
         );
         let rendered = template.render().unwrap();
         assert!(rendered.contains(r#"aria-current="page""#));

--- a/templates/pages/catalog.html
+++ b/templates/pages/catalog.html
@@ -17,6 +17,15 @@
         </p>
     </div>
 
+    {# #428 — highest V-code / L-code in use, so freshly printed label
+       sheets start after them. Librarian workflow only; hidden when no
+       codes exist yet (empty line from the handler). #}
+    {% if !highest_codes_line.is_empty() && (base.role == "librarian" || base.role == "admin") %}
+    <p id="highest-codes-line" class="text-xs text-stone-500 dark:text-stone-400 px-3">
+        {{ highest_codes_line }}
+    </p>
+    {% endif %}
+
     <div class="flex items-center justify-between">
         <div id="contributor-list" class="text-sm">
             <!-- Contributor list populated via OOB swap -->

--- a/tests/e2e/specs/journeys/highest-label-codes.spec.ts
+++ b/tests/e2e/specs/journeys/highest-label-codes.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+import { scanTitleAndVolume } from "../../helpers/loans";
+import { createLocation } from "../../helpers/locations";
+
+/**
+ * Issue #428 — "labels in use up to V…· L…" info line on /catalog, so
+ * freshly printed label sheets start after the highest used numbers.
+ *
+ * Determinism in the shared parallel DB: V9999/L9999 are reserved as
+ * never-created by loans.spec.ts / shelving.spec.ts (they assert the
+ * not-found path on them), so once this spec creates V9998 + L9998 no
+ * other spec can out-rank them — the MAX display is stable regardless
+ * of scheduling order.
+ */
+test.describe("Issue #428 — highest V/L-code line on /catalog", () => {
+  test("librarian sees the high-water marks after creating them", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    // scanTitleAndVolume is rerun-safe (the phantom-volume modal handles
+    // an already-existing V9998); the location creation is NOT (UNIQUE
+    // L-code collision on a persistent DB), so only create it when a
+    // previous run hasn't already.
+    await scanTitleAndVolume(page, specIsbn("HC", 1), "V9998");
+    await page.goto("/locations");
+    const existing = page.locator("text=L9998");
+    if (!(await existing.isVisible({ timeout: 2000 }).catch(() => false))) {
+      await createLocation(page, "HC-428 shelf", "L9998");
+    }
+
+    await page.goto("/catalog");
+    const line = page.locator("#highest-codes-line");
+    await expect(line).toBeVisible();
+    await expect(line).toContainText("V9998");
+    await expect(line).toContainText("L9998");
+  });
+
+  test("anonymous visitor does not see the line", async ({ page }) => {
+    // No login — /catalog is anonymous-accessible but the label-printing
+    // line is a Librarian+ affordance.
+    await page.goto("/catalog");
+    // Page rendered (guide strip is anonymous-visible; the scan field is
+    // itself a Librarian+ affordance) — and the label line is absent.
+    await expect(page.locator("#guide-strip")).toBeVisible();
+    await expect(page.locator("#highest-codes-line")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #428

## What

A small Librarian+-only info line under the /catalog guide strip: **"Labels in use up to V0142 · L0037 — print new label sheets starting after these numbers."** Hidden when no codes exist; best-effort (a failed lookup renders the page without the line).

## Design decisions

- **Soft-deleted rows count.** A printed sticker outlives the row's trash state — reissuing its number would create a physical duplicate. Documented exception to the `deleted_at IS NULL` rule, and intentionally asymmetric with `LocationService::get_next_available_lcode` (which proposes creation codes over live rows only). Known limitation (per the issue): the 30-day hard purge eventually frees a number.
- **Lexicographic MAX = numeric MAX** since labels are CHAR(5) `V/L` + 4 zero-padded validated digits; the `REGEXP '^V[0-9]{4}$'` filter is belt-and-braces against legacy rows.
- Surface: /catalog only (where labelling sessions start). The Health-tab placement from the issue's "and/or" was dropped to keep the story minimal — trivially addable later if wanted.

## Tests

- `#[sqlx::test]` per model: numeric ordering and soft-deleted inclusion for both V and L.
- E2E `highest-label-codes.spec.ts`: creates **V9998 + L9998** — deterministic in the shared parallel DB because V9999/L9999 are reserved never-created by `loans.spec.ts` / `shelving.spec.ts` (they assert the not-found path on them) — asserts the line's content, plus an anonymous-visitor absence check. Rerun-safe on a persistent DB (conditional location creation; the scan helper already tolerates the phantom-volume modal).
- i18n keys in all 4 locales; full Rust suite + full Playwright suite (308 tests) green locally at CI shape on a fresh stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)