### PR TITLE
fix: v1.14.0 cataloging bundle (#440, #441, #442)

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -216,6 +216,9 @@ feedback:
   volume_created: "Exemplar %{label} an %{title} angehängt."
   volume_created_suggestion: "L-Code scannen zum Einsortieren, oder weiteren V-Code scannen."
   volume_duplicate: "Etikett %{label} ist bereits %{title} zugeordnet. Bitte ein anderes Etikett scannen."
+  volume_label_reused: "Etikett %{label} für %{title} wiederverwendet. Es gehörte zu einem gelöschten Exemplar, dessen Zustand, Standort und Kaufangaben verworfen wurden."
+  volume_label_in_trash_with_loans: "Etikett %{label} gehört zu einem gelöschten Exemplar mit Ausleihverlauf und kann daher nicht wiederverwendet werden. Stellen Sie das Exemplar wieder her oder löschen Sie es endgültig aus dem Papierkorb."
+  volume_label_race: "Etikett %{label} wurde im selben Moment geändert. Bitte erneut scannen."
   volume_no_title: "Kein Titel ausgewählt. Scannen Sie zuerst eine ISBN, um einen Titelkontext aufzubauen."
   volume_confirm:
     title: "Weiteres Exemplar hinzufügen?"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -216,6 +216,9 @@ feedback:
   volume_created: "Volume %{label} attached to %{title}."
   volume_created_suggestion: "Scan L-code to shelve, or scan another V-code."
   volume_duplicate: "Label %{label} is already assigned to %{title}. Scan a different label."
+  volume_label_reused: "Label %{label} reused for %{title}. It belonged to a deleted volume, whose condition, shelf and purchase details were discarded."
+  volume_label_in_trash_with_loans: "Label %{label} belongs to a deleted volume that still has loan history, so it can't be reused. Restore that volume, or delete it permanently from the Trash."
+  volume_label_race: "Label %{label} was being changed at the same moment. Scan it again."
   volume_no_title: "No title selected. Scan an ISBN first to establish a title context."
   volume_confirm:
     title: "Add another copy?"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -217,6 +217,9 @@ feedback:
   volume_created: "Volume %{label} attaché à %{title}."
   volume_created_suggestion: "Scannez un code L pour ranger, ou scannez un autre code V."
   volume_duplicate: "Le label %{label} est déjà assigné à %{title}. Scannez un autre label."
+  volume_label_reused: "Label %{label} réutilisé pour %{title}. Il appartenait à un volume supprimé, dont l'état, l'emplacement et les informations d'achat ont été écartés."
+  volume_label_in_trash_with_loans: "Le label %{label} appartient à un volume supprimé qui a un historique de prêts, il ne peut donc pas être réutilisé. Restaurez ce volume, ou supprimez-le définitivement depuis la corbeille."
+  volume_label_race: "Le label %{label} a été modifié au même moment. Scannez-le à nouveau."
   volume_no_title: "Aucun titre sélectionné. Scannez d'abord un ISBN pour établir un contexte."
   volume_confirm:
     title: "Ajouter un autre exemplaire ?"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -212,6 +212,9 @@ feedback:
   volume_created: "Esemplare %{label} collegato a %{title}."
   volume_created_suggestion: "Scansiona un codice L per collocare, oppure un altro codice V."
   volume_duplicate: "L'etichetta %{label} è già assegnata a %{title}. Scansiona un'etichetta diversa."
+  volume_label_reused: "Etichetta %{label} riutilizzata per %{title}. Apparteneva a un esemplare eliminato, di cui stato, collocazione e dati di acquisto sono stati scartati."
+  volume_label_in_trash_with_loans: "L'etichetta %{label} appartiene a un esemplare eliminato che ha uno storico prestiti, quindi non può essere riutilizzata. Ripristina quell'esemplare oppure eliminalo definitivamente dal cestino."
+  volume_label_race: "L'etichetta %{label} è stata modificata nello stesso momento. Scansionala di nuovo."
   volume_no_title: "Nessun titolo selezionato. Scansiona prima un ISBN per stabilire un titolo di contesto."
   volume_confirm:
     title: "Aggiungere un'altra copia?"

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -214,6 +214,18 @@ impl SessionModel {
         Ok(data.get("active_location_id").and_then(|v| v.as_u64()))
     }
 
+    /// Drop the active scan context (#441).
+    ///
+    /// `current_title_id` is written on every scan and was never removed, so a
+    /// session could keep pointing at a title that had since been deleted. The
+    /// V-code arm of `handle_scan` calls this the moment it notices, so the
+    /// next scan starts from a clean context instead of failing again.
+    pub async fn clear_current_title(pool: &DbPool, token: &str) -> Result<(), AppError> {
+        let mut data = Self::load_session_data(pool, token).await?;
+        data.as_object_mut().map(|o| o.remove("current_title_id"));
+        Self::save_session_data(pool, token, &data).await
+    }
+
     pub async fn clear_active_location(pool: &DbPool, token: &str) -> Result<(), AppError> {
         let mut data = Self::load_session_data(pool, token).await?;
         data.as_object_mut().map(|o| o.remove("active_location_id"));

--- a/src/models/volume.rs
+++ b/src/models/volume.rs
@@ -121,6 +121,103 @@ impl VolumeModel {
         }
     }
 
+    /// Look a volume up by label **including soft-deleted rows** (#442).
+    ///
+    /// `volumes.label` carries a global `UNIQUE` index that soft-deletion does
+    /// not release, so a label can collide with a row `find_by_label` cannot
+    /// see. That is how the duplicate-label error used to name its owner `"?"`.
+    /// Returns the row plus whether it is soft-deleted.
+    pub async fn find_by_label_any_state(
+        pool: &DbPool,
+        label: &str,
+    ) -> Result<Option<(VolumeModel, bool)>, AppError> {
+        tracing::debug!(label = %label, "Looking up volume by label (any state)");
+
+        // Same DECIMAL/TIMESTAMP casts as `find_by_label` (fix #288 and the
+        // MariaDB type gotchas in CLAUDE.md).
+        let row = sqlx::query(
+            r#"SELECT id, title_id, label, condition_state_id, edition_comment, location_id, version,
+                      CAST(purchase_price AS DOUBLE) AS purchase_price, purchase_currency,
+                      CAST(current_value AS DOUBLE) AS current_value, current_value_currency,
+                      CAST(current_value_updated_at AS DATETIME) AS current_value_updated_at,
+                      CAST(under_audit_since AS DATETIME) AS under_audit_since,
+                      (deleted_at IS NOT NULL) AS is_deleted
+               FROM volumes
+               WHERE label = ?"#,
+        )
+        .bind(label)
+        .fetch_optional(pool)
+        .await?;
+
+        match row {
+            Some(r) => {
+                let is_deleted: i8 = r.try_get("is_deleted")?;
+                Ok(Some((
+                    VolumeModel {
+                        id: r.try_get("id")?,
+                        title_id: r.try_get("title_id")?,
+                        label: r.try_get("label")?,
+                        condition_state_id: r.try_get("condition_state_id")?,
+                        edition_comment: r.try_get("edition_comment")?,
+                        location_id: r.try_get("location_id")?,
+                        version: r.try_get("version")?,
+                        purchase_price: r.try_get("purchase_price")?,
+                        purchase_currency: r.try_get("purchase_currency")?,
+                        current_value: r.try_get("current_value")?,
+                        current_value_currency: r.try_get("current_value_currency")?,
+                        current_value_updated_at: r.try_get("current_value_updated_at")?,
+                        under_audit_since: r.try_get("under_audit_since")?,
+                    },
+                    is_deleted != 0,
+                )))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// How many loans — past or present — reference this volume (#442).
+    ///
+    /// Reusing a soft-deleted volume's row keeps its `id`, and `loans` point at
+    /// `volume_id`. Re-pointing a row that carries loan history would silently
+    /// re-attribute that history to a different physical copy, so the reuse
+    /// path refuses when this is non-zero.
+    pub async fn count_loans(pool: &DbPool, volume_id: u64) -> Result<i64, AppError> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM loans WHERE volume_id = ?")
+            .bind(volume_id)
+            .fetch_one(pool)
+            .await?;
+        Ok(row.0)
+    }
+
+    /// Reuse a soft-deleted volume row for a different physical copy (#442).
+    ///
+    /// Clears `deleted_at`, re-points `title_id`, and **wipes every
+    /// copy-specific field** — the sticker is going onto a different object, so
+    /// its condition, shelf, purchase price and valuation do not carry over.
+    /// The caller is responsible for the loan-history guard and for the audit
+    /// entry; this method deliberately does not decide policy.
+    pub async fn reactivate_for_reuse(
+        pool: &DbPool,
+        id: u64,
+        title_id: u64,
+    ) -> Result<(), AppError> {
+        tracing::info!(volume_id = id, title_id = title_id, "Reusing soft-deleted volume label");
+
+        sqlx::query(
+            "UPDATE volumes SET deleted_at = NULL, title_id = ?, condition_state_id = NULL, \
+             edition_comment = NULL, location_id = NULL, purchase_price = NULL, \
+             purchase_currency = NULL, current_value = NULL, current_value_currency = NULL, \
+             current_value_updated_at = NULL, under_audit_since = NULL, version = version + 1 \
+             WHERE id = ?",
+        )
+        .bind(title_id)
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn create(
         pool: &DbPool,
         title_id: u64,

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -650,6 +650,49 @@ pub async fn handle_scan(
                     return Ok(Html(feedback_html("warning", &message, "")).into_response());
                 };
 
+                // #441 — `current_title_id` is sticky: it is written on scan and
+                // never cleared, including when the title it points at is later
+                // deleted. Creating the volume anyway used to bubble a raw
+                // NotFound out of `VolumeService::create_volume`'s "verify title
+                // exists" guard, which the error arm below flattened into the
+                // generic internal-error copy — "Introuvable — l'élément a
+                // peut-être été déplacé ou supprimé". That blames the LABEL the
+                // librarian just scanned, when the real problem is that there is
+                // no active item any more. Detect it here instead, drop the
+                // stale pointer so the context recovers, and say what to do.
+                if crate::models::title::TitleModel::find_by_id(pool, title_id)
+                    .await?
+                    .is_none()
+                {
+                    if let Some(token) = &session.token {
+                        let _ = SessionModel::clear_current_title(pool, token).await;
+                    }
+                    tracing::info!(
+                        stale_title_id = title_id,
+                        code = %code,
+                        "V-code scanned with a deleted active title; context cleared"
+                    );
+                    let message = rust_i18n::t!("feedback.volume_no_title").to_string();
+                    let resp = HtmxResponse {
+                        main: feedback_html("warning", &message, ""),
+                        oob: vec![
+                            OobUpdate {
+                                swap_mode: Default::default(),
+                                target: "context-banner".to_string(),
+                                content: String::new(),
+                            },
+                            OobUpdate {
+                                swap_mode: Default::default(),
+                                target: "guide-strip".to_string(),
+                                content: guide_strip_html(
+                                    rust_i18n::t!("guide.initial", locale = loc).as_ref(),
+                                ),
+                            },
+                        ],
+                    };
+                    return Ok(resp.into_response());
+                }
+
                 // CR #300: phantom-volume guard. `current_title_id` is sticky
                 // (set on ISBN scan, never cleared) — scanning a fresh V-code
                 // for ANOTHER physical book without re-scanning its ISBN would
@@ -720,8 +763,13 @@ pub async fn handle_scan(
                     }
                 }
 
-                match VolumeService::create_volume(pool, &code, title_id).await {
-                    Ok(volume) => {
+                match VolumeService::create_volume(pool, &code, title_id, session.user_id).await {
+                    Ok(creation) => {
+                        // #442 — a reused label discards the previous copy's
+                        // data, so the librarian must be told in as many words.
+                        let reused_label =
+                            matches!(creation, crate::services::volume::VolumeCreation::ReusedLabel(_));
+                        let volume = creation.into_volume();
                         if let Some(token) = &session.token {
                             // Store last volume label for subsequent L-code scan
                             if let Err(e) =
@@ -821,7 +869,21 @@ pub async fn handle_scan(
                                     .map(|t| (t.title.clone(), t.media_type.clone()))
                                     .unwrap_or_else(|| ("?".to_string(), "book".to_string()));
 
-                            let (message, suggestion) = if let Some(ref path) = shelved_path {
+                            let (message, suggestion) = if reused_label {
+                                // #442 — reuse takes precedence over the
+                                // shelved/not-shelved split: discarding the
+                                // previous copy's data is the thing the
+                                // librarian most needs to read.
+                                (
+                                    rust_i18n::t!(
+                                        "feedback.volume_label_reused",
+                                        label = &volume.label,
+                                        title = &title.0
+                                    )
+                                    .to_string(),
+                                    String::new(),
+                                )
+                            } else if let Some(ref path) = shelved_path {
                                 (
                                     rust_i18n::t!(
                                         "feedback.volume_created_and_shelved",
@@ -911,11 +973,21 @@ pub async fn handle_scan(
                     }
                     Err(e) => {
                         tracing::error!(error = %e, code = %code, "V-code scan failed");
-                        let message = match &e {
-                            AppError::BadRequest(msg) => msg.clone(),
-                            _ => rust_i18n::t!("error.internal").to_string(),
+                        let (level, message) = match &e {
+                            AppError::BadRequest(msg) => ("error", msg.clone()),
+                            // #441 — defence in depth. The guard above catches
+                            // the deleted-active-title case before we get here,
+                            // but if a title is deleted between that check and
+                            // the INSERT, the librarian must still be told the
+                            // item is gone rather than that something unnamed
+                            // is "introuvable".
+                            AppError::NotFound(_) => (
+                                "warning",
+                                rust_i18n::t!("feedback.volume_no_title").to_string(),
+                            ),
+                            _ => ("error", rust_i18n::t!("error.internal").to_string()),
                         };
-                        Ok(Html(feedback_html("error", &message, "")).into_response())
+                        Ok(Html(feedback_html(level, &message, "")).into_response())
                     }
                 }
             }

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -11,8 +11,10 @@ use crate::utils::base_context;
 use crate::middleware::auth::{Role, Session};
 use crate::middleware::htmx::{HtmxResponse, HxRequest, OobUpdate};
 use crate::middleware::locale::Locale;
+use crate::db::DbPool;
 use crate::models::contributor::{ContributorModel, ContributorRoleModel, TitleContributorModel};
 use crate::models::session::SessionModel;
+use crate::models::title::TitleModel;
 use crate::models::volume::VolumeModel;
 use crate::services::contributor::ContributorService;
 use crate::services::scan_undo::UndoableAction;
@@ -105,6 +107,77 @@ fn skeleton_feedback_html(title_id: u64, isbn: &str) -> String {
 </div>"##,
         message = html_escape(&message)
     )
+}
+
+/// Make a freshly scanned title the session's scan context, and build the
+/// OOB updates that tell the librarian which title is now active.
+///
+/// **Every scan arm that resolves a code to a title MUST go through this.**
+/// Before #440 the four operations below were open-coded in the `"isbn"`
+/// arm, the `"issn"` arm and `handle_scan_with_type` — while the `"upc"`
+/// arm, the one that fires once a media-type preference has been
+/// remembered in a cookie, performed none of them. The session therefore
+/// kept pointing at the PREVIOUS title, so the next V-code scan attached
+/// its volume to the wrong item, or failed with a misleading "not found"
+/// when that stale title had since been deleted. Since
+/// `media_type_preference` is a session cookie, the first CD of a session
+/// worked and every subsequent one was broken.
+///
+/// Holding the sequence in one place is the actual fix: a fifth scan arm
+/// cannot silently reintroduce the omission.
+///
+/// Returns the OOB updates for the context banner plus, when the title was
+/// newly created, the session counter. Callers append their own
+/// guide-strip update and build the main feedback body.
+async fn activate_scanned_title(
+    pool: &DbPool,
+    token: Option<&str>,
+    title: &TitleModel,
+    is_new: bool,
+) -> Vec<OobUpdate> {
+    if let Some(token) = token {
+        if let Err(e) = SessionModel::set_current_title(pool, token, title.id).await {
+            tracing::warn!(
+                error = %e,
+                title_id = title.id,
+                "Failed to update current title in session"
+            );
+        }
+        // A new title context invalidates both the pending volume label
+        // (an L-code scan pairs with it) and the batch shelving mode.
+        let _ = SessionModel::set_last_volume_label(pool, token, "").await;
+        let _ = SessionModel::clear_active_location(pool, token).await;
+    }
+
+    let vol_count = VolumeModel::count_by_title(pool, title.id)
+        .await
+        .unwrap_or(0);
+    let author = TitleContributorModel::get_primary_contributor(pool, title.id)
+        .await
+        .unwrap_or(None);
+    let mut oob = vec![OobUpdate {
+        swap_mode: Default::default(),
+        target: "context-banner".to_string(),
+        content: context_banner_html(
+            &title.title,
+            &title.media_type,
+            vol_count,
+            author.as_deref(),
+        ),
+    }];
+
+    if is_new
+        && let Some(token) = token
+        && let Ok(counter) = SessionModel::increment_session_counter(pool, token).await
+    {
+        oob.push(OobUpdate {
+            swap_mode: Default::default(),
+            target: "session-counter".to_string(),
+            content: session_counter_html(counter),
+        });
+    }
+
+    oob
 }
 
 fn push_guide_oob(oob: &mut Vec<OobUpdate>, message: &str) {
@@ -387,48 +460,15 @@ pub async fn handle_scan(
             "isbn" => {
                 match TitleService::create_from_isbn(pool, &code, session.token.as_deref()).await {
                     Ok((title, is_new)) => {
-                        // Update current title in session
-                        if let Some(token) = &session.token {
-                            if let Err(e) =
-                                SessionModel::set_current_title(pool, token, title.id).await
-                            {
-                                tracing::warn!(error = %e, "Failed to update current title in session");
-                            }
-                            let _ = SessionModel::set_last_volume_label(pool, token, "").await;
-                            // Clear batch shelving mode on new ISBN context
-                            let _ = SessionModel::clear_active_location(pool, token).await;
-                        }
-
-                        let vol_count = VolumeModel::count_by_title(pool, title.id)
-                            .await
-                            .unwrap_or(0);
-
-                        // Build OOB updates: context banner + session counter
-                        let mut oob = vec![OobUpdate { swap_mode: Default::default(),
-                            target: "context-banner".to_string(),
-                            content: {
-                                let author =
-                                    TitleContributorModel::get_primary_contributor(pool, title.id)
-                                        .await
-                                        .unwrap_or(None);
-                                context_banner_html(
-                                    &title.title,
-                                    &title.media_type,
-                                    vol_count,
-                                    author.as_deref(),
-                                )
-                            },
-                        }];
-                        if is_new
-                            && let Some(token) = &session.token
-                            && let Ok(counter) =
-                                SessionModel::increment_session_counter(pool, token).await
-                        {
-                            oob.push(OobUpdate { swap_mode: Default::default(),
-                                target: "session-counter".to_string(),
-                                content: session_counter_html(counter),
-                            });
-                        }
+                        // #440 — one shared context activation for every
+                        // scan arm; see `activate_scanned_title`.
+                        let mut oob = activate_scanned_title(
+                            pool,
+                            session.token.as_deref(),
+                            &title,
+                            is_new,
+                        )
+                        .await;
 
                         // CR #242 — auto-link banner appended to either the
                         // "title exists" or the new-title skeleton feedback so
@@ -1032,44 +1072,14 @@ pub async fn handle_scan(
                 .await
                 {
                     Ok((title, is_new)) => {
-                        if let Some(token) = &session.token {
-                            if let Err(e) =
-                                SessionModel::set_current_title(pool, token, title.id).await
-                            {
-                                tracing::warn!(error = %e, "Failed to update current title in session");
-                            }
-                            let _ = SessionModel::set_last_volume_label(pool, token, "").await;
-                            let _ = SessionModel::clear_active_location(pool, token).await;
-                        }
-
-                        let vol_count = VolumeModel::count_by_title(pool, title.id)
-                            .await
-                            .unwrap_or(0);
-                        let mut oob = vec![OobUpdate { swap_mode: Default::default(),
-                            target: "context-banner".to_string(),
-                            content: {
-                                let author =
-                                    TitleContributorModel::get_primary_contributor(pool, title.id)
-                                        .await
-                                        .unwrap_or(None);
-                                context_banner_html(
-                                    &title.title,
-                                    &title.media_type,
-                                    vol_count,
-                                    author.as_deref(),
-                                )
-                            },
-                        }];
-                        if is_new
-                            && let Some(token) = &session.token
-                            && let Ok(counter) =
-                                SessionModel::increment_session_counter(pool, token).await
-                        {
-                            oob.push(OobUpdate { swap_mode: Default::default(),
-                                target: "session-counter".to_string(),
-                                content: session_counter_html(counter),
-                            });
-                        }
+                        // #440 — shared context activation.
+                        let mut oob = activate_scanned_title(
+                            pool,
+                            session.token.as_deref(),
+                            &title,
+                            is_new,
+                        )
+                        .await;
 
                         if !is_new {
                             let guide = rust_i18n::t!("guide.title_active", title = &title.title)
@@ -1145,35 +1155,65 @@ pub async fn handle_scan(
                     )
                     .await
                     {
-                        Ok((title, _is_new)) => {
-                            let timeout_secs = state
-                                .settings
-                                .read()
-                                .map(|s| s.metadata_fetch_timeout_secs)
-                                .unwrap_or(30);
-                            let per_provider_timeouts = state.metadata_chain_provider_timeouts();
-                            crate::tasks::metadata_fetch::spawn_fetch(
-                                "catalog_upc_session_pref",
-                                title.id,
-                                crate::tasks::metadata_fetch::fetch_metadata_chain(
-                                    pool.clone(),
+                        Ok((title, is_new)) => {
+                            // #440 — THIS is the arm that was missing the
+                            // context activation entirely. It fires from the
+                            // second UPC scan of a session onward (once the
+                            // media-type preference cookie is set), so the
+                            // session kept pointing at the previous title and
+                            // the next V-code attached its volume there.
+                            let mut oob = activate_scanned_title(
+                                pool,
+                                session.token.as_deref(),
+                                &title,
+                                is_new,
+                            )
+                            .await;
+
+                            // Only a genuinely new title warrants a metadata
+                            // fetch; re-scanning a known UPC used to re-trigger
+                            // the whole provider chain for nothing.
+                            if is_new {
+                                let timeout_secs = state
+                                    .settings
+                                    .read()
+                                    .map(|s| s.metadata_fetch_timeout_secs)
+                                    .unwrap_or(30);
+                                let per_provider_timeouts =
+                                    state.metadata_chain_provider_timeouts();
+                                crate::tasks::metadata_fetch::spawn_fetch(
+                                    "catalog_upc_session_pref",
                                     title.id,
-                                    code.clone(),
-                                    CodeType::Upc,
-                                    media_type,
-                                    state.registry.clone(),
-                                    timeout_secs,
-                                    per_provider_timeouts.clone(),
-                                    state.http_client.clone(),
-                                    state.covers_dir.clone(),
-                                    false,
-                                ),
-                            );
-                            Ok(HtmxResponse {
-                                main: skeleton_feedback_html(title.id, &code),
-                                oob: vec![],
+                                    crate::tasks::metadata_fetch::fetch_metadata_chain(
+                                        pool.clone(),
+                                        title.id,
+                                        code.clone(),
+                                        CodeType::Upc,
+                                        media_type,
+                                        state.registry.clone(),
+                                        timeout_secs,
+                                        per_provider_timeouts.clone(),
+                                        state.http_client.clone(),
+                                        state.covers_dir.clone(),
+                                        false,
+                                    ),
+                                );
                             }
-                            .into_response())
+
+                            let guide =
+                                rust_i18n::t!("guide.title_active", title = &title.title)
+                                    .to_string();
+                            push_guide_oob(&mut oob, &guide);
+
+                            let main = if is_new {
+                                skeleton_feedback_html(title.id, &code)
+                            } else {
+                                let message = rust_i18n::t!("feedback.title_exists").to_string();
+                                let suggestion =
+                                    rust_i18n::t!("feedback.title_exists_suggestion").to_string();
+                                feedback_html("info", &message, &suggestion)
+                            };
+                            Ok(HtmxResponse { main, oob }.into_response())
                         }
                         Err(e) => {
                             tracing::error!(error = %e, code = %code, "UPC scan failed");
@@ -1341,40 +1381,9 @@ pub async fn handle_scan_with_type(
     .await
     {
         Ok((title, is_new)) => {
-            if let Some(token) = &session.token {
-                if let Err(e) = SessionModel::set_current_title(pool, token, title.id).await {
-                    tracing::warn!(error = %e, "Failed to update current title");
-                }
-                let _ = SessionModel::set_last_volume_label(pool, token, "").await;
-                let _ = SessionModel::clear_active_location(pool, token).await;
-            }
-
-            let vol_count = VolumeModel::count_by_title(pool, title.id)
-                .await
-                .unwrap_or(0);
-            let mut oob = vec![OobUpdate { swap_mode: Default::default(),
-                target: "context-banner".to_string(),
-                content: {
-                    let author = TitleContributorModel::get_primary_contributor(pool, title.id)
-                        .await
-                        .unwrap_or(None);
-                    context_banner_html(
-                        &title.title,
-                        &title.media_type,
-                        vol_count,
-                        author.as_deref(),
-                    )
-                },
-            }];
-            if is_new
-                && let Some(token) = &session.token
-                && let Ok(counter) = SessionModel::increment_session_counter(pool, token).await
-            {
-                oob.push(OobUpdate { swap_mode: Default::default(),
-                    target: "session-counter".to_string(),
-                    content: session_counter_html(counter),
-                });
-            }
+            // #440 — shared context activation.
+            let mut oob =
+                activate_scanned_title(pool, session.token.as_deref(), &title, is_new).await;
 
             if is_new {
                 let timeout_secs = state

--- a/src/services/volume.rs
+++ b/src/services/volume.rs
@@ -4,6 +4,34 @@ use crate::models::location::LocationModel;
 use crate::models::title::TitleModel;
 use crate::models::volume::VolumeModel;
 
+/// Outcome of a V-code scan that lands a volume on a title (#442).
+///
+/// A soft-deleted volume keeps its label locked by the global `UNIQUE` index,
+/// so re-sticking a physical label used to be impossible without an admin
+/// round-trip through the Trash. `ReusedLabel` is the transparent-reactivation
+/// path — same shape as `CreateOutcome::Reactivated` for reference data — and
+/// is reported differently to the librarian, because it discards the previous
+/// copy's data.
+#[derive(Debug)]
+pub enum VolumeCreation {
+    Created(VolumeModel),
+    ReusedLabel(VolumeModel),
+}
+
+impl VolumeCreation {
+    pub fn volume(&self) -> &VolumeModel {
+        match self {
+            VolumeCreation::Created(v) | VolumeCreation::ReusedLabel(v) => v,
+        }
+    }
+
+    pub fn into_volume(self) -> VolumeModel {
+        match self {
+            VolumeCreation::Created(v) | VolumeCreation::ReusedLabel(v) => v,
+        }
+    }
+}
+
 pub struct VolumeService;
 
 impl VolumeService {
@@ -25,11 +53,16 @@ impl VolumeService {
 
     /// Create a new volume attached to the given title.
     /// Validates V-code format, checks title exists, checks label uniqueness.
+    ///
+    /// `actor_user_id` is the librarian performing the scan; it is only used to
+    /// attribute the audit entry written when a soft-deleted label is reused
+    /// (#442), and may be `None` for non-interactive callers.
     pub async fn create_volume(
         pool: &DbPool,
         label: &str,
         title_id: u64,
-    ) -> Result<VolumeModel, AppError> {
+        actor_user_id: Option<u64>,
+    ) -> Result<VolumeCreation, AppError> {
         if !Self::validate_vcode(label) {
             return Err(AppError::BadRequest(
                 rust_i18n::t!("feedback.vcode_invalid").to_string(),
@@ -46,26 +79,93 @@ impl VolumeService {
 
         // Create volume — handle UNIQUE constraint with user-friendly message
         match VolumeModel::create(pool, title_id, label).await {
-            Ok(vol) => Ok(vol),
+            Ok(vol) => Ok(VolumeCreation::Created(vol)),
             Err(AppError::BadRequest(msg)) if msg.starts_with("DUPLICATE_LABEL:") => {
-                // Duplicate label — look up which title owns the existing volume
-                let existing_title =
-                    if let Some(existing_vol) = VolumeModel::find_by_label(pool, label).await? {
-                        Self::get_volume_title_name(pool, &existing_vol).await
-                    } else {
-                        "?".to_string()
-                    };
-                Err(AppError::BadRequest(
-                    rust_i18n::t!(
-                        "feedback.volume_duplicate",
-                        label = label,
-                        title = &existing_title
-                    )
-                    .to_string(),
-                ))
+                Self::resolve_duplicate_label(pool, label, title_id, actor_user_id).await
             }
             Err(e) => Err(e),
         }
+    }
+
+    /// #442 — the label already exists. Decide between "taken", "reusable" and
+    /// "in the Trash but not reusable".
+    ///
+    /// The lookup MUST include soft-deleted rows: `volumes.label` is globally
+    /// UNIQUE and soft-deletion does not release it, so the previous
+    /// `find_by_label` (which filters `deleted_at IS NULL`) returned `None` for
+    /// exactly the collision it was trying to explain — and the message named
+    /// the owner `"?"`.
+    async fn resolve_duplicate_label(
+        pool: &DbPool,
+        label: &str,
+        title_id: u64,
+        actor_user_id: Option<u64>,
+    ) -> Result<VolumeCreation, AppError> {
+        let Some((existing, is_deleted)) =
+            VolumeModel::find_by_label_any_state(pool, label).await?
+        else {
+            // The row vanished between the failed INSERT and this lookup — a
+            // concurrent hard delete. Retrying is the honest advice.
+            return Err(AppError::Conflict(
+                rust_i18n::t!("feedback.volume_label_race", label = label).to_string(),
+            ));
+        };
+
+        if !is_deleted {
+            // Live volume — the label is genuinely taken.
+            let owner = Self::get_volume_title_name(pool, &existing).await;
+            return Err(AppError::BadRequest(
+                rust_i18n::t!("feedback.volume_duplicate", label = label, title = &owner)
+                    .to_string(),
+            ));
+        }
+
+        // Soft-deleted. Reuse is safe only when nothing references the row.
+        let loans = VolumeModel::count_loans(pool, existing.id).await?;
+        if loans > 0 {
+            return Err(AppError::BadRequest(
+                rust_i18n::t!("feedback.volume_label_in_trash_with_loans", label = label)
+                    .to_string(),
+            ));
+        }
+
+        // Record what we are about to discard BEFORE the update, so the audit
+        // entry can restore it by hand if the reuse was a mistake.
+        let discarded = serde_json::json!({
+            "label": label,
+            "previous_title_id": existing.title_id,
+            "previous_location_id": existing.location_id,
+            "previous_condition_state_id": existing.condition_state_id,
+            "previous_edition_comment": existing.edition_comment,
+            "previous_purchase_price": existing.purchase_price,
+            "previous_purchase_currency": existing.purchase_currency,
+            "previous_current_value": existing.current_value,
+            "previous_current_value_currency": existing.current_value_currency,
+            "new_title_id": title_id,
+        });
+
+        VolumeModel::reactivate_for_reuse(pool, existing.id, title_id).await?;
+
+        if let Some(user_id) = actor_user_id
+            && let Err(e) = crate::models::admin_audit::AdminAuditModel::create(
+                pool,
+                user_id,
+                "volume_label_reused",
+                Some("volumes"),
+                Some(existing.id),
+                Some(discarded),
+            )
+            .await
+        {
+            // Best-effort: a missing audit row must not undo a successful
+            // reuse, but it is worth shouting about.
+            tracing::warn!(error = %e, volume_id = existing.id, "Failed to audit volume label reuse");
+        }
+
+        let refreshed = VolumeModel::find_by_label(pool, label)
+            .await?
+            .ok_or_else(|| AppError::Internal("reactivated volume vanished".to_string()))?;
+        Ok(VolumeCreation::ReusedLabel(refreshed))
     }
 
     /// Assign a location to a volume by their labels.

--- a/tests/e2e/specs/journeys/catalog-cd-sequence.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-cd-sequence.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+/**
+ * #440 — cataloging several CDs in a row.
+ *
+ * The first UPC of a browser session goes through the MediaTypeSelector, which
+ * always set the active title correctly. Once "CD" is picked, a
+ * `media_type_preference` session cookie is remembered and every subsequent UPC
+ * takes a different code path — the one that used to create the title without
+ * ever making it the session's active scan context. The librarian then scanned
+ * the volume label and it attached to the PREVIOUS title, or failed outright
+ * with "Introuvable" when that title had since been deleted.
+ *
+ * This is the production incident of 2026-07-27 replayed as a journey: two CDs
+ * in a row, then a volume label.
+ *
+ * Codes are 13-digit EAN product barcodes unique to this spec (the 12-digit
+ * UPC-A mod-10 guard does not apply at this length). The MusicBrainz mock only
+ * knows 0093624738626, so these resolve to no metadata and each title keeps its
+ * raw code as its name — which makes the assertions below unambiguous about
+ * WHICH title a volume landed on.
+ */
+const CD_FIRST = "0093624700011";
+const CD_SECOND = "0093624700028";
+const VOLUME_LABEL = "V0440";
+
+async function scan(page: import("@playwright/test").Page, code: string) {
+  const scanField = page.locator("[data-mybibli-scan-field]");
+  await scanField.fill(code);
+  await scanField.press("Enter");
+}
+
+test.describe("Cataloging consecutive CDs (#440)", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page);
+  });
+
+  test("the second CD becomes the active title, and its volume attaches to it", async ({
+    page,
+  }) => {
+    // ── First CD: goes through the MediaTypeSelector ──────────────────
+    await scan(page, CD_FIRST);
+
+    const cdButton = page.locator('button[role="radio"]', { hasText: "CD" });
+    await expect(cdButton).toBeVisible({ timeout: 10000 });
+    await cdButton.click();
+
+    const banner = page.locator("#context-banner");
+    await expect(banner).toContainText(CD_FIRST, { timeout: 10000 });
+
+    // ── Second CD: the media type is now remembered, so no selector ───
+    await scan(page, CD_SECOND);
+
+    // The regression: the banner used to keep showing the FIRST CD, leaving
+    // the librarian no cue that the scan context had not moved.
+    await expect(banner).toContainText(CD_SECOND, { timeout: 10000 });
+    await expect(banner).not.toContainText(CD_FIRST);
+
+    // ── The volume label must land on the second CD ───────────────────
+    await scan(page, VOLUME_LABEL);
+
+    const feedback = page.locator(".feedback-entry").first();
+    await expect(feedback).toContainText(VOLUME_LABEL, { timeout: 10000 });
+    await expect(feedback).toContainText(CD_SECOND);
+    await expect(feedback).not.toContainText(CD_FIRST);
+  });
+
+  test("re-scanning an already catalogued CD reports it as existing", async ({
+    page,
+  }) => {
+    await scan(page, CD_FIRST);
+    const cdButton = page.locator('button[role="radio"]', { hasText: "CD" });
+    await expect(cdButton).toBeVisible({ timeout: 10000 });
+    await cdButton.click();
+    await expect(page.locator("#context-banner")).toContainText(CD_FIRST, {
+      timeout: 10000,
+    });
+
+    // Same disc again — the cookie arm used to discard `is_new` and replay the
+    // whole provider chain, showing the "fetching metadata" skeleton for a
+    // title already in the catalog.
+    await scan(page, CD_FIRST);
+
+    const feedback = page.locator(".feedback-entry").first();
+    await expect(feedback).toContainText(
+      /already in your catalog|déjà dans votre catalogue/i,
+      { timeout: 10000 },
+    );
+  });
+});

--- a/tests/e2e/specs/journeys/vcode-label-recovery.spec.ts
+++ b/tests/e2e/specs/journeys/vcode-label-recovery.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * #441 + #442 — recovering from the two dead ends the librarian hit while
+ * cataloging on 2026-07-27.
+ *
+ * #441: the active title is deleted, then a V-code is scanned. The scan used to
+ * answer "Introuvable — l'élément a peut-être été déplacé ou supprimé", which
+ * blames the label the librarian just scanned. It must instead say there is no
+ * active item, and clear the stale context so the next scan works.
+ *
+ * #442: a volume is deleted, then its physical label is re-stuck on another
+ * book and re-scanned. The label used to stay locked by the UNIQUE index —
+ * "déjà assigné à ?" — until an admin permanently deleted the row from the
+ * Trash. It must now be reusable, with the librarian told that the previous
+ * copy's data was discarded.
+ *
+ * Spec ID "VR" — generated ISBNs never collide with other specs.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+import { specIsbn } from "../../helpers/isbn";
+
+async function catalogTitle(
+  page: import("@playwright/test").Page,
+  isbn: string,
+) {
+  const scanField = page.locator("#scan-field");
+  await scanField.fill(isbn);
+  await scanField.press("Enter");
+  await page.waitForSelector(".feedback-skeleton, .feedback-entry", {
+    timeout: 10000,
+  });
+}
+
+/**
+ * Confirm a UX-DR8 delete modal and wait for the `HX-Redirect` it triggers to
+ * land.
+ *
+ * Deleting a title redirects to `/`; deleting a volume redirects to
+ * `/title/:id`. Navigating on our own before that redirect completes aborts it
+ * — `net::ERR_ABORTED` — which is a genuine race, not a slow page. So we wait
+ * for the URL to leave the page we were on rather than guessing a duration.
+ */
+async function confirmDeleteModal(
+  page: import("@playwright/test").Page,
+  leavingUrl: RegExp,
+) {
+  const dialog = page.locator("#modal-slot dialog[open]");
+  await expect(dialog).toBeVisible();
+  await Promise.all([
+    page.waitForURL((url) => !leavingUrl.test(url.pathname), {
+      timeout: 15000,
+    }),
+    dialog
+      .getByRole("button", { name: /Delete|Supprimer|Confirm|Confirmer/i })
+      .last()
+      .click(),
+  ]);
+}
+
+async function openTitlePage(
+  page: import("@playwright/test").Page,
+  isbn: string,
+) {
+  await page.goto(`/?q=${isbn}`);
+  const titleLink = page
+    .locator('#browse-results table.browse-table tbody tr td a[href^="/title/"]')
+    .first();
+  await expect(titleLink).toBeVisible({ timeout: 15000 });
+  await page.goto((await titleLink.getAttribute("href"))!);
+  await page.waitForURL(/\/title\/\d+/);
+}
+
+test.describe("Recovering a V-code label (#441, #442)", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, "librarian");
+  });
+
+  test("#441 — scanning a V-code after the active title was deleted says so plainly", async ({
+    page,
+  }) => {
+    const isbn = specIsbn("VR", 1);
+
+    await page.goto("/catalog");
+    await catalogTitle(page, isbn);
+
+    // Delete the title that is currently active in the scan session.
+    await openTitlePage(page, isbn);
+    await page
+      .getByRole("button", { name: /Delete|Supprimer/i })
+      .first()
+      .click();
+    // Title delete redirects to "/" — wait for it before navigating ourselves.
+    await confirmDeleteModal(page, /^\/title\/\d+$/);
+
+    // Back to the scan field, with the session still pointing at the dead title.
+    await page.goto("/catalog");
+    const scanField = page.locator("#scan-field");
+    await scanField.fill("V0441");
+    await scanField.press("Enter");
+
+    const feedback = page.locator(".feedback-entry").first();
+    await expect(feedback).toContainText(
+      /No title selected|Aucun titre sélectionné/i,
+      { timeout: 10000 },
+    );
+    await expect(feedback).not.toContainText(
+      /may have been moved or deleted|peut-être été déplacé ou supprimé/i,
+    );
+  });
+
+  test("#442 — a deleted volume's label can be re-stuck on another book", async ({
+    page,
+  }) => {
+    const firstIsbn = specIsbn("VR", 2);
+    const secondIsbn = specIsbn("VR", 3);
+    const label = "V0442";
+
+    // Catalog the first book and give it the label.
+    await page.goto("/catalog");
+    await catalogTitle(page, firstIsbn);
+    const scanField = page.locator("#scan-field");
+    await scanField.fill(label);
+    await scanField.press("Enter");
+    await expect(
+      page.locator(".feedback-entry").filter({ hasText: label }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // The librarian realises it went on the wrong book and deletes the volume.
+    await openTitlePage(page, firstIsbn);
+    const volumeRow = page.locator("#title-volumes table tbody tr").first();
+    await expect(volumeRow).toContainText(label);
+    await volumeRow.getByRole("button", { name: /Delete|Supprimer/i }).click();
+    // Volume delete redirects back to the same /title/:id — wait for the
+    // reload rather than racing it.
+    await Promise.all([
+      page.waitForLoadState("load"),
+      (async () => {
+        const dialog = page.locator("#modal-slot dialog[open]");
+        await expect(dialog).toBeVisible();
+        await dialog
+          .getByRole("button", { name: /Delete|Supprimer|Confirm|Confirmer/i })
+          .last()
+          .click();
+      })(),
+    ]);
+    await expect(page.locator("#title-volumes")).not.toContainText(label);
+
+    // Now the same physical sticker goes on a different book.
+    await page.goto("/catalog");
+    await catalogTitle(page, secondIsbn);
+    await scanField.fill(label);
+    await scanField.press("Enter");
+
+    const feedback = page.locator(".feedback-entry").first();
+    // It must succeed, and it must say the previous copy's data was dropped.
+    await expect(feedback).toContainText(label, { timeout: 10000 });
+    await expect(feedback).toContainText(
+      /reused|réutilisé|wiederverwendet|riutilizzata/i,
+    );
+    await expect(feedback).not.toContainText(/already assigned|déjà assigné/i);
+
+    // And the volume now hangs off the second title.
+    await openTitlePage(page, secondIsbn);
+    await expect(page.locator("#title-volumes")).toContainText(label);
+  });
+});

--- a/tests/scan_title_context.rs
+++ b/tests/scan_title_context.rs
@@ -327,6 +327,91 @@ async fn rescanning_a_known_upc_reports_the_existing_title(pool: DbPool) {
     );
 }
 
+// ─── #441 — the active title was deleted under the librarian's feet ───
+
+/// `current_title_id` is sticky: written on every scan, never removed. When the
+/// title it points at is deleted, the V-code scan used to bubble a raw
+/// `NotFound` out of `VolumeService::create_volume`'s "verify title exists"
+/// guard, which the error arm flattened into the generic copy — "Introuvable —
+/// l'élément a peut-être été déplacé ou supprimé". That blames the label the
+/// librarian just scanned; the real problem is that there is no active item.
+#[sqlx::test(migrations = "./migrations")]
+async fn vcode_scan_with_a_deleted_active_title_reports_no_active_item(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    post_scan(&router, &cookie, &csrf, ISBN_FIRST, None).await;
+    let title_id = title_id_for_code(&pool, "isbn", ISBN_FIRST).await;
+
+    // The librarian deletes the title — exactly what happened in production on
+    // 2026-07-27 — while the session still points at it.
+    sqlx::query("UPDATE titles SET deleted_at = NOW() WHERE id = ?")
+        .bind(title_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let res = post_scan(&router, &cookie, &csrf, "V9101", None).await;
+    let body = String::from_utf8(
+        axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+
+    assert!(
+        body.contains("No title selected") || body.contains("Aucun titre sélectionné"),
+        "#441: the librarian must be told there is no active item; got: {body}"
+    );
+    assert!(
+        !body.contains("may have been moved or deleted")
+            && !body.contains("peut-être été déplacé ou supprimé"),
+        "#441 regression: the generic not-found copy blames the scanned label"
+    );
+    assert!(
+        !body.contains("Something went wrong on our end")
+            && !body.contains("erreur est survenue de notre côté"),
+        "#441 regression: a stale context is not an internal error"
+    );
+}
+
+/// Noticing the stale pointer is only half the fix — it must be dropped, so the
+/// next scan starts from a clean context instead of failing the same way.
+#[sqlx::test(migrations = "./migrations")]
+async fn vcode_scan_clears_the_stale_title_context(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    post_scan(&router, &cookie, &csrf, ISBN_FIRST, None).await;
+    let title_id = title_id_for_code(&pool, "isbn", ISBN_FIRST).await;
+    sqlx::query("UPDATE titles SET deleted_at = NOW() WHERE id = ?")
+        .bind(title_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    post_scan(&router, &cookie, &csrf, "V9102", None).await;
+
+    assert_eq!(
+        SessionModel::get_current_title_id(&pool, &cookie)
+            .await
+            .unwrap(),
+        None,
+        "#441: the stale active title must be dropped from the session"
+    );
+
+    // And no phantom volume was created against the deleted title.
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM volumes WHERE label = ?")
+        .bind("V9102")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0, "no volume may be created without an active title");
+}
+
 // ─── Non-regression on the arms that already worked ───────────────────
 
 /// The `"isbn"` arm was correct before #440 and is now routed through the

--- a/tests/scan_title_context.rs
+++ b/tests/scan_title_context.rs
@@ -1,0 +1,410 @@
+//! #440 — the scan flow must make every freshly scanned title the session's
+//! active scan context. DB-backed integration tests.
+//!
+//! Drives the real router through `tower::oneshot` against a fresh
+//! `#[sqlx::test]` database so the session middleware, CSRF, locale and
+//! role-gate all run end-to-end.
+//!
+//! The regression: the `"upc"` arm of `handle_scan` — the one that fires once
+//! a `media_type_preference` cookie has been remembered — created the title
+//! but never called `SessionModel::set_current_title`. Because that cookie is
+//! a session cookie, the FIRST CD of a browser session went through the
+//! media-type selector (which did set the context) and every subsequent one
+//! did not. The session kept pointing at the previous title, so the next
+//! V-code scan attached its volume to the wrong item — or failed with a
+//! misleading "not found" when that stale title had since been deleted.
+//!
+//! These tests lock the contract for all four scan arms, not just the one
+//! that was broken, because the fix factored them into `activate_scanned_title`
+//! and a regression in any of them is the same class of bug.
+//!
+//! To run locally:
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true \
+//!     DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test scan_title_context
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use mybibli::db::DbPool;
+use mybibli::models::session::SessionModel;
+use std::sync::{Arc, RwLock};
+use tower::ServiceExt;
+
+// Two genuinely valid UPC-A codes — the #384 mod-10 guard rejects anything
+// else. `028947590774` is the CD from the production incident that surfaced
+// this bug; `036000291452` is the textbook UPC-A already used by
+// `tests/upc_checksum_guard.rs`.
+const UPC_FIRST: &str = "028947590774";
+const UPC_SECOND: &str = "036000291452";
+// Valid ISBN-13 check digits — used for the non-regression pass.
+const ISBN_FIRST: &str = "9782070360246";
+const ISBN_SECOND: &str = "9780134685991";
+
+fn state_with_pool(pool: DbPool) -> mybibli::AppState {
+    mybibli::AppState {
+        pool,
+        settings: Arc::new(RwLock::new(mybibli::config::AppSettings::default())),
+        http_client: reqwest::Client::new(),
+        // Empty registry: the spawned metadata fetch finds no provider and
+        // exits immediately, so these tests never touch the network.
+        registry: Arc::new(mybibli::metadata::registry::ProviderRegistry::new()),
+        covers_dir: std::path::PathBuf::from("/tmp"),
+        provider_health: mybibli::tasks::provider_health::new_provider_health_map(),
+        mariadb_version_cache: mybibli::services::admin_health::new_mariadb_version_cache(),
+        setup_gate: Arc::new(RwLock::new(
+            mybibli::middleware::setup_gate::SetupGateState::default(),
+        )),
+        bulk_cover_fetch: Arc::new(RwLock::new(
+            mybibli::services::bulk_cover_fetch::BulkCoverFetchStatus::default(),
+        )),
+        log_level_reloader: mybibli::noop_log_level_reloader(),
+    }
+}
+
+fn app(state: mybibli::AppState) -> axum::Router {
+    mybibli::routes::build_router(state)
+}
+
+// Argon2 hash for password "librarian" — same hash used across the suite.
+const PW_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$NfI9SYT0huhcqAanQWa9pw$mSEHLW8Wl8wlk504MRpzyS42JlcU9w2CXYVVFMFvbcU";
+
+/// Seed an admin (satisfies the Librarian gate on /catalog/scan). An active
+/// admin also deactivates the first-launch setup gate so /login works.
+async fn seed_librarian(pool: &DbPool) -> String {
+    sqlx::query("INSERT INTO users (username, password_hash, role) VALUES (?, ?, 'admin')")
+        .bind("scan_admin")
+        .bind(PW_HASH)
+        .execute(pool)
+        .await
+        .unwrap();
+    "scan_admin".to_string()
+}
+
+fn extract_session_cookie(res: &axum::response::Response) -> Option<String> {
+    let header = res
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .find(|s| s.starts_with("session="))?;
+    let kv = header.split(';').next()?;
+    let (_, raw_value) = kv.split_once('=')?;
+    Some(
+        percent_encoding::percent_decode_str(raw_value)
+            .decode_utf8_lossy()
+            .to_string(),
+    )
+}
+
+async fn fetch_csrf_token(router: &axum::Router, session_cookie: &str) -> String {
+    let res = router
+        .clone()
+        .oneshot(
+            Request::get("/")
+                .header("cookie", format!("session={session_cookie}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let html = String::from_utf8(bytes.to_vec()).unwrap();
+    let needle = "name=\"csrf-token\" content=\"";
+    let start = html.find(needle).expect("csrf-token meta tag") + needle.len();
+    let rest = &html[start..];
+    let end = rest.find('"').unwrap();
+    rest[..end].to_string()
+}
+
+async fn login(router: &axum::Router, username: &str) -> (String, String) {
+    let body = format!("username={username}&password=librarian");
+    let res = router
+        .clone()
+        .oneshot(
+            Request::post("/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SEE_OTHER, "login should succeed");
+    let cookie = extract_session_cookie(&res).expect("session cookie");
+    let csrf = fetch_csrf_token(router, &cookie).await;
+    (cookie, csrf)
+}
+
+/// POST /catalog/scan. `media_type_pref` mirrors the browser sending the
+/// `media_type_preference` cookie once the media-type selector has run once —
+/// this is the exact condition that triggered the #440 regression.
+async fn post_scan(
+    router: &axum::Router,
+    cookie: &str,
+    csrf: &str,
+    code: &str,
+    media_type_pref: Option<&str>,
+) -> axum::response::Response {
+    let cookie_header = match media_type_pref {
+        Some(mt) => format!("session={cookie}; media_type_preference={mt}"),
+        None => format!("session={cookie}"),
+    };
+    router
+        .clone()
+        .oneshot(
+            Request::post("/catalog/scan")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", cookie_header)
+                .header("X-CSRF-Token", csrf)
+                .header("HX-Request", "true")
+                .body(Body::from(format!("code={code}")))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// POST /catalog/scan-with-type — the media-type selector path, which is what
+/// a librarian hits for the FIRST UPC of a session.
+async fn post_scan_with_type(
+    router: &axum::Router,
+    cookie: &str,
+    csrf: &str,
+    code: &str,
+    media_type: &str,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::post("/catalog/scan-with-type")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", format!("session={cookie}"))
+                .header("X-CSRF-Token", csrf)
+                .header("HX-Request", "true")
+                .body(Body::from(format!("code={code}&media_type={media_type}")))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn title_id_for_code(pool: &DbPool, column: &str, code: &str) -> u64 {
+    let id: (u64,) = sqlx::query_as(&format!(
+        "SELECT id FROM titles WHERE {column} = ? AND deleted_at IS NULL"
+    ))
+    .bind(code)
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("title for {column}={code} should exist: {e}"));
+    id.0
+}
+
+// ─── The regression ───────────────────────────────────────────────────
+
+/// The core of #440. Scan a first UPC through the media-type selector (which
+/// always worked), then a SECOND UPC with the preference cookie set — the arm
+/// that used to skip the context activation entirely.
+#[sqlx::test(migrations = "./migrations")]
+async fn second_upc_scan_with_preference_cookie_sets_current_title(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    // First CD — goes through the selector, which sets the context.
+    post_scan_with_type(&router, &cookie, &csrf, UPC_FIRST, "cd").await;
+    let first_id = title_id_for_code(&pool, "upc", UPC_FIRST).await;
+    assert_eq!(
+        SessionModel::get_current_title_id(&pool, &cookie)
+            .await
+            .unwrap(),
+        Some(first_id),
+        "the media-type selector path must set the active title"
+    );
+
+    // Second CD — the cookie is now set, so this takes the `"upc"` arm.
+    post_scan(&router, &cookie, &csrf, UPC_SECOND, Some("cd")).await;
+    let second_id = title_id_for_code(&pool, "upc", UPC_SECOND).await;
+    assert_ne!(first_id, second_id, "the two CDs must be distinct titles");
+
+    assert_eq!(
+        SessionModel::get_current_title_id(&pool, &cookie)
+            .await
+            .unwrap(),
+        Some(second_id),
+        "#440: a UPC scan using the remembered media type must make the NEW \
+         title active — leaving the previous one active is what made V-code \
+         labels attach to the wrong item"
+    );
+}
+
+/// The user-visible consequence: the V-code scanned right after the second UPC
+/// must produce a volume on the second title, not on the first.
+#[sqlx::test(migrations = "./migrations")]
+async fn vcode_after_second_upc_scan_attaches_to_the_new_title(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    post_scan_with_type(&router, &cookie, &csrf, UPC_FIRST, "cd").await;
+    let first_id = title_id_for_code(&pool, "upc", UPC_FIRST).await;
+
+    post_scan(&router, &cookie, &csrf, UPC_SECOND, Some("cd")).await;
+    let second_id = title_id_for_code(&pool, "upc", UPC_SECOND).await;
+
+    // Now the volume label, exactly as the librarian scans it.
+    post_scan(&router, &cookie, &csrf, "V9001", Some("cd")).await;
+
+    let owner: (u64,) = sqlx::query_as(
+        "SELECT title_id FROM volumes WHERE label = ? AND deleted_at IS NULL",
+    )
+    .bind("V9001")
+    .fetch_one(&pool)
+    .await
+    .expect("the V-code scan should have created a volume");
+
+    assert_eq!(
+        owner.0, second_id,
+        "#440: the volume must land on the title that was just scanned, not \
+         on the previous one"
+    );
+    assert_ne!(
+        owner.0, first_id,
+        "#440 regression: the volume was attached to the PREVIOUS title"
+    );
+}
+
+/// Re-scanning a UPC that is already catalogued must be reported as an
+/// existing title, not silently re-skeletoned. The old `"upc"` arm discarded
+/// `is_new` and re-triggered the whole provider chain every time.
+#[sqlx::test(migrations = "./migrations")]
+async fn rescanning_a_known_upc_reports_the_existing_title(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    post_scan_with_type(&router, &cookie, &csrf, UPC_FIRST, "cd").await;
+    let first_id = title_id_for_code(&pool, "upc", UPC_FIRST).await;
+
+    // Same code again, through the cookie arm.
+    let res = post_scan(&router, &cookie, &csrf, UPC_FIRST, Some("cd")).await;
+    let body = String::from_utf8(
+        axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+
+    // The old arm discarded `is_new` and always returned the "fetching
+    // metadata" skeleton, re-triggering the whole provider chain for a title
+    // it already had. The librarian must instead be told it is already
+    // catalogued.
+    assert!(
+        !body.contains("feedback-skeleton"),
+        "re-scanning a known UPC must not return the metadata-fetch skeleton"
+    );
+    assert!(
+        body.contains("already in your catalog") || body.contains("déjà dans votre catalogue"),
+        "re-scanning a known UPC must report the existing title; got: {body}"
+    );
+
+    let count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM titles WHERE upc = ? AND deleted_at IS NULL")
+            .bind(UPC_FIRST)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count.0, 1, "re-scanning a known UPC must not duplicate it");
+
+    assert_eq!(
+        SessionModel::get_current_title_id(&pool, &cookie)
+            .await
+            .unwrap(),
+        Some(first_id),
+        "re-scanning a known UPC must still make it the active title"
+    );
+}
+
+// ─── Non-regression on the arms that already worked ───────────────────
+
+/// The `"isbn"` arm was correct before #440 and is now routed through the
+/// shared helper — this locks it against a refactor regression.
+#[sqlx::test(migrations = "./migrations")]
+async fn isbn_scan_sets_current_title(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    post_scan(&router, &cookie, &csrf, ISBN_FIRST, None).await;
+    let first_id = title_id_for_code(&pool, "isbn", ISBN_FIRST).await;
+    assert_eq!(
+        SessionModel::get_current_title_id(&pool, &cookie)
+            .await
+            .unwrap(),
+        Some(first_id)
+    );
+
+    // A second ISBN must move the context, not keep the first one.
+    post_scan(&router, &cookie, &csrf, ISBN_SECOND, None).await;
+    let second_id = title_id_for_code(&pool, "isbn", ISBN_SECOND).await;
+    assert_eq!(
+        SessionModel::get_current_title_id(&pool, &cookie)
+            .await
+            .unwrap(),
+        Some(second_id),
+        "consecutive ISBN scans must each take over the context"
+    );
+}
+
+/// Activating a new title clears the batch shelving mode and the pending
+/// volume label. Both are part of the same session-context contract the
+/// `"upc"` arm was skipping, and both have user-visible consequences: a stale
+/// active location silently shelves the next volume in the wrong place.
+#[sqlx::test(migrations = "./migrations")]
+async fn activating_a_title_clears_batch_location_and_pending_label(pool: DbPool) {
+    let username = seed_librarian(&pool).await;
+    let router = app(state_with_pool(pool.clone()));
+    let (cookie, csrf) = login(&router, &username).await;
+
+    post_scan_with_type(&router, &cookie, &csrf, UPC_FIRST, "cd").await;
+
+    // Simulate a batch-shelving session in progress.
+    sqlx::query("INSERT INTO storage_locations (label, name, node_type) VALUES (?, ?, ?)")
+        .bind("L9001")
+        .bind("Test shelf")
+        .bind("shelf")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let loc: (u64,) = sqlx::query_as("SELECT id FROM storage_locations WHERE label = ?")
+        .bind("L9001")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    SessionModel::set_active_location(&pool, &cookie, loc.0)
+        .await
+        .unwrap();
+    SessionModel::set_last_volume_label(&pool, &cookie, "V9002")
+        .await
+        .unwrap();
+
+    // Scanning the next item must reset both.
+    post_scan(&router, &cookie, &csrf, UPC_SECOND, Some("cd")).await;
+
+    assert_eq!(
+        SessionModel::get_active_location(&pool, &cookie)
+            .await
+            .unwrap(),
+        None,
+        "a new title context must clear the batch shelving location"
+    );
+    assert_eq!(
+        SessionModel::get_last_volume_label(&pool, &cookie)
+            .await
+            .unwrap(),
+        None,
+        "a new title context must clear the pending volume label"
+    );
+}

--- a/tests/volume_label_reuse.rs
+++ b/tests/volume_label_reuse.rs
@@ -1,0 +1,341 @@
+//! #442 — soft-deleting a volume must not permanently lock its V-code label.
+//!
+//! `volumes.label` carries a global `UNIQUE` index that soft-deletion does not
+//! release, and `VolumeModel::create` had no reactivation path (unlike the four
+//! reference-data taxonomies, which reuse `CreateOutcome::Reactivated`). Worse,
+//! the duplicate-label message resolved its owner through `find_by_label`,
+//! which filters `deleted_at IS NULL` — so it named the owner `"?"`, telling
+//! the librarian the label was taken by nothing.
+//!
+//! In production on 2026-07-27 the only way out was Admin → Trash → permanent
+//! delete before the physical sticker could be re-stuck.
+//!
+//! The settled behaviour:
+//!   - label free                     → create
+//!   - label held by a live volume    → refuse, naming the owning title
+//!   - label held by a deleted volume with NO loans   → reuse it, wiping the
+//!     previous copy's data, and write an audit row recording what was wiped
+//!   - label held by a deleted volume WITH loan history → refuse, pointing at
+//!     the Trash. Reusing the row would keep its `id`, and `loans.volume_id`
+//!     references it — the old loan history would silently re-attach to a
+//!     different physical copy.
+//!
+//! To run locally:
+//!     docker compose -f tests/docker-compose.rust-test.yml up -d
+//!     SQLX_OFFLINE=true \
+//!     DATABASE_URL='mysql://root:root_test@localhost:3307/mybibli_rust_test' \
+//!         cargo test --test volume_label_reuse
+
+use mybibli::db::DbPool;
+use mybibli::error::AppError;
+use mybibli::models::volume::VolumeModel;
+use mybibli::services::volume::{VolumeCreation, VolumeService};
+
+const LABEL: &str = "V4420";
+
+async fn seed_title(pool: &DbPool, name: &str) -> u64 {
+    // `titles.genre_id` has no default — borrow the first seeded genre, as the
+    // rest of the suite does.
+    let res = sqlx::query(
+        "INSERT INTO titles (title, media_type, genre_id) \
+         VALUES (?, 'book', (SELECT id FROM genres LIMIT 1))",
+    )
+    .bind(name)
+    .execute(pool)
+    .await
+    .unwrap();
+    res.last_insert_id()
+}
+
+async fn seed_admin(pool: &DbPool) -> u64 {
+    let res = sqlx::query(
+        "INSERT INTO users (username, password_hash, role) VALUES ('reuse_admin', 'x', 'admin')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    res.last_insert_id()
+}
+
+async fn soft_delete_volume(pool: &DbPool, id: u64) {
+    sqlx::query("UPDATE volumes SET deleted_at = NOW() WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+// ─── The mechanism that produced the "?" ──────────────────────────────
+
+/// Documents the root cause, independently of the service layer: soft-deleting
+/// a volume leaves its label locked by the `UNIQUE` index while making the row
+/// invisible to `find_by_label`. The old duplicate-label message resolved its
+/// owner through that filtered lookup, got `None`, and printed `"?"`.
+///
+/// This is the invariant the fix is built on, so it is worth locking on its
+/// own: if a future migration ever makes the index partial, the reuse path
+/// becomes dead code and this test says so.
+#[sqlx::test(migrations = "./migrations")]
+async fn soft_delete_hides_the_row_but_keeps_the_label_locked(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let title = seed_title(&pool, "Old").await;
+    let other = seed_title(&pool, "New").await;
+
+    let id = VolumeService::create_volume(&pool, LABEL, title, Some(admin))
+        .await
+        .unwrap()
+        .volume()
+        .id;
+    soft_delete_volume(&pool, id).await;
+
+    // Invisible to the filtered lookup…
+    assert!(
+        VolumeModel::find_by_label(&pool, LABEL).await.unwrap().is_none(),
+        "find_by_label filters deleted_at IS NULL — this is why the owner was \"?\""
+    );
+    // …but the UNIQUE index still holds the label.
+    let err = VolumeModel::create(&pool, other, LABEL).await.unwrap_err();
+    match err {
+        AppError::BadRequest(msg) => assert!(
+            msg.starts_with("DUPLICATE_LABEL:"),
+            "the raw INSERT must still collide; got: {msg}"
+        ),
+        other => panic!("expected the UNIQUE collision, got {other:?}"),
+    }
+    // The state-aware lookup is what makes the fix possible.
+    let (row, is_deleted) = VolumeModel::find_by_label_any_state(&pool, LABEL)
+        .await
+        .unwrap()
+        .expect("the row is still there, just soft-deleted");
+    assert!(is_deleted);
+    assert_eq!(row.id, id);
+}
+
+// ─── The reuse path ───────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn deleted_label_without_loans_is_reused_for_the_new_title(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let old_title = seed_title(&pool, "Mon potager de vivaces").await;
+    let new_title = seed_title(&pool, "Mémento du bibliothécaire").await;
+
+    let created = VolumeService::create_volume(&pool, LABEL, old_title, Some(admin))
+        .await
+        .unwrap();
+    let original_id = created.volume().id;
+    soft_delete_volume(&pool, original_id).await;
+
+    let outcome = VolumeService::create_volume(&pool, LABEL, new_title, Some(admin))
+        .await
+        .expect("#442: a deleted label with no loan history must be reusable");
+
+    assert!(
+        matches!(outcome, VolumeCreation::ReusedLabel(_)),
+        "reuse must be reported distinctly so the feedback copy can warn about \
+         the discarded copy data"
+    );
+    let volume = outcome.into_volume();
+    assert_eq!(volume.id, original_id, "the row is reused, not duplicated");
+    assert_eq!(volume.title_id, new_title, "it must point at the new title");
+    assert_eq!(volume.label, LABEL);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn reuse_wipes_the_previous_copys_data(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let old_title = seed_title(&pool, "Old").await;
+    let new_title = seed_title(&pool, "New").await;
+
+    let created = VolumeService::create_volume(&pool, LABEL, old_title, Some(admin))
+        .await
+        .unwrap();
+    let id = created.volume().id;
+
+    // Give the copy the full set of per-copy data a librarian can enter.
+    sqlx::query(
+        "UPDATE volumes SET edition_comment = 'signed first edition', \
+         purchase_price = 42.50, purchase_currency = 'CHF', current_value = 90.00, \
+         current_value_currency = 'CHF', current_value_updated_at = NOW(), \
+         under_audit_since = NOW() WHERE id = ?",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    soft_delete_volume(&pool, id).await;
+
+    let volume = VolumeService::create_volume(&pool, LABEL, new_title, Some(admin))
+        .await
+        .unwrap()
+        .into_volume();
+
+    // The sticker is on a DIFFERENT physical object — none of this carries over.
+    assert_eq!(volume.edition_comment, None);
+    assert_eq!(volume.purchase_price, None);
+    assert_eq!(volume.purchase_currency, None);
+    assert_eq!(volume.current_value, None);
+    assert_eq!(volume.current_value_currency, None);
+    assert_eq!(volume.current_value_updated_at, None);
+    assert_eq!(volume.under_audit_since, None);
+    assert_eq!(volume.location_id, None);
+    assert_eq!(volume.condition_state_id, None);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn reuse_records_an_audit_entry_naming_what_was_discarded(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let old_title = seed_title(&pool, "Old").await;
+    let new_title = seed_title(&pool, "New").await;
+
+    let id = VolumeService::create_volume(&pool, LABEL, old_title, Some(admin))
+        .await
+        .unwrap()
+        .volume()
+        .id;
+    sqlx::query("UPDATE volumes SET purchase_price = 42.50, purchase_currency = 'CHF' WHERE id = ?")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    soft_delete_volume(&pool, id).await;
+
+    VolumeService::create_volume(&pool, LABEL, new_title, Some(admin))
+        .await
+        .unwrap();
+
+    let row: (String, String) = sqlx::query_as(
+        "SELECT action, CAST(details AS CHAR) FROM admin_audit \
+         WHERE action = 'volume_label_reused' AND entity_id = ?",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .expect("#442: reuse discards user-entered data and must be auditable");
+
+    assert_eq!(row.0, "volume_label_reused");
+    let details: serde_json::Value = serde_json::from_str(&row.1).unwrap();
+    assert_eq!(details["previous_title_id"], old_title);
+    assert_eq!(details["new_title_id"], new_title);
+    assert_eq!(details["previous_purchase_price"], 42.50);
+    assert_eq!(details["previous_purchase_currency"], "CHF");
+}
+
+// ─── The guard ────────────────────────────────────────────────────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn deleted_label_with_loan_history_is_refused(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let old_title = seed_title(&pool, "Old").await;
+    let new_title = seed_title(&pool, "New").await;
+
+    let id = VolumeService::create_volume(&pool, LABEL, old_title, Some(admin))
+        .await
+        .unwrap()
+        .volume()
+        .id;
+
+    // A returned loan is still history: reusing the row would re-attribute it.
+    let borrower = sqlx::query("INSERT INTO borrowers (name) VALUES ('Past borrower')")
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_id();
+    sqlx::query("INSERT INTO loans (volume_id, borrower_id, returned_at) VALUES (?, ?, NOW())")
+        .bind(id)
+        .bind(borrower)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    soft_delete_volume(&pool, id).await;
+
+    let err = VolumeService::create_volume(&pool, LABEL, new_title, Some(admin))
+        .await
+        .expect_err("#442: a volume with loan history must not be silently reused");
+
+    match err {
+        AppError::BadRequest(msg) => {
+            assert!(
+                msg.contains("loan history") || msg.contains("historique de prêts"),
+                "the message must explain WHY reuse is refused; got: {msg}"
+            );
+            assert!(
+                !msg.contains('?') || msg.contains("Trash") || msg.contains("corbeille"),
+                "and must never degrade to the bare \"?\" owner; got: {msg}"
+            );
+        }
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+
+    // The volume stays deleted and still points at its original title.
+    let (volume, is_deleted) = VolumeModel::find_by_label_any_state(&pool, LABEL)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(is_deleted, "the refused reuse must not resurrect the row");
+    assert_eq!(volume.title_id, old_title);
+}
+
+// ─── The live-collision path keeps working, minus the "?" ─────────────
+
+#[sqlx::test(migrations = "./migrations")]
+async fn live_label_collision_names_the_owning_title(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let owner = seed_title(&pool, "Mon potager de vivaces").await;
+    let other = seed_title(&pool, "Mémento du bibliothécaire").await;
+
+    VolumeService::create_volume(&pool, LABEL, owner, Some(admin))
+        .await
+        .unwrap();
+
+    let err = VolumeService::create_volume(&pool, LABEL, other, Some(admin))
+        .await
+        .expect_err("a live label is genuinely taken");
+
+    match err {
+        AppError::BadRequest(msg) => {
+            assert!(
+                msg.contains("Mon potager de vivaces"),
+                "the owning title must be named; got: {msg}"
+            );
+        }
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+/// The regression that produced the nonsense message: a soft-deleted owner used
+/// to be invisible to the lookup, so the copy fell back to `"?"`. Even on the
+/// refusal path the librarian must never read "assigned to ?".
+#[sqlx::test(migrations = "./migrations")]
+async fn no_path_ever_reports_the_owner_as_a_bare_question_mark(pool: DbPool) {
+    let admin = seed_admin(&pool).await;
+    let old_title = seed_title(&pool, "Old").await;
+    let new_title = seed_title(&pool, "New").await;
+
+    let id = VolumeService::create_volume(&pool, LABEL, old_title, Some(admin))
+        .await
+        .unwrap()
+        .volume()
+        .id;
+    let borrower = sqlx::query("INSERT INTO borrowers (name) VALUES ('B')")
+        .execute(&pool)
+        .await
+        .unwrap()
+        .last_insert_id();
+    sqlx::query("INSERT INTO loans (volume_id, borrower_id) VALUES (?, ?)")
+        .bind(id)
+        .bind(borrower)
+        .execute(&pool)
+        .await
+        .unwrap();
+    soft_delete_volume(&pool, id).await;
+
+    let err = VolumeService::create_volume(&pool, LABEL, new_title, Some(admin))
+        .await
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        !msg.contains("assigned to ?") && !msg.contains("assigné à ?"),
+        "#442 regression: the owner degraded to \"?\"; got: {msg}"
+    );
+}


### PR DESCRIPTION
v1.14.0 cataloging bundle — the three defects behind the 2026-07-27 CD-cataloging incident. They share `catalog.rs` / `volume.rs` and the same E2E scan loop, so they travel together rather than as three serial PRs.

**No migration.** Verified across all three: session/routing logic and `UPDATE`s on existing columns only. The upgrade is an image swap against an unchanged schema, so rollback by re-pulling the previous tag is clean in both directions.

### Progress

- [x] **#440** — `severity:high`. The `"upc"` arm never activated the title it resolved.
- [x] **#441** — `severity:medium`. Stale active title reports "Introuvable" instead of "no active item".
- [x] **#442** — `severity:medium`. Soft-deleting a volume does not free its V-code label.

### #440 — what changed

The `"upc"` arm of `handle_scan`, which fires once a `media_type_preference` cookie has been remembered, created the title but skipped all four context operations its sibling arms performed. Since that cookie is a session cookie, the **first** CD of a browser session worked (it went through the media-type selector) and **every subsequent one** left the session pointing at the previous title — so the next V-code attached its volume to the wrong item, or failed with a misleading "not found" when that title had been deleted.

The fix extracts `activate_scanned_title` and routes all four call sites through it — `"isbn"`, `"issn"`, `handle_scan_with_type` and `"upc"` — rather than patching the one broken arm. The duplication is how the bug was born. The `"upc"` arm also now honours `is_new` instead of replaying the provider chain for known titles.

### Verification

- `tests/scan_title_context.rs` drives the real router through `tower::oneshot`. **Four of its five cases fail against the previous code** and pass after; the fifth locks the ISBN arm against a refactor regression.
- `tests/e2e/specs/journeys/catalog-cd-sequence.spec.ts` replays the production incident: two CDs in a row, then a volume label.
- Full local suite on a fresh stack: **1429 unit/integration passed, 0 failed**; **308 E2E passed, 0 failed** at `CI=true --workers=2`. The two flaky-then-green E2E cases include `title-detail-volumes.spec.ts:22`, which is the known flake #422 and is independent of this change.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo sqlx prepare --check` clean (no query changes).

### #441 — what changed

The deleted-title case is now detected where the context is read, not left to bubble a raw `NotFound` out of the service layer. The stale pointer is dropped (new `SessionModel::clear_current_title`) so the next scan starts clean, and the context banner and guide strip reset. `AppError::NotFound` is additionally mapped to the same copy in the V-code error arm, for the narrow window where a title is deleted between the check and the INSERT.

### #442 — what changed

The label is reused transparently, with one guard that surfaced while instructing the option: reuse keeps the row id and `loans.volume_id` references it, so reusing a row carrying loan history would silently re-attribute that history to a different physical copy.

- no loan history → reactivate, re-point `title_id`, and wipe every copy-specific field (condition, edition comment, location, purchase price/currency, current value, audit flag)
- loan history → refuse, pointing at the Trash and saying why

Reuse discards user-entered data, so it writes an `admin_audit` row recording the previous title, location, condition, purchase and valuation values, and the feedback copy states plainly that the previous copy's data was dropped. The owner lookup now includes soft-deleted rows, so no path can print `?`. Three new i18n keys across all four locales.

### Verification for the full bundle

- **1438 unit/integration passed, 0 failed.** `tests/scan_title_context.rs` (7 cases) and `tests/volume_label_reuse.rs` (7 cases). Every #440 and #441 case was re-run against the previous code and fails there; #442's could not be (the service signature changed), so it additionally locks the underlying UNIQUE-index/soft-delete mechanism directly.
- **E2E: 308 passed, 0 failed** at `CI=true --workers=2` on a freshly reset stack. The new `vcode-label-recovery.spec.ts` was run over **three reset+run cycles with zero retries** after an `ERR_ABORTED` race was found and fixed — the spec was navigating while the delete modal's `HX-Redirect` was still in flight.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo sqlx prepare --check` clean.
- The retry-green specs in the full run (`catalog-title.spec.ts`, `title-detail-volumes.spec.ts`, `language-toggle.spec.ts`) were **measured against `main` with no branch changes applied** and flake identically there. Evidence recorded in #422.

Closes #440
Closes #441
Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)


