### PR TITLE
chore(readme): add Docker/GitHub status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 ![CI](https://github.com/guycorbaz/mybibli/actions/workflows/ci.yml/badge.svg?branch=main)
 [![Version](https://img.shields.io/github/v/tag/guycorbaz/mybibli?label=version&sort=semver&color=blue)](https://github.com/guycorbaz/mybibli/releases)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0--or--later-lightgrey)](LICENSE)
+[![Docker Pulls](https://img.shields.io/docker/pulls/gcorbaz/mybibli?logo=docker&label=docker%20pulls)](https://hub.docker.com/r/gcorbaz/mybibli)
+[![Docker Image Size](https://img.shields.io/docker/image-size/gcorbaz/mybibli/1.12.0?logo=docker&label=image%20size)](https://hub.docker.com/r/gcorbaz/mybibli/tags)
+[![Open Issues](https://img.shields.io/github/issues/guycorbaz/mybibli?logo=github)](https://github.com/guycorbaz/mybibli/issues)
+[![Last Commit](https://img.shields.io/github/last-commit/guycorbaz/mybibli/main?logo=github)](https://github.com/guycorbaz/mybibli/commits/main)
+[![Stars](https://img.shields.io/github/stars/guycorbaz/mybibli?logo=github&style=flat)](https://github.com/guycorbaz/mybibli/stargazers)
+[![Rust](https://img.shields.io/badge/rust-2024-orange?logo=rust)](https://www.rust-lang.org/)
 
 > Personal library cataloging for home collectors.
 


### PR DESCRIPTION
## What

Adds six shields.io badges to the README header, alongside the existing CI / Version / License badges:

- **Docker Pulls** — `gcorbaz/mybibli` pull count
- **Docker Image Size** — pinned to tag `1.12.0`
- **Open Issues** — `guycorbaz/mybibli`
- **Last Commit** — `main`
- **Stars**
- **Rust** — edition 2024 (static)

## Notes

- All badges render from public Docker Hub / GitHub data — no CI job, secret, or external-service account required.
- **Maintenance:** the image-size badge is pinned to `1.12.0` in the URL and must be bumped on each release. The Rule #19 doc-sync grep looks for `v1.12.0` (with the `v`), which will **not** match the `1.12.0` in this badge — worth adding to the release checklist, or switch the badge to `latest` for zero maintenance.
- Codecov coverage badge was considered but deferred (requires a coverage CI job + `CODECOV_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)