### PR TITLE
feat(#389): UNIMARC Palier 1 — internal-model conformity (+ #434 cataloging logs)

### DIFF
--- a/docs/unimarc-mapping.md
+++ b/docs/unimarc-mapping.md
@@ -1,0 +1,76 @@
+# UNIMARC field mapping (#389 — Palier 1)
+
+This document is the authoritative correspondence table between mybibli's internal
+data model and the [UNIMARC](https://www.ifla.org/g/unimarc-rc/) bibliographic
+standard. It exists so that:
+
+1. Every cataloged title can be **expressed and stored conformant to UNIMARC**
+   without abandoning the flat, UX-friendly schema.
+2. There is a documented, testable contract (`tests/unimarc_mapping.rs`) that a
+   title's fields round-trip losslessly to/from their UNIMARC zones.
+3. A future **Palier 2** (ISO 2709 `.mrc` / UNIMARC XML import-export — tracked
+   separately) has a stable foundation to build on.
+
+**Scope of Palier 1:** internal-model conformity only. No `.mrc` / XML
+serialization is produced yet — that is Palier 2.
+
+## Storage decision
+
+mybibli keeps the **flat `titles` table** and enriches it with a pragmatic
+subset of the most common UNIMARC zones (below). We deliberately do **not**
+introduce a parallel "raw UNIMARC zones" table: the pragmatic subset is
+sufficient for a domestic / small-association library, and a raw-zone store only
+becomes necessary if Palier 2 demands byte-fidelity round-trip with an external
+SIGB. Structured contributors and work-level series already live in their own
+tables (`title_contributors`, `series` / `title_series`).
+
+## Mapping table
+
+Legend — **Source**: `titles` = column on the `titles` table; `title_contributors`
+/ `series` = related table. **Status**: `existing` (pre-#389), `new` (added by
+migration `20260724000000_titles_unimarc_zones.sql`), `related-table`.
+
+| UNIMARC zone | Label | mybibli field | Source | Status |
+|---|---|---|---|---|
+| 010$a | ISBN | `isbn` | titles | existing |
+| 011$a | ISSN | `issn` | titles | existing |
+| 101$a | Language of the work | `language` | titles | existing |
+| 200$a | Title proper | `title` | titles | existing |
+| 200$e | Other title information (subtitle) | `subtitle` | titles | existing |
+| 200$f / 200$g | Statement of responsibility | `statement_of_responsibility` | titles | **new** |
+| 205$a | Edition statement | `edition_statement` | titles | **new** |
+| 210$c | Publisher | `publisher` | titles | existing |
+| 210$d | Date of publication | `publication_date` | titles | existing |
+| 215$a | Extent (page count) | `page_count` | titles | existing |
+| 225$a | Collection / publisher's series title | `collection_title` | titles | **new** |
+| 225$v | Collection volume numbering | `collection_number` | titles | **new** |
+| 300$a | General note | `general_note` | titles | **new** |
+| 330$a | Summary / abstract | `description` | titles | existing |
+| 454 / 500$a | Uniform / original title | `original_title` | titles | **new** |
+| 676$a | Dewey Decimal Classification | `dewey_code` | titles | existing |
+| 700 / 701 / 702 | Personal-name responsibility (author, etc.) | contributor + `contributor_roles.name` | `title_contributors` | related-table |
+| 410 (work-level series) | Series link | `series` + `title_series.position_number` | `series` / `title_series` | related-table |
+
+### Notes on zone choices
+
+- **200$f vs 700**: 200$f is the transcribed *statement of responsibility* (the
+  by-line exactly as printed); the 7xx block holds *structured, indexed* name
+  entries. mybibli keeps both — `statement_of_responsibility` for fidelity and
+  `title_contributors` for search/indexing. `src/metadata/bnf.rs` already reads
+  200$f as an author fallback; Palier 1 stops discarding it.
+- **225 vs 410**: 225 is the collection *as printed on the item* (publisher's
+  series, e.g. "Folio SF, 42"); 410 links to the *work-level* series entity.
+  mybibli's `series` table models 410; the new `collection_*` columns model 225.
+  They are intentionally distinct and may both be populated.
+- **Cover image** (`cover_image_url`) has no standard UNIMARC bibliographic zone
+  and is out of scope for conformity — it is a mybibli convenience field.
+
+## Data migration for existing titles
+
+The migration is **additive** (all new columns NULLable) — the 207 titles already
+in production keep every value; nothing is transformed. The new zones are
+populated by an application-layer **BnF re-fetch backfill** (same mechanism as the
+cover re-fetch, #427): for any title BnF knows, `statement_of_responsibility`,
+`collection_*`, etc. are filled from the UNIMARC record. Titles unknown to BnF
+stay sparse until manually enriched — incompleteness, never corruption. The
+backfill run is observable through the `info`-level cataloging logs added by #434.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -826,6 +826,11 @@ admin:
       empty: "Keine Titel benötigen einen Cover-Nachzug — alles, was abrufbar war, ist abgerufen."
       already_running: "Ein Cover-Nachzug läuft bereits. Bitte warten Sie auf den Abschluss."
       review_cta: "Titel ohne Cover ansehen"
+    bulk_metadata_backfill:
+      button: "Metadaten von der BnF nachladen"
+      started: "Massenhaftes Metadaten-Nachladen für %{total} Titel gestartet. Fortschritt steht im Log; aktualisieren Sie das Panel für Updates."
+      empty: "Keine Titel mit einem Suchcode zum Nachladen."
+      already_running: "Ein BnF-Massenvorgang läuft bereits. Bitte warten Sie auf den Abschluss."
   users:
     heading: Benutzerkonten
     empty_state: "Nur Sie hier! Erstellen Sie ein Bibliothekar-Konto für andere Haushaltsmitglieder."

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -556,6 +556,12 @@ metadata:
     publisher: Verlag
     publication_date: Erscheinungsdatum
     dewey_code: Dewey-Code
+    # #389 — UNIMARC-zone metadata labels (palier 1) surfaced on title detail.
+    statement_of_responsibility: Verfasserangabe
+    edition_statement: Ausgabe
+    collection: Reihe
+    general_note: Anmerkung
+    original_title: Originaltitel
     page_count: Seitenzahl
     track_count: Anzahl Titel
     total_duration: "Dauer (Min.)"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -563,6 +563,12 @@ metadata:
     publisher: Publisher
     publication_date: Publication date
     dewey_code: Dewey code
+    # #389 — UNIMARC-zone metadata labels (palier 1) surfaced on title detail.
+    statement_of_responsibility: Statement of responsibility
+    edition_statement: Edition
+    collection: Collection
+    general_note: Note
+    original_title: Original title
     page_count: Page count
     track_count: Track count
     total_duration: "Duration (min)"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -840,6 +840,11 @@ admin:
       empty: "No titles need a cover refetch — everything that can be fetched has been."
       already_running: "A bulk cover-refetch is already in progress. Please wait for it to complete."
       review_cta: "Review titles without a cover"
+    bulk_metadata_backfill:
+      button: "Backfill metadata from BnF"
+      started: "Bulk metadata backfill started for %{total} titles. Progress is logged; refresh the panel to see updates."
+      empty: "No titles with a lookup code to backfill."
+      already_running: "A bulk BnF operation is already in progress. Please wait for it to complete."
   users:
     heading: User accounts
     empty_state: "Only you here! Create a Librarian account for household members."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -558,6 +558,12 @@ metadata:
     publisher: Éditeur
     publication_date: Date de publication
     dewey_code: Code Dewey
+    # #389 — UNIMARC-zone metadata labels (palier 1) surfaced on title detail.
+    statement_of_responsibility: Mention de responsabilité
+    edition_statement: Édition
+    collection: Collection
+    general_note: Note
+    original_title: Titre original
     page_count: Nombre de pages
     track_count: Nombre de pistes
     total_duration: "Durée (min)"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -835,6 +835,11 @@ admin:
       empty: "Aucun titre n'a besoin d'être re-fetché — tout ce qui peut être récupéré l'a été."
       already_running: "Une récupération en lot est déjà en cours. Attendez sa fin."
       review_cta: "Voir les titres sans couverture"
+    bulk_metadata_backfill:
+      button: "Compléter les métadonnées via BnF"
+      started: "Complément des métadonnées en lot lancé pour %{total} titres. La progression est journalisée ; rafraîchissez le panneau pour voir les mises à jour."
+      empty: "Aucun titre avec un code à compléter."
+      already_running: "Une opération BnF en lot est déjà en cours. Attendez sa fin."
   users:
     heading: "Comptes utilisateurs"
     empty_state: "Vous êtes seul·e ! Créez un compte Bibliothécaire pour les membres du foyer."

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -547,6 +547,12 @@ metadata:
     publisher: Editore
     publication_date: Data di pubblicazione
     dewey_code: Codice Dewey
+    # #389 — UNIMARC-zone metadata labels (palier 1) surfaced on title detail.
+    statement_of_responsibility: Formulazione di responsabilità
+    edition_statement: Edizione
+    collection: Collana
+    general_note: Nota
+    original_title: Titolo originale
     page_count: Numero di pagine
     track_count: Numero di tracce
     total_duration: "Durata (min)"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -814,6 +814,11 @@ admin:
       empty: "Nessun titolo ha bisogno di un nuovo recupero copertina — tutto ciò che era recuperabile è stato recuperato."
       already_running: "Un riscaricamento delle copertine è già in corso. Attendi il suo completamento."
       review_cta: "Vedi i titoli senza copertina"
+    bulk_metadata_backfill:
+      button: "Recupera metadati dalla BnF"
+      started: "Recupero massivo dei metadati avviato per %{total} titoli. Il progresso è registrato nei log; aggiorna il pannello per vedere gli aggiornamenti."
+      empty: "Nessun titolo con un codice da completare."
+      already_running: "Un'operazione BnF massiva è già in corso. Attendi il suo completamento."
   users:
     heading: Account utenti
     empty_state: "Solo tu qui! Crea un account Bibliotecario per i membri della famiglia."

--- a/migrations/20260724000000_titles_unimarc_zones.sql
+++ b/migrations/20260724000000_titles_unimarc_zones.sql
@@ -1,0 +1,22 @@
+-- #389 Palier 1 — UNIMARC internal-model conformity.
+--
+-- Additive migration: adds nullable columns to `titles` for UNIMARC zones the
+-- flat schema did not yet capture explicitly. Existing rows are preserved
+-- unchanged (every column is NULLable, no backfill inside the migration — the
+-- BnF re-fetch backfill runs at the application layer, observable via #434 logs).
+--
+-- Zone reference (see docs/unimarc-mapping.md for the full mapping table):
+--   200$f/$g  statement of responsibility  (already read by src/metadata/bnf.rs, previously dropped)
+--   205$a     edition statement
+--   225$a     collection (publisher's series) title — distinct from the work-level `series` table
+--   225$v     collection numbering
+--   300$a     general note
+--   454/500   original / uniform title (useful for translations)
+
+ALTER TABLE titles
+    ADD COLUMN statement_of_responsibility VARCHAR(1000) NULL AFTER subtitle,
+    ADD COLUMN edition_statement          VARCHAR(255)  NULL AFTER statement_of_responsibility,
+    ADD COLUMN collection_title           VARCHAR(500)  NULL AFTER publisher,
+    ADD COLUMN collection_number          VARCHAR(50)   NULL AFTER collection_title,
+    ADD COLUMN general_note               TEXT          NULL AFTER description,
+    ADD COLUMN original_title             VARCHAR(500)  NULL AFTER title;

--- a/src/metadata/bnf.rs
+++ b/src/metadata/bnf.rs
@@ -115,6 +115,14 @@ impl BnfProvider {
             language: Self::extract_subfield(xml, "101", "a"),
             description: Self::extract_subfield(xml, "330", "a"),
             dewey_code: Self::extract_subfield(xml, "676", "a"),
+            // #389 Palier 1 — UNIMARC pragmatic-subset zones. Note 200$f is
+            // also read above as an author fallback; both uses coexist.
+            statement_of_responsibility: Self::extract_subfield(xml, "200", "f"),
+            edition_statement: Self::extract_subfield(xml, "205", "a"),
+            collection_title: Self::extract_subfield(xml, "225", "a"),
+            collection_number: Self::extract_subfield(xml, "225", "v"),
+            general_note: Self::extract_subfield(xml, "300", "a"),
+            original_title: Self::extract_subfield(xml, "500", "a"),
             authors,
             page_count,
             ..MetadataResult::default()
@@ -399,6 +407,60 @@ mod tests {
     fn test_parse_sru_response_without_dewey_returns_none() {
         let result = BnfProvider::parse_sru_response(SAMPLE_BNF_RESPONSE).unwrap();
         assert!(result.dewey_code.is_none());
+    }
+
+    #[test]
+    fn test_parse_sru_response_unimarc_palier1_zones() {
+        // #389 Palier 1 — 205$a, 225$a, 225$v, 300$a, 500$a plus 200$f
+        // (statement of responsibility, which also feeds the author fallback).
+        let xml = r#"<record>
+          <mxc:datafield tag="200" ind1="1" ind2=" ">
+            <mxc:subfield code="a">Fondation</mxc:subfield>
+            <mxc:subfield code="f">Isaac Asimov ; traduit de l'anglais</mxc:subfield>
+          </mxc:datafield>
+          <mxc:datafield tag="205" ind1=" " ind2=" ">
+            <mxc:subfield code="a">Nouvelle édition revue</mxc:subfield>
+          </mxc:datafield>
+          <mxc:datafield tag="225" ind1=" " ind2=" ">
+            <mxc:subfield code="a">Folio SF</mxc:subfield>
+            <mxc:subfield code="v">42</mxc:subfield>
+          </mxc:datafield>
+          <mxc:datafield tag="300" ind1=" " ind2=" ">
+            <mxc:subfield code="a">Traduction de : Foundation</mxc:subfield>
+          </mxc:datafield>
+          <mxc:datafield tag="500" ind1="1" ind2=" ">
+            <mxc:subfield code="a">Foundation</mxc:subfield>
+          </mxc:datafield>
+        </record>"#;
+        let meta = BnfProvider::parse_sru_response(xml).unwrap();
+        assert_eq!(meta.title.as_deref(), Some("Fondation"));
+        assert_eq!(
+            meta.statement_of_responsibility.as_deref(),
+            Some("Isaac Asimov ; traduit de l'anglais")
+        );
+        assert_eq!(meta.edition_statement.as_deref(), Some("Nouvelle édition revue"));
+        assert_eq!(meta.collection_title.as_deref(), Some("Folio SF"));
+        assert_eq!(meta.collection_number.as_deref(), Some("42"));
+        assert_eq!(
+            meta.general_note.as_deref(),
+            Some("Traduction de : Foundation")
+        );
+        assert_eq!(meta.original_title.as_deref(), Some("Foundation"));
+        // 200$f still feeds the author fallback (no 700 field present).
+        assert_eq!(meta.authors, vec!["Isaac Asimov ; traduit de l'anglais"]);
+    }
+
+    #[test]
+    fn test_parse_sru_response_without_palier1_zones_returns_none() {
+        // The base sample has none of the Palier 1 zones except 200$f.
+        let meta = BnfProvider::parse_sru_response(SAMPLE_BNF_RESPONSE).unwrap();
+        assert!(meta.edition_statement.is_none());
+        assert!(meta.collection_title.is_none());
+        assert!(meta.collection_number.is_none());
+        assert!(meta.general_note.is_none());
+        assert!(meta.original_title.is_none());
+        // 200$f IS present in the sample, so statement_of_responsibility carries it.
+        assert_eq!(meta.statement_of_responsibility.as_deref(), Some("Boris Vian"));
     }
 
     #[test]

--- a/src/metadata/provider.rs
+++ b/src/metadata/provider.rs
@@ -24,6 +24,13 @@ pub struct MetadataResult {
     pub age_rating: Option<String>,
     pub issue_number: Option<String>,
     pub dewey_code: Option<String>,
+    // #389 Palier 1 — UNIMARC pragmatic-subset zones.
+    pub statement_of_responsibility: Option<String>,
+    pub edition_statement: Option<String>,
+    pub collection_title: Option<String>,
+    pub collection_number: Option<String>,
+    pub general_note: Option<String>,
+    pub original_title: Option<String>,
 }
 
 /// Trim a metadata string and treat the empty / whitespace-only result
@@ -64,6 +71,12 @@ impl MetadataResult {
         self.age_rating = normalize_empty(self.age_rating);
         self.issue_number = normalize_empty(self.issue_number);
         self.dewey_code = normalize_empty(self.dewey_code);
+        self.statement_of_responsibility = normalize_empty(self.statement_of_responsibility);
+        self.edition_statement = normalize_empty(self.edition_statement);
+        self.collection_title = normalize_empty(self.collection_title);
+        self.collection_number = normalize_empty(self.collection_number);
+        self.general_note = normalize_empty(self.general_note);
+        self.original_title = normalize_empty(self.original_title);
         self.authors = self
             .authors
             .into_iter()

--- a/src/models/metadata_cache.rs
+++ b/src/models/metadata_cache.rs
@@ -118,6 +118,31 @@ impl MetadataCacheModel {
                 .get("dewey_code")
                 .and_then(|v| v.as_str())
                 .map(String::from),
+            // #389 Palier 1 — UNIMARC pragmatic-subset zones.
+            statement_of_responsibility: obj
+                .get("statement_of_responsibility")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            edition_statement: obj
+                .get("edition_statement")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            collection_title: obj
+                .get("collection_title")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            collection_number: obj
+                .get("collection_number")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            general_note: obj
+                .get("general_note")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            original_title: obj
+                .get("original_title")
+                .and_then(|v| v.as_str())
+                .map(String::from),
         })
     }
 
@@ -138,6 +163,13 @@ impl MetadataCacheModel {
             "age_rating": result.age_rating,
             "issue_number": result.issue_number,
             "dewey_code": result.dewey_code,
+            // #389 Palier 1 — UNIMARC pragmatic-subset zones.
+            "statement_of_responsibility": result.statement_of_responsibility,
+            "edition_statement": result.edition_statement,
+            "collection_title": result.collection_title,
+            "collection_number": result.collection_number,
+            "general_note": result.general_note,
+            "original_title": result.original_title,
         })
     }
 }

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -11,12 +11,24 @@ use crate::models::{DEFAULT_PAGE_SIZE, PaginatedList};
 pub struct TitleModel {
     pub id: u64,
     pub title: String,
+    /// UNIMARC 454/500 — title of the original work (for translations).
+    pub original_title: Option<String>,
     pub subtitle: Option<String>,
+    /// UNIMARC 200$f — statement of responsibility.
+    pub statement_of_responsibility: Option<String>,
     pub description: Option<String>,
+    /// UNIMARC 300$a — general note.
+    pub general_note: Option<String>,
     pub language: String,
     pub media_type: String,
     pub publication_date: Option<NaiveDate>,
     pub publisher: Option<String>,
+    /// UNIMARC 205$a — edition statement.
+    pub edition_statement: Option<String>,
+    /// UNIMARC 225$a — collection (series) title.
+    pub collection_title: Option<String>,
+    /// UNIMARC 225$v — collection (series) number.
+    pub collection_number: Option<String>,
     pub isbn: Option<String>,
     pub issn: Option<String>,
     pub upc: Option<String>,
@@ -66,18 +78,31 @@ pub struct NewTitle {
     pub total_duration: Option<i32>,
     pub age_rating: Option<String>,
     pub issue_number: Option<i32>,
+    // UNIMARC Palier 1 (#389) zones — populated by the BnF backfill.
+    pub statement_of_responsibility: Option<String>,
+    pub edition_statement: Option<String>,
+    pub collection_title: Option<String>,
+    pub collection_number: Option<String>,
+    pub general_note: Option<String>,
+    pub original_title: Option<String>,
 }
 
 fn row_to_title(row: sqlx::mysql::MySqlRow) -> Result<TitleModel, sqlx::Error> {
     Ok(TitleModel {
         id: row.try_get("id")?,
         title: row.try_get("title")?,
+        original_title: row.try_get("original_title")?,
         subtitle: row.try_get("subtitle")?,
+        statement_of_responsibility: row.try_get("statement_of_responsibility")?,
         description: row.try_get("description")?,
+        general_note: row.try_get("general_note")?,
         language: row.try_get("language")?,
         media_type: row.try_get("media_type")?,
         publication_date: row.try_get("publication_date")?,
         publisher: row.try_get("publisher")?,
+        edition_statement: row.try_get("edition_statement")?,
+        collection_title: row.try_get("collection_title")?,
+        collection_number: row.try_get("collection_number")?,
         isbn: row.try_get("isbn")?,
         issn: row.try_get("issn")?,
         upc: row.try_get("upc")?,
@@ -99,8 +124,11 @@ impl TitleModel {
         tracing::debug!(isbn = %isbn, "Looking up title by ISBN");
 
         let row = sqlx::query(
-            r#"SELECT id, title, subtitle, description, language,
-                      media_type, publication_date, publisher, isbn, issn, upc,
+            r#"SELECT id, title, original_title, subtitle, statement_of_responsibility,
+                      description, general_note, language,
+                      media_type, publication_date, publisher,
+                      edition_statement, collection_title, collection_number,
+                      isbn, issn, upc,
                       cover_image_url, genre_id, dewey_code,
                       page_count, track_count, total_duration,
                       age_rating, issue_number,
@@ -140,8 +168,11 @@ impl TitleModel {
         tracing::debug!(upc = %upc, "Looking up title by UPC");
 
         let row = sqlx::query(
-            r#"SELECT id, title, subtitle, description, language,
-                      media_type, publication_date, publisher, isbn, issn, upc,
+            r#"SELECT id, title, original_title, subtitle, statement_of_responsibility,
+                      description, general_note, language,
+                      media_type, publication_date, publisher,
+                      edition_statement, collection_title, collection_number,
+                      isbn, issn, upc,
                       cover_image_url, genre_id, dewey_code,
                       page_count, track_count, total_duration,
                       age_rating, issue_number,
@@ -164,8 +195,11 @@ impl TitleModel {
         tracing::debug!(issn = %issn, "Looking up title by ISSN");
 
         let row = sqlx::query(
-            r#"SELECT id, title, subtitle, description, language,
-                      media_type, publication_date, publisher, isbn, issn, upc,
+            r#"SELECT id, title, original_title, subtitle, statement_of_responsibility,
+                      description, general_note, language,
+                      media_type, publication_date, publisher,
+                      edition_statement, collection_title, collection_number,
+                      isbn, issn, upc,
                       cover_image_url, genre_id, dewey_code,
                       page_count, track_count, total_duration,
                       age_rating, issue_number,
@@ -188,8 +222,11 @@ impl TitleModel {
         tracing::debug!(id = id, "Looking up title by ID");
 
         let row = sqlx::query(
-            r#"SELECT id, title, subtitle, description, language,
-                      media_type, publication_date, publisher, isbn, issn, upc,
+            r#"SELECT id, title, original_title, subtitle, statement_of_responsibility,
+                      description, general_note, language,
+                      media_type, publication_date, publisher,
+                      edition_statement, collection_title, collection_number,
+                      isbn, issn, upc,
                       cover_image_url, genre_id, dewey_code,
                       page_count, track_count, total_duration,
                       age_rating, issue_number,
@@ -388,8 +425,11 @@ impl TitleModel {
         let result = sqlx::query(
             r#"INSERT INTO titles (title, subtitle, language, media_type, publication_date,
                                    publisher, isbn, issn, upc, genre_id, page_count,
-                                   track_count, total_duration, age_rating, issue_number)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                                   track_count, total_duration, age_rating, issue_number,
+                                   statement_of_responsibility, edition_statement,
+                                   collection_title, collection_number, general_note,
+                                   original_title)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&new_title.title)
         .bind(&new_title.subtitle)
@@ -406,6 +446,12 @@ impl TitleModel {
         .bind(new_title.total_duration)
         .bind(&new_title.age_rating)
         .bind(new_title.issue_number)
+        .bind(&new_title.statement_of_responsibility)
+        .bind(&new_title.edition_statement)
+        .bind(&new_title.collection_title)
+        .bind(&new_title.collection_number)
+        .bind(&new_title.general_note)
+        .bind(&new_title.original_title)
         .execute(pool)
         .await?;
 
@@ -413,6 +459,51 @@ impl TitleModel {
         TitleModel::find_by_id(pool, id)
             .await?
             .ok_or_else(|| AppError::Internal("Failed to retrieve created title".to_string()))
+    }
+
+    /// Backfill the six UNIMARC Palier 1 (#389) zones on an existing title.
+    ///
+    /// Best-effort, gap-filling update: each column is wrapped in
+    /// `COALESCE(?, col)` so passing `None` for an argument leaves the
+    /// existing value untouched (backfill only fills gaps — it never
+    /// wipes data). Intentionally does NOT do optimistic-lock version
+    /// checking; the BnF backfill path is best-effort and must not fail
+    /// on a concurrent edit.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_unimarc_zones(
+        pool: &DbPool,
+        id: u64,
+        statement_of_responsibility: Option<&str>,
+        edition_statement: Option<&str>,
+        collection_title: Option<&str>,
+        collection_number: Option<&str>,
+        general_note: Option<&str>,
+        original_title: Option<&str>,
+    ) -> Result<(), AppError> {
+        tracing::debug!(id = id, "Backfilling UNIMARC zones on title");
+
+        sqlx::query(
+            "UPDATE titles SET \
+             statement_of_responsibility = COALESCE(?, statement_of_responsibility), \
+             edition_statement = COALESCE(?, edition_statement), \
+             collection_title = COALESCE(?, collection_title), \
+             collection_number = COALESCE(?, collection_number), \
+             general_note = COALESCE(?, general_note), \
+             original_title = COALESCE(?, original_title), \
+             version = version + 1, updated_at = NOW() \
+             WHERE id = ? AND deleted_at IS NULL",
+        )
+        .bind(statement_of_responsibility)
+        .bind(edition_statement)
+        .bind(collection_title)
+        .bind(collection_number)
+        .bind(general_note)
+        .bind(original_title)
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+        Ok(())
     }
 
     /// Update a title with optimistic locking (version check).
@@ -1381,6 +1472,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         assert_eq!(title.to_string(), "L'Étranger (book)");
@@ -1409,6 +1506,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         assert_eq!(title.to_string(), "Kind of Blue (cd)");
@@ -1436,6 +1539,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         }
     }

--- a/src/models/title.rs
+++ b/src/models/title.rs
@@ -311,6 +311,80 @@ impl TitleModel {
         Ok(titles)
     }
 
+    /// #389 Palier 1 — count of active titles that carry any lookup code
+    /// (ISBN / ISSN / UPC). Drives the "Backfill metadata from BnF" admin
+    /// action, which re-fetches metadata for the whole coded-title set so
+    /// the newly-added UNIMARC zones populate on already-cataloged titles.
+    /// Unlike [`count_missing_covers`], there is NO `cover_image_url` filter
+    /// — every coded title is a candidate regardless of cover state.
+    pub async fn count_all_with_code(pool: &DbPool) -> Result<i64, AppError> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM titles \
+             WHERE deleted_at IS NULL \
+               AND ((isbn IS NOT NULL AND isbn <> '') \
+                 OR (issn IS NOT NULL AND issn <> '') \
+                 OR (upc IS NOT NULL AND upc <> ''))",
+        )
+        .fetch_one(pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    /// #389 Palier 1 — list every active title that carries a lookup code,
+    /// for the bulk metadata backfill. Reuses the [`MissingCoverTitle`]
+    /// projection and the same ISBN → UPC → ISSN priority as
+    /// [`list_missing_covers`], but WITHOUT the `cover_image_url IS NULL`
+    /// filter: the goal here is to re-run the metadata chain over the whole
+    /// coded catalog so new UNIMARC zones backfill on existing titles.
+    ///
+    /// Ordered by `created_at ASC` so the oldest titles fill in first.
+    pub async fn list_all_with_code(
+        pool: &DbPool,
+    ) -> Result<Vec<MissingCoverTitle>, AppError> {
+        let rows = sqlx::query(
+            "SELECT id, isbn, issn, upc, media_type FROM titles \
+             WHERE deleted_at IS NULL \
+               AND ((isbn IS NOT NULL AND isbn <> '') \
+                 OR (issn IS NOT NULL AND issn <> '') \
+                 OR (upc IS NOT NULL AND upc <> '')) \
+             ORDER BY created_at ASC",
+        )
+        .fetch_all(pool)
+        .await?;
+
+        let titles = rows
+            .into_iter()
+            .filter_map(|r| {
+                let id: u64 = r.try_get("id").ok()?;
+                let isbn: Option<String> = r.try_get("isbn").ok().flatten();
+                let issn: Option<String> = r.try_get("issn").ok().flatten();
+                let upc: Option<String> = r.try_get("upc").ok().flatten();
+                let media_type: String = r.try_get("media_type").ok()?;
+                // Priority order: ISBN first (best provider coverage),
+                // then UPC, then ISSN. Empty strings are treated as absent
+                // to match the SQL `<> ''` filter.
+                let (code, code_type) = isbn
+                    .filter(|c| !c.is_empty())
+                    .map(|c| (c, crate::models::media_type::CodeType::Isbn))
+                    .or_else(|| {
+                        upc.filter(|c| !c.is_empty())
+                            .map(|c| (c, crate::models::media_type::CodeType::Upc))
+                    })
+                    .or_else(|| {
+                        issn.filter(|c| !c.is_empty())
+                            .map(|c| (c, crate::models::media_type::CodeType::Issn))
+                    })?;
+                Some(MissingCoverTitle {
+                    id,
+                    code,
+                    code_type,
+                    media_type,
+                })
+            })
+            .collect();
+        Ok(titles)
+    }
+
     /// Count of active (non-soft-deleted) titles in the catalog.
     /// Used by `services::dashboard::collection_glance` for the home-page
     /// "Collection at a glance" card and reusable by other dashboard surfaces.

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -166,6 +166,11 @@ struct AdminHealthPanel {
     // bulk-refetch left titles uncovered (the FR/CH/DE publisher gap) has a
     // direct path to the manual-upload review list. Shown when count > 0.
     bulk_cover_fetch_review_cta: String,
+    // #389 Palier 1 — "Backfill metadata from BnF": re-fetch metadata for
+    // every coded title so the new UNIMARC zones populate on existing rows.
+    // Shares the cover-refetch status lock (mutual exclusion).
+    bulk_metadata_backfill_button_label: String,
+    bulk_metadata_backfill_can_start: bool,
 }
 
 struct ProviderHealthRow {
@@ -333,9 +338,38 @@ pub async fn admin_bulk_cover_refetch(
         "Bulk cover-refetch started"
     );
 
-    // Spawn the detached worker. Clones what it needs from AppState
-    // (cheap — all Arc-wrapped); no shared mutable references.
-    let pool_clone = pool.clone();
+    // Spawn the shared detached BnF worker (#389 factored it out — see
+    // `spawn_bulk_bnf_worker`). The `bulk_cover_fetch` status lock has
+    // already been armed by `try_start` above.
+    spawn_bulk_bnf_worker(&state, titles, "Bulk cover-refetch");
+
+    let message = rust_i18n::t!(
+        "admin.health.bulk_cover_fetch.started",
+        locale = loc,
+        total = total
+    )
+    .to_string();
+    Ok(crate::utils::feedback_html("success", &message, "")
+        .into_response())
+}
+
+/// #389 Palier 1 — shared detached worker for the two bulk-BnF admin
+/// actions (cover-refetch #214 and metadata-backfill #389). Both loop over
+/// a [`crate::models::title::MissingCoverTitle`] projection calling
+/// [`crate::tasks::metadata_fetch::fetch_metadata_chain_outcome`] with
+/// `force_refresh=true`, retry on `Throttled` per the backoff schedule,
+/// pace between titles with the admin-configured delay, and report progress
+/// into the shared `bulk_cover_fetch` status lock (which the caller has
+/// already armed via `try_start`). `log_label` distinguishes the two runs
+/// in the tracing stream.
+fn spawn_bulk_bnf_worker(
+    state: &AppState,
+    titles: Vec<crate::models::title::MissingCoverTitle>,
+    log_label: &'static str,
+) {
+    // Clone what the worker needs from AppState (cheap — all Arc-wrapped);
+    // no shared mutable references.
+    let pool_clone = state.pool.clone();
     let registry_clone = state.registry.clone();
     let http_client_clone = state.http_client.clone();
     let covers_dir_clone = state.covers_dir.clone();
@@ -355,15 +389,12 @@ pub async fn admin_bulk_cover_refetch(
 
     tokio::spawn(async move {
         for title in titles {
-            // Fix #311 — force_refresh=true: this is the bulk-cover-
-            // refetch path, whose whole point is "try the providers
-            // again, maybe a cover URL is available now". Without
-            // this, the chain short-circuits on the cache hit set
-            // when the title was originally cataloged (often via BnF,
-            // which never returns cover URLs in its UNIMARC payload)
-            // and the only "try harder" step left is the OpenLibrary
-            // Covers ISBN fallback — which 404s for most French /
-            // Swiss / academic titles.
+            // Fix #311 — force_refresh=true: the whole point of these
+            // bulk actions is "try the providers again". Without it the
+            // chain short-circuits on the cache hit set at catalog time
+            // (often via BnF, which never returns cover URLs in its
+            // UNIMARC payload) — and for #389 the point is precisely to
+            // re-run the chain so the newly-added UNIMARC zones backfill.
             //
             // #419 — a Throttled outcome (chain empty-handed with a
             // provider answering 429/503) is retried per the
@@ -397,10 +428,11 @@ pub async fn admin_bulk_cover_refetch(
                 match crate::services::bulk_cover_fetch::retry_backoff(attempts_done) {
                     Some(backoff) => {
                         tracing::info!(
+                            label = log_label,
                             title_id = title.id,
                             attempt = attempts_done,
                             backoff_secs = backoff.as_secs(),
-                            "Bulk cover-refetch: provider throttled (429/503), backing off before retry"
+                            "Bulk BnF task: provider throttled (429/503), backing off before retry"
                         );
                         tokio::time::sleep(backoff).await;
                     }
@@ -421,16 +453,82 @@ pub async fn admin_bulk_cover_refetch(
         let summary = crate::services::bulk_cover_fetch::snapshot(&status_clone);
         crate::services::bulk_cover_fetch::mark_complete(&status_clone);
         tracing::info!(
+            label = log_label,
             recovered = summary.recovered,
             provider_failed = summary.provider_failed,
             not_found = summary.not_found,
             total = summary.total,
-            "Bulk cover-refetch completed"
+            "Bulk BnF task completed"
         );
     });
+}
+
+/// #389 Palier 1 — admin action: re-fetch metadata (force_refresh) for
+/// EVERY active title that carries a lookup code, so the six new UNIMARC
+/// zones populate on already-cataloged titles. Mirrors
+/// [`admin_bulk_cover_refetch`] but targets the broader `list_all_with_code`
+/// set (no cover filter). Shares the SAME `bulk_cover_fetch` status lock —
+/// the two bulk-BnF operations are mutually exclusive; a second click while
+/// one is in flight returns 409. Work runs in a detached `tokio::spawn`;
+/// the handler returns immediately with a feedback snippet for HTMX.
+pub async fn admin_bulk_metadata_backfill(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(locale): Extension<Locale>,
+) -> Result<Response, AppError> {
+    session.require_role_with_return(Role::Admin, "/admin?tab=health", locale.0)?;
+    let pool = &state.pool;
+    let loc = locale.0;
+
+    let titles = crate::models::title::TitleModel::list_all_with_code(pool).await?;
+    let total = titles.len();
+
+    if total == 0 {
+        // Nothing to do — surface a friendly message, don't lock the
+        // status, don't audit-log.
+        return Ok(crate::utils::feedback_html(
+            "info",
+            &rust_i18n::t!("admin.health.bulk_metadata_backfill.empty", locale = loc),
+            "",
+        )
+        .into_response());
+    }
+
+    if crate::services::bulk_cover_fetch::try_start(&state.bulk_cover_fetch, total).is_err() {
+        return Err(AppError::Conflict(
+            rust_i18n::t!(
+                "admin.health.bulk_metadata_backfill.already_running",
+                locale = loc
+            )
+            .to_string(),
+        ));
+    }
+
+    let admin_id = session.user_id.unwrap_or(0);
+    tracing::info!(admin_id, total, "Bulk metadata backfill started");
+
+    // Forensic audit trail: who kicked off the backfill and over how many
+    // titles. Best-effort — a failed audit insert must NOT abort the run
+    // (the status lock is already armed).
+    if let Err(e) = crate::models::admin_audit::AdminAuditModel::create(
+        &state.pool,
+        admin_id,
+        "bulk_metadata_backfill",
+        None,
+        None,
+        Some(serde_json::json!({ "total": total })),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "Failed to record bulk_metadata_backfill in admin_audit");
+    }
+
+    // Spawn the shared detached BnF worker (force_refresh=true, throttle
+    // retry, inter-title delay). The status lock has already been armed.
+    spawn_bulk_bnf_worker(&state, titles, "Bulk metadata backfill");
 
     let message = rust_i18n::t!(
-        "admin.health.bulk_cover_fetch.started",
+        "admin.health.bulk_metadata_backfill.started",
         locale = loc,
         total = total
     )
@@ -1054,6 +1152,9 @@ async fn render_health_panel(state: &AppState, loc: &'static str) -> Result<Stri
     // cover + bulk-fetch status. Cheap query (single SELECT COUNT) and
     // a lock-only status read; no extra DB round-trip beyond the count.
     let missing_covers_count = crate::models::title::TitleModel::count_missing_covers(pool).await?;
+    // #389 Palier 1: count of coded titles eligible for the metadata
+    // backfill (all active titles with a lookup code, cover or not).
+    let coded_titles_count = crate::models::title::TitleModel::count_all_with_code(pool).await?;
     let bulk_status =
         crate::services::bulk_cover_fetch::snapshot(&state.bulk_cover_fetch);
     let bulk_cover_fetch_status_label = if bulk_status.running {
@@ -1130,6 +1231,15 @@ async fn render_health_panel(state: &AppState, loc: &'static str) -> Result<Stri
             locale = loc
         )
         .to_string(),
+        // #389 Palier 1 — bulk metadata backfill. Shares the same status
+        // lock as the cover-refetch, so the button is disabled while EITHER
+        // bulk-BnF run is in flight.
+        bulk_metadata_backfill_button_label: rust_i18n::t!(
+            "admin.health.bulk_metadata_backfill.button",
+            locale = loc
+        )
+        .to_string(),
+        bulk_metadata_backfill_can_start: !bulk_status.running && coded_titles_count > 0,
     };
 
     panel

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -437,6 +437,10 @@ pub fn build_router(state: AppState) -> Router {
             "/admin/health/bulk-cover-refetch",
             axum::routing::post(admin::admin_bulk_cover_refetch),
         )
+        .route(
+            "/admin/health/bulk-metadata-backfill",
+            axum::routing::post(admin::admin_bulk_metadata_backfill),
+        )
         .route("/admin/users", axum::routing::get(admin_users::admin_users_panel).post(admin_users::admin_users_create))
         .route("/admin/users/new", axum::routing::get(admin_users::admin_users_create_form))
         .route("/admin/users/{id}/edit", axum::routing::get(admin_users::admin_users_edit_form))

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -1770,6 +1770,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 0,
         };
         let session = crate::middleware::auth::Session {
@@ -1819,6 +1825,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 0,
         };
         let session = crate::middleware::auth::Session {
@@ -1957,6 +1969,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         let template = TitleDetailTemplate {
@@ -2053,6 +2071,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         let mut template = TitleDetailTemplate {
@@ -2155,6 +2179,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         let similar = vec![
@@ -2273,6 +2303,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         let metadata = MetadataResult {
@@ -2310,6 +2346,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         };
         let metadata = MetadataResult {

--- a/src/routes/titles.rs
+++ b/src/routes/titles.rs
@@ -83,6 +83,13 @@ pub struct TitleDetailTemplate {
     pub similar_titles: Vec<SimilarTitle>,
     pub label_similar_titles: String,
     pub label_dewey_code: String,
+    // #389 — UNIMARC-zone metadata labels (palier 1). One label per zone;
+    // collection_title + collection_number share the single "Collection" label.
+    pub label_statement_of_responsibility: String,
+    pub label_edition_statement: String,
+    pub label_collection: String,
+    pub label_general_note: String,
+    pub label_original_title: String,
 }
 
 pub async fn title_detail(
@@ -184,6 +191,17 @@ pub async fn title_detail(
             similar_titles,
             label_similar_titles: rust_i18n::t!("title_detail.similar_titles", locale = loc).to_string(),
             label_dewey_code: rust_i18n::t!("metadata.field.dewey_code", locale = loc).to_string(),
+            label_statement_of_responsibility: rust_i18n::t!(
+                "metadata.field.statement_of_responsibility",
+                locale = loc
+            )
+            .to_string(),
+            label_edition_statement: rust_i18n::t!("metadata.field.edition_statement", locale = loc)
+                .to_string(),
+            label_collection: rust_i18n::t!("metadata.field.collection", locale = loc).to_string(),
+            label_general_note: rust_i18n::t!("metadata.field.general_note", locale = loc).to_string(),
+            label_original_title: rust_i18n::t!("metadata.field.original_title", locale = loc)
+                .to_string(),
         };
         match template.render() {
             Ok(html) => Ok(Html(html).into_response()),
@@ -2027,6 +2045,11 @@ mod tests {
             similar_titles: vec![],
             label_similar_titles: "Similar titles".to_string(),
             label_dewey_code: "Dewey code".to_string(),
+            label_statement_of_responsibility: "Statement of responsibility".to_string(),
+            label_edition_statement: "Edition".to_string(),
+            label_collection: "Collection".to_string(),
+            label_general_note: "Note".to_string(),
+            label_original_title: "Original title".to_string(),
         };
         let rendered = template.render().unwrap();
         assert!(
@@ -2129,6 +2152,11 @@ mod tests {
             similar_titles: vec![],
             label_similar_titles: "Similar titles".to_string(),
             label_dewey_code: "Dewey code".to_string(),
+            label_statement_of_responsibility: "Statement of responsibility".to_string(),
+            label_edition_statement: "Edition".to_string(),
+            label_collection: "Collection".to_string(),
+            label_general_note: "Note".to_string(),
+            label_original_title: "Original title".to_string(),
         };
 
         // No cover → prominent CTA branch: explainer + upload-modal trigger.
@@ -2255,6 +2283,11 @@ mod tests {
             similar_titles: similar,
             label_similar_titles: "Similar titles".to_string(),
             label_dewey_code: "Dewey code".to_string(),
+            label_statement_of_responsibility: "Statement of responsibility".to_string(),
+            label_edition_statement: "Edition".to_string(),
+            label_collection: "Collection".to_string(),
+            label_general_note: "Note".to_string(),
+            label_original_title: "Original title".to_string(),
         };
         let rendered = template.render().unwrap();
         assert!(

--- a/src/services/title.rs
+++ b/src/services/title.rs
@@ -105,6 +105,12 @@ impl TitleService {
             total_duration: None,
             age_rating: None,
             issue_number: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
         };
 
         let created = TitleModel::create(pool, &new_title).await?;
@@ -184,6 +190,12 @@ impl TitleService {
             total_duration: None,
             age_rating: None,
             issue_number: None,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
         };
 
         let created = TitleModel::create(pool, &new_title).await?;
@@ -281,6 +293,12 @@ impl TitleService {
             total_duration: form.total_duration,
             age_rating: non_empty_option(&form.age_rating),
             issue_number: form.issue_number,
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
         };
 
         TitleModel::create(pool, &new_title).await
@@ -797,6 +815,12 @@ mod tests {
             age_rating: None,
             issue_number: None,
             manually_edited_fields: manually_edited.map(|s| s.to_string()),
+            statement_of_responsibility: None,
+            edition_statement: None,
+            collection_title: None,
+            collection_number: None,
+            general_note: None,
+            original_title: None,
             version: 1,
         }
     }

--- a/src/tasks/metadata_fetch.rs
+++ b/src/tasks/metadata_fetch.rs
@@ -262,6 +262,27 @@ pub async fn update_title_from_metadata(
             title_id = title_id,
             "Background fetch lost race with concurrent manual edit; column UPDATE no-op"
         );
+    } else {
+        // #434 — cataloging observability. One structured line summarizing
+        // the outcome of this metadata resolution (no per-field values).
+        let unimarc_zones_populated = [
+            metadata.statement_of_responsibility.is_some(),
+            metadata.edition_statement.is_some(),
+            metadata.collection_title.is_some(),
+            metadata.collection_number.is_some(),
+            metadata.general_note.is_some(),
+            metadata.original_title.is_some(),
+        ]
+        .iter()
+        .filter(|present| **present)
+        .count();
+        tracing::info!(
+            title_id = title_id,
+            isbn = snapshot.isbn.as_deref().unwrap_or(""),
+            cover_resolved = metadata.cover_url.is_some(),
+            unimarc_zones_populated = unimarc_zones_populated,
+            "Title metadata resolved"
+        );
     }
 
     // Add primary author as contributor if available (skip empty/whitespace names).
@@ -326,6 +347,12 @@ pub async fn do_update(
          total_duration = COALESCE(?, total_duration), \
          age_rating = COALESCE(?, age_rating), \
          issue_number = COALESCE(?, issue_number), \
+         statement_of_responsibility = COALESCE(?, statement_of_responsibility), \
+         edition_statement = COALESCE(?, edition_statement), \
+         collection_title = COALESCE(?, collection_title), \
+         collection_number = COALESCE(?, collection_number), \
+         general_note = COALESCE(?, general_note), \
+         original_title = COALESCE(?, original_title), \
          version = version + 1, \
          updated_at = NOW() \
          WHERE id = ? AND version = ? AND deleted_at IS NULL",
@@ -389,6 +416,36 @@ pub async fn do_update(
         None
     } else {
         metadata.issue_number.clone()
+    })
+    .bind(if g("statement_of_responsibility") {
+        None
+    } else {
+        metadata.statement_of_responsibility.clone()
+    })
+    .bind(if g("edition_statement") {
+        None
+    } else {
+        metadata.edition_statement.clone()
+    })
+    .bind(if g("collection_title") {
+        None
+    } else {
+        metadata.collection_title.clone()
+    })
+    .bind(if g("collection_number") {
+        None
+    } else {
+        metadata.collection_number.clone()
+    })
+    .bind(if g("general_note") {
+        None
+    } else {
+        metadata.general_note.clone()
+    })
+    .bind(if g("original_title") {
+        None
+    } else {
+        metadata.original_title.clone()
     })
     .bind(title_id)
     .bind(snapshot.version)

--- a/templates/fragments/admin_health_panel.html
+++ b/templates/fragments/admin_health_panel.html
@@ -55,21 +55,41 @@
                 <p class="text-sm text-stone-500 dark:text-stone-400">{{ missing_covers_label }}</p>
                 <p class="text-2xl font-mono text-stone-900 dark:text-stone-100">{{ missing_covers_count }}</p>
             </div>
-            {% if bulk_cover_fetch_can_start %}
-            <button type="button"
-                    hx-post="/admin/health/bulk-cover-refetch"
-                    hx-target="#admin-panel-feedback"
-                    hx-swap="innerHTML"
-                    class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700">
-                {{ bulk_cover_fetch_button_label }}
-            </button>
-            {% else %}
-            <button type="button"
-                    disabled
-                    class="px-4 py-2 text-sm font-medium text-stone-400 bg-stone-200 dark:bg-stone-800 rounded-md cursor-not-allowed">
-                {{ bulk_cover_fetch_button_label }}
-            </button>
-            {% endif %}
+            <div class="flex gap-2">
+                {% if bulk_cover_fetch_can_start %}
+                <button type="button"
+                        hx-post="/admin/health/bulk-cover-refetch"
+                        hx-target="#admin-panel-feedback"
+                        hx-swap="innerHTML"
+                        class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700">
+                    {{ bulk_cover_fetch_button_label }}
+                </button>
+                {% else %}
+                <button type="button"
+                        disabled
+                        class="px-4 py-2 text-sm font-medium text-stone-400 bg-stone-200 dark:bg-stone-800 rounded-md cursor-not-allowed">
+                    {{ bulk_cover_fetch_button_label }}
+                </button>
+                {% endif %}
+                {# #389 Palier 1 — backfill metadata from BnF over every coded
+                   title so the new UNIMARC zones populate on existing rows.
+                   Shares the cover-refetch status lock (mutual exclusion). #}
+                {% if bulk_metadata_backfill_can_start %}
+                <button type="button"
+                        hx-post="/admin/health/bulk-metadata-backfill"
+                        hx-target="#admin-panel-feedback"
+                        hx-swap="innerHTML"
+                        class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700">
+                    {{ bulk_metadata_backfill_button_label }}
+                </button>
+                {% else %}
+                <button type="button"
+                        disabled
+                        class="px-4 py-2 text-sm font-medium text-stone-400 bg-stone-200 dark:bg-stone-800 rounded-md cursor-not-allowed">
+                    {{ bulk_metadata_backfill_button_label }}
+                </button>
+                {% endif %}
+            </div>
         </div>
         <p class="text-sm {% if bulk_cover_fetch_running %}text-amber-700 dark:text-amber-300{% else %}text-stone-500 dark:text-stone-400{% endif %}">
             {{ bulk_cover_fetch_status_label }}

--- a/templates/pages/title_detail.html
+++ b/templates/pages/title_detail.html
@@ -68,6 +68,22 @@
                 {% if let Some(upc) = title.upc %}
                     <p class="mt-1 text-xs text-stone-500 dark:text-stone-400">UPC: {{ upc }}</p>
                 {% endif %}
+                {# #389 — UNIMARC-zone metadata (palier 1). Each row renders only when present. #}
+                {% if let Some(sor) = title.statement_of_responsibility %}
+                    <p class="mt-1 text-sm text-stone-500 dark:text-stone-400">{{ label_statement_of_responsibility }}: {{ sor }}</p>
+                {% endif %}
+                {% if let Some(edition) = title.edition_statement %}
+                    <p class="mt-1 text-sm text-stone-500 dark:text-stone-400">{{ label_edition_statement }}: {{ edition }}</p>
+                {% endif %}
+                {% if let Some(coll) = title.collection_title %}
+                    <p class="mt-1 text-sm text-stone-500 dark:text-stone-400">{{ label_collection }}: {{ coll }}{% if let Some(coll_num) = title.collection_number %} {{ coll_num }}{% endif %}</p>
+                {% endif %}
+                {% if let Some(orig) = title.original_title %}
+                    <p class="mt-1 text-sm text-stone-500 dark:text-stone-400">{{ label_original_title }}: {{ orig }}</p>
+                {% endif %}
+                {% if let Some(note) = title.general_note %}
+                    <p class="mt-2 text-sm text-stone-500 dark:text-stone-400">{{ label_general_note }}: {{ note }}</p>
+                {% endif %}
                 {% if let Some(desc) = title.description %}
                 <div class="mt-4">
                     <p class="text-stone-700 dark:text-stone-300 text-sm">{{ desc }}</p>

--- a/tests/e2e/specs/journeys/admin-metadata-backfill.spec.ts
+++ b/tests/e2e/specs/journeys/admin-metadata-backfill.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+/**
+ * #389 Palier 1 — admin "Backfill metadata from BnF" button.
+ *
+ * Verifies the new admin action end-to-end: the button renders on the
+ * Health panel (template + 4-locale label wiring) and POSTing to its
+ * route runs the handler through CSRF and returns a valid feedback.
+ *
+ * The backfill shares the single stack-wide bulk-BnF status lock with
+ * cover-refetch, so the button's enabled state is non-deterministic under
+ * parallel execution. We therefore assert the button's PRESENCE via the UI
+ * and drive the route via a direct POST (CSRF-authenticated) whose outcome
+ * is asserted by shape — started | empty | already-running are all valid,
+ * lock-state-dependent responses. Mirrors the direct-POST style of
+ * bulk-cover-refetch.spec.ts.
+ */
+test.describe("#389 — admin BnF metadata backfill", () => {
+  const backfillButton =
+    /Backfill metadata from BnF|Compléter les métadonnées via BnF/i;
+
+  // Any of the three lock-state-dependent outcomes proves the handler ran.
+  const validOutcome =
+    /Bulk metadata backfill started|Complément des métadonnées en lot lancé|already in progress|déjà en cours|No titles with a lookup code|Aucun titre avec un code/i;
+
+  test("backfill button renders and its route runs through CSRF", async ({
+    page,
+    request,
+  }) => {
+    await loginAs(page, "admin");
+    await page.goto("/admin?tab=health");
+
+    // 1. UI wiring: the button is present with its localized label.
+    await expect(
+      page.getByRole("button", { name: backfillButton }),
+    ).toBeVisible();
+
+    // 2. Route end-to-end via a direct, CSRF-authenticated POST — robust to
+    //    the shared bulk lock's state under parallel runs.
+    const csrf = await page
+      .locator('meta[name="csrf-token"]')
+      .getAttribute("content");
+    expect(csrf).toBeTruthy();
+    const cookies = await page.context().cookies();
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+
+    const resp = await request.post("/admin/health/bulk-metadata-backfill", {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: cookieHeader,
+        "HX-Request": "true",
+      },
+      data: `_csrf_token=${encodeURIComponent(csrf!)}`,
+      maxRedirects: 0,
+    });
+
+    // Conflict (409) is the legitimate "already running" response; 200 is
+    // started/empty. Both mean the handler executed correctly.
+    expect([200, 409]).toContain(resp.status());
+    expect(await resp.text()).toMatch(validOutcome);
+  });
+
+  test("backfill route rejects an anonymous (unauthenticated) POST", async ({
+    request,
+  }) => {
+    // No session cookie, no CSRF: the admin guard must not run the backfill.
+    const resp = await request.post("/admin/health/bulk-metadata-backfill", {
+      headers: { "HX-Request": "true" },
+      data: "",
+      maxRedirects: 0,
+    });
+    // CSRF rejection (403) or auth bounce (303/401/403) — never a 200 run.
+    expect(resp.status()).not.toBe(200);
+  });
+});

--- a/tests/unimarc_mapping.rs
+++ b/tests/unimarc_mapping.rs
@@ -61,7 +61,7 @@ fn base_new_title(title: &str, isbn: &str) -> NewTitle {
 
 #[sqlx::test(migrations = "./migrations")]
 async fn create_persists_and_reads_back_all_unimarc_zones(pool: MySqlPool) {
-    let mut new_title = base_new_title("Zone Round-Trip", "UNIMARC-CREATE-9782000000001");
+    let mut new_title = base_new_title("Zone Round-Trip", "9782000000001");
     new_title.statement_of_responsibility = Some("par Victor Hugo".to_string());
     new_title.edition_statement = Some("3e édition revue".to_string());
     new_title.collection_title = Some("Le Livre de Poche".to_string());
@@ -114,7 +114,7 @@ async fn create_persists_and_reads_back_all_unimarc_zones(pool: MySqlPool) {
 
 #[sqlx::test(migrations = "./migrations")]
 async fn update_unimarc_zones_coalesce_fills_gaps_without_overwriting(pool: MySqlPool) {
-    let mut new_title = base_new_title("Coalesce Guard", "UNIMARC-COALESCE-9782000000002");
+    let mut new_title = base_new_title("Coalesce Guard", "9782000000002");
     new_title.statement_of_responsibility = Some("original SOR".to_string());
     // The other 5 zones remain None.
 
@@ -159,7 +159,7 @@ async fn update_unimarc_zones_coalesce_fills_gaps_without_overwriting(pool: MySq
 #[sqlx::test(migrations = "./migrations")]
 async fn do_update_writes_unimarc_zones_from_metadata(pool: MySqlPool) {
     // Bare title — all zones start None.
-    let new_title = base_new_title("Metadata Zones", "UNIMARC-METADATA-9782000000003");
+    let new_title = base_new_title("Metadata Zones", "9782000000003");
     let created = TitleModel::create(&pool, &new_title)
         .await
         .expect("create should succeed");

--- a/tests/unimarc_mapping.rs
+++ b/tests/unimarc_mapping.rs
@@ -1,0 +1,210 @@
+//! Integration tests for the UNIMARC Palier 1 zone round-trip (#389).
+//!
+//! Palier 1 added 6 `Option<String>` UNIMARC-zone columns to `titles`:
+//!   - `statement_of_responsibility` (200$f)
+//!   - `edition_statement`           (205$a)
+//!   - `collection_title`            (225$a)
+//!   - `collection_number`           (225$v)
+//!   - `general_note`                (300$a)
+//!   - `original_title`              (500$a)
+//!
+//! These tests validate that the zones persist through `TitleModel::create`,
+//! survive the COALESCE-based `update_unimarc_zones` backfill, and land from a
+//! `MetadataResult` via `tasks::metadata_fetch::do_update`.
+//!
+//! Each test gets a freshly provisioned database via `#[sqlx::test]`, with all
+//! migrations applied (the bootstrap migrations seed the default genres, so
+//! `genre_id = 1` satisfies the NOT-NULL FK on `titles.genre_id`).
+//!
+//! To run locally:
+//!
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true \
+//!         DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test unimarc_mapping
+
+use mybibli::metadata::provider::MetadataResult;
+use mybibli::models::title::{NewTitle, TitleModel};
+use mybibli::tasks::metadata_fetch::do_update;
+use sqlx::MySqlPool;
+
+/// Build a bare `NewTitle` with all 6 UNIMARC zones unset. `genre_id = 1` is
+/// the default genre seeded by the bootstrap migrations, satisfying the NOT-NULL
+/// FK on `titles.genre_id`. Callers override zones as needed per test.
+fn base_new_title(title: &str, isbn: &str) -> NewTitle {
+    NewTitle {
+        title: title.to_string(),
+        media_type: "book".to_string(),
+        genre_id: 1,
+        language: "fr".to_string(),
+        subtitle: None,
+        publisher: None,
+        publication_date: None,
+        isbn: Some(isbn.to_string()),
+        issn: None,
+        upc: None,
+        page_count: None,
+        track_count: None,
+        total_duration: None,
+        age_rating: None,
+        issue_number: None,
+        statement_of_responsibility: None,
+        edition_statement: None,
+        collection_title: None,
+        collection_number: None,
+        general_note: None,
+        original_title: None,
+    }
+}
+
+// ─── 1. create() persists and reads back all 6 zones ───────────────────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_persists_and_reads_back_all_unimarc_zones(pool: MySqlPool) {
+    let mut new_title = base_new_title("Zone Round-Trip", "UNIMARC-CREATE-9782000000001");
+    new_title.statement_of_responsibility = Some("par Victor Hugo".to_string());
+    new_title.edition_statement = Some("3e édition revue".to_string());
+    new_title.collection_title = Some("Le Livre de Poche".to_string());
+    new_title.collection_number = Some("42".to_string());
+    new_title.general_note = Some("Contient un index détaillé.".to_string());
+    new_title.original_title = Some("Les Misérables (original)".to_string());
+
+    let created = TitleModel::create(&pool, &new_title)
+        .await
+        .expect("create should succeed");
+
+    let refreshed = TitleModel::find_by_id(&pool, created.id)
+        .await
+        .expect("find_by_id query should succeed")
+        .expect("created title must exist");
+
+    assert_eq!(
+        refreshed.statement_of_responsibility.as_deref(),
+        Some("par Victor Hugo"),
+        "200$f must round-trip"
+    );
+    assert_eq!(
+        refreshed.edition_statement.as_deref(),
+        Some("3e édition revue"),
+        "205$a must round-trip"
+    );
+    assert_eq!(
+        refreshed.collection_title.as_deref(),
+        Some("Le Livre de Poche"),
+        "225$a must round-trip"
+    );
+    assert_eq!(
+        refreshed.collection_number.as_deref(),
+        Some("42"),
+        "225$v must round-trip"
+    );
+    assert_eq!(
+        refreshed.general_note.as_deref(),
+        Some("Contient un index détaillé."),
+        "300$a must round-trip"
+    );
+    assert_eq!(
+        refreshed.original_title.as_deref(),
+        Some("Les Misérables (original)"),
+        "500$a must round-trip"
+    );
+}
+
+// ─── 2. update_unimarc_zones COALESCE fills gaps, never overwrites ──────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_unimarc_zones_coalesce_fills_gaps_without_overwriting(pool: MySqlPool) {
+    let mut new_title = base_new_title("Coalesce Guard", "UNIMARC-COALESCE-9782000000002");
+    new_title.statement_of_responsibility = Some("original SOR".to_string());
+    // The other 5 zones remain None.
+
+    let created = TitleModel::create(&pool, &new_title)
+        .await
+        .expect("create should succeed");
+
+    // Backfill: SOR passed as None (must NOT overwrite the existing value),
+    // edition_statement passed as Some (must fill the previously-empty gap).
+    TitleModel::update_unimarc_zones(
+        &pool,
+        created.id,
+        None,             // statement_of_responsibility — must be preserved
+        Some("2e éd."),   // edition_statement — must fill
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("update_unimarc_zones should succeed");
+
+    let refreshed = TitleModel::find_by_id(&pool, created.id)
+        .await
+        .expect("find_by_id query should succeed")
+        .expect("title must exist");
+
+    assert_eq!(
+        refreshed.statement_of_responsibility.as_deref(),
+        Some("original SOR"),
+        "COALESCE(NULL, col) must preserve the existing statement_of_responsibility"
+    );
+    assert_eq!(
+        refreshed.edition_statement.as_deref(),
+        Some("2e éd."),
+        "COALESCE(value, col) must fill the previously-empty edition_statement"
+    );
+}
+
+// ─── 3. do_update writes the 6 zones from a MetadataResult ──────────────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn do_update_writes_unimarc_zones_from_metadata(pool: MySqlPool) {
+    // Bare title — all zones start None.
+    let new_title = base_new_title("Metadata Zones", "UNIMARC-METADATA-9782000000003");
+    let created = TitleModel::create(&pool, &new_title)
+        .await
+        .expect("create should succeed");
+
+    // Snapshot the row at version=1 for the optimistic-lock check inside do_update.
+    let snapshot = TitleModel::find_by_id(&pool, created.id)
+        .await
+        .expect("find_by_id query should succeed")
+        .expect("title must exist");
+
+    let metadata = MetadataResult {
+        // `title` is required — do_update early-returns on an empty title.
+        title: Some("Metadata Zones".to_string()),
+        statement_of_responsibility: Some("par un collectif".to_string()),
+        edition_statement: Some("Édition définitive".to_string()),
+        collection_title: Some("Folio SF".to_string()),
+        collection_number: Some("7".to_string()),
+        general_note: Some("Traduit du japonais.".to_string()),
+        original_title: Some("元のタイトル".to_string()),
+        ..MetadataResult::default()
+    };
+
+    let rows = do_update(&pool, created.id, &metadata, &snapshot)
+        .await
+        .expect("do_update should succeed");
+    assert_eq!(rows, 1, "the fresh snapshot must apply exactly one row");
+
+    let refreshed = TitleModel::find_by_id(&pool, created.id)
+        .await
+        .expect("find_by_id query should succeed")
+        .expect("title must exist");
+
+    assert_eq!(
+        refreshed.statement_of_responsibility.as_deref(),
+        Some("par un collectif")
+    );
+    assert_eq!(
+        refreshed.edition_statement.as_deref(),
+        Some("Édition définitive")
+    );
+    assert_eq!(refreshed.collection_title.as_deref(), Some("Folio SF"));
+    assert_eq!(refreshed.collection_number.as_deref(), Some("7"));
+    assert_eq!(
+        refreshed.general_note.as_deref(),
+        Some("Traduit du japonais.")
+    );
+    assert_eq!(refreshed.original_title.as_deref(), Some("元のタイトル"));
+}


### PR DESCRIPTION
## Scope — #389 Palier 1 (internal model conformity) + #434 (cataloging observability)

Implements the internal-model half of UNIMARC conformity. Import/export (ISO 2709 `.mrc` / UNIMARC XML round-trip) is **Palier 2**, tracked in #436. See the [découpage on #389](https://github.com/guycorbaz/mybibli/issues/389#issuecomment-5071586470).

### Delivered
- **Migration** `20260724000000_titles_unimarc_zones.sql` — 6 additive NULLable UNIMARC-zone columns on `titles` (200$f, 205$a, 225$a/$v, 300$a, 500$a).
- **`docs/unimarc-mapping.md`** — authoritative field⇄zone mapping + storage-decision rationale + backfill plan.
- **Model** — 6 zones plumbed through `TitleModel`/`NewTitle`/`row_to_title`/SELECTs/`create`, plus `update_unimarc_zones` (COALESCE gap-fill) and `list_all_with_code`/`count_all_with_code`.
- **BnF capture** — `MetadataResult` carries the zones; `bnf.rs` parses them; `metadata_fetch::do_update` writes them with the existing `manually_edited_fields` guard + optimistic lock; metadata cache round-trips them.
- **#434** — one `info`-level "Title metadata resolved" summary line per fetch (title_id, isbn, cover_resolved, unimarc-zones-populated count). Note: title/volume creation and shelving were already logged at `info`; the issue's premise is corrected in [#434's comment](https://github.com/guycorbaz/mybibli/issues/434#issuecomment-5072150912) — this PR delivers the per-title resolution summary that was genuinely missing.
- **UI** — title-detail page renders the zones when present; labels in all 4 locales (en/fr/de/it).
- **Admin backfill** — `POST /admin/health/bulk-metadata-backfill` re-fetches metadata for every coded title, populating zones on existing records; reuses the bulk-BnF status lock (shared worker factored out, DRY); writes an `admin_audit` row.

### Tests
- `tests/unimarc_mapping.rs` — DB round-trip (create, COALESCE gap-fill, do_update-from-metadata).
- `bnf.rs` unit tests for the new zone parse.
- `tests/e2e/specs/journeys/admin-metadata-backfill.spec.ts` — button-renders + CSRF-route journey (+ anonymous-POST rejection).

### Data migration
Additive — the 207 production titles keep all values; new zones backfill from BnF on demand via the admin button.

Closes #389
Closes #434
