### PR TITLE
feat(#439): LoC MARC 21 zones over SRU for anglophone titles

### DIFF
--- a/docs/manual/en/05-metadata-providers.tex
+++ b/docs/manual/en/05-metadata-providers.tex
@@ -19,6 +19,9 @@ media type:
 \endhead
 BnF\index{BnF}                  & Books         & French
 Bibliothèque nationale catalogue; best for French-language titles. & no \\
+Library of Congress\index{Library of Congress} & Books & United
+States national library catalogue; the anglophone counterpart to the
+BnF. Also supplies MARC~21 zones. & no \\
 Open Library\index{Open Library} & Books         & Volunteer
 catalogue; broad English / multilingual coverage. & no \\
 Google Books\index{Google Books} & Books         & Commercial; good
@@ -36,6 +39,28 @@ The first provider to return a \emph{clean} record wins. ``Clean''
 means: title present, at least one contributor, and a year. Partial
 matches are recorded but mybibli keeps walking the chain until it
 finds a clean one or runs out of providers.
+
+\subsection*{Bibliographic zones: BnF and Library of Congress}
+
+Six detailed cataloguing fields — statement of responsibility,
+edition statement, collection title and number, general note,
+original title — come only from the \emph{national libraries}. No
+other provider carries them.
+
+The two catalogues are complementary rather than redundant: the BnF
+describes the French-language corpus, the Library of Congress the
+English-language one. A title held by neither will have none of these
+zones, and a French title the BnF could not describe will not be
+rescued by the Library of Congress.
+
+When the provider that resolved a title fills only some of the six
+zones, mybibli asks the other library to complete the ones left
+empty. The rule is \emph{first source wins}: a value already present
+is never overwritten. Only these six zones are merged — the title,
+authors and cover always come from a single provider.
+
+The \emph{Backfill metadata from libraries} button on the Health tab
+applies the same treatment to titles already in the catalogue.
 
 \subsection*{Cover-image fallbacks}
 

--- a/docs/manual/fr/05-metadata-providers.tex
+++ b/docs/manual/fr/05-metadata-providers.tex
@@ -20,6 +20,9 @@ type de média deviné :
 \endhead
 BnF\index{BnF}                  & Livres         & Catalogue de la
 Bibliothèque nationale de France ; idéal pour les titres en français. & non \\
+Library of Congress\index{Library of Congress} & Livres & Catalogue
+de la bibliothèque nationale des États-Unis ; pendant anglophone de
+la BnF. Fournit aussi les zones MARC~21. & non \\
 Open Library\index{Open Library} & Livres         & Catalogue
 bénévole ; large couverture anglaise / multilingue. & non \\
 Google Books\index{Google Books} & Livres         & Commercial ; bon
@@ -38,6 +41,30 @@ l'emporte. « Propre » veut dire : titre présent, au moins un
 contributeur, et une année. Les correspondances partielles sont
 enregistrées mais mybibli continue à parcourir la chaîne jusqu'à
 trouver une correspondance propre ou épuiser les fournisseurs.
+
+\subsection*{Zones bibliographiques : BnF et Library of Congress}
+
+Six champs de catalogage détaillés — mention de responsabilité,
+mention d'édition, titre et numéro de collection, note générale,
+titre original — ne proviennent que des \emph{bibliothèques
+nationales}. Les autres fournisseurs ne les portent pas.
+
+Ces deux catalogues sont complémentaires plutôt que redondants : la
+BnF décrit le fonds francophone, la Library of Congress le fonds
+anglophone. Un titre absent des deux restera sans ces zones, et un
+titre français que la BnF ne décrit pas ne sera pas rattrapé par la
+Library of Congress.
+
+Quand le fournisseur qui a résolu le titre ne remplit qu'une partie
+de ces six zones, mybibli interroge l'autre bibliothèque pour
+compléter les zones restées vides. La règle est \emph{la première
+source l'emporte} : une valeur déjà présente n'est jamais écrasée.
+Seules ces six zones sont fusionnées — le titre, les auteurs et la
+couverture proviennent toujours d'un seul et même fournisseur.
+
+Le bouton \emph{Compléter les métadonnées via les bibliothèques} de
+l'onglet Santé applique le même traitement aux titres déjà
+catalogués.
 
 \subsection*{Replis sur les couvertures}
 

--- a/docs/unimarc-mapping.md
+++ b/docs/unimarc-mapping.md
@@ -65,6 +65,47 @@ migration `20260724000000_titles_unimarc_zones.sql`), `related-table`.
 - **Cover image** (`cover_image_url`) has no standard UNIMARC bibliographic zone
   and is out of scope for conformity — it is a mybibli convenience field.
 
+## MARC 21 equivalence (#439)
+
+UNIMARC is the French/European standard; the Library of Congress catalogs in
+**MARC 21**. Both serialise identically — `<datafield tag><subfield code>` —
+so `src/metadata/marc.rs` reads either, and only the tag table below differs.
+The LoC provider uses it to fill the same six columns for anglophone titles
+that the BnF does not hold.
+
+| mybibli field | UNIMARC (BnF) | MARC 21 (LoC) | MARC 21 label |
+|---|---|---|---|
+| `statement_of_responsibility` | 200$f | **245$c** | Statement of responsibility |
+| `edition_statement` | 205$a | **250$a** | Edition statement |
+| `collection_title` | 225$a | **490$a** | Series statement |
+| `collection_number` | 225$v | **490$v** | Series volume number |
+| `general_note` | 300$a | **500$a** | General note |
+| `original_title` | 454 / 500$a | **240$a** | Uniform title |
+
+**Read that table carefully: `500` means opposite things in the two standards.**
+UNIMARC 500 is the uniform/original title; MARC 21 500 is the general note. The
+two rows are not a typo.
+
+Two further asymmetries worth knowing:
+
+- **MARC 21 500 repeats.** Real LoC records routinely carry several general
+  notes (confirmed on ISBN 9780134685991, which has two). `marc::extract_subfield`
+  returns the first; `marc::extract_subfields` returns all. We store the first —
+  a concatenated blob reads badly on the title-detail page.
+- **240$a is a uniform title, not strictly an original title.** For a translated
+  work it usually *is* the original title, which is why it is mapped here, but it
+  is also used to disambiguate works with generic titles. Treat it as a good
+  approximation rather than an exact equivalence.
+
+### Coverage reality
+
+Measured against the live LoC SRU endpoint on 2026-07-28 over the production
+catalog's zone-less titles, by ISBN prefix: 9780 → 6/6 recovered, 9781 → 4/6,
+and **zero** for 9782 (FR), 9783 (DE), 9791 and 9798. The two national-library
+providers are complementary, not redundant: BnF covers the francophone catalog,
+LoC the anglophone one, and a title in neither stays empty. French-prefix titles
+the BnF could not describe will **not** be rescued by LoC.
+
 ## Data migration for existing titles
 
 The migration is **additive** (all new columns NULLable) — the 207 titles already

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -830,10 +830,10 @@ admin:
       already_running: "Ein Cover-Nachzug läuft bereits. Bitte warten Sie auf den Abschluss."
       review_cta: "Titel ohne Cover ansehen"
     bulk_metadata_backfill:
-      button: "Metadaten von der BnF nachladen"
+      button: "Metadaten von Bibliotheken nachladen"
       started: "Massenhaftes Metadaten-Nachladen für %{total} Titel gestartet. Fortschritt steht im Log; aktualisieren Sie das Panel für Updates."
       empty: "Keine Titel mit einem Suchcode zum Nachladen."
-      already_running: "Ein BnF-Massenvorgang läuft bereits. Bitte warten Sie auf den Abschluss."
+      already_running: "Ein Metadaten-Massenvorgang läuft bereits. Bitte warten Sie auf den Abschluss."
   users:
     heading: Benutzerkonten
     empty_state: "Nur Sie hier! Erstellen Sie ein Bibliothekar-Konto für andere Haushaltsmitglieder."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -844,10 +844,10 @@ admin:
       already_running: "A bulk cover-refetch is already in progress. Please wait for it to complete."
       review_cta: "Review titles without a cover"
     bulk_metadata_backfill:
-      button: "Backfill metadata from BnF"
+      button: "Backfill metadata from libraries"
       started: "Bulk metadata backfill started for %{total} titles. Progress is logged; refresh the panel to see updates."
       empty: "No titles with a lookup code to backfill."
-      already_running: "A bulk BnF operation is already in progress. Please wait for it to complete."
+      already_running: "A bulk metadata operation is already in progress. Please wait for it to complete."
   users:
     heading: User accounts
     empty_state: "Only you here! Create a Librarian account for household members."

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -839,10 +839,10 @@ admin:
       already_running: "Une récupération en lot est déjà en cours. Attendez sa fin."
       review_cta: "Voir les titres sans couverture"
     bulk_metadata_backfill:
-      button: "Compléter les métadonnées via BnF"
+      button: "Compléter les métadonnées via les bibliothèques"
       started: "Complément des métadonnées en lot lancé pour %{total} titres. La progression est journalisée ; rafraîchissez le panneau pour voir les mises à jour."
       empty: "Aucun titre avec un code à compléter."
-      already_running: "Une opération BnF en lot est déjà en cours. Attendez sa fin."
+      already_running: "Une opération de métadonnées en lot est déjà en cours. Attendez sa fin."
   users:
     heading: "Comptes utilisateurs"
     empty_state: "Vous êtes seul·e ! Créez un compte Bibliothécaire pour les membres du foyer."

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -818,10 +818,10 @@ admin:
       already_running: "Un riscaricamento delle copertine è già in corso. Attendi il suo completamento."
       review_cta: "Vedi i titoli senza copertina"
     bulk_metadata_backfill:
-      button: "Recupera metadati dalla BnF"
+      button: "Recupera metadati dalle biblioteche"
       started: "Recupero massivo dei metadati avviato per %{total} titoli. Il progresso è registrato nei log; aggiorna il pannello per vedere gli aggiornamenti."
       empty: "Nessun titolo con un codice da completare."
-      already_running: "Un'operazione BnF massiva è già in corso. Attendi il suo completamento."
+      already_running: "Un'operazione massiva sui metadati è già in corso. Attendi il suo completamento."
   users:
     heading: Account utenti
     empty_state: "Solo tu qui! Crea un account Bibliotecario per i membri della famiglia."

--- a/src/metadata/bnf.rs
+++ b/src/metadata/bnf.rs
@@ -129,58 +129,16 @@ impl BnfProvider {
         })
     }
 
-    /// Extract a subfield value from UNIMARC XML.
-    /// Looks for `<datafield tag="TAG" ...><subfield code="CODE">VALUE</subfield></datafield>`
+    /// Read a UNIMARC subfield.
+    ///
+    /// #439 — the implementation moved to `crate::metadata::marc` when the
+    /// Library of Congress provider needed the identical traversal over MARC 21
+    /// (Foundation Rule #1). Kept as a thin alias so the ~16 call sites below
+    /// stay readable as `Self::extract_subfield(xml, "200", "f")`.
     fn extract_subfield(xml: &str, tag: &str, code: &str) -> Option<String> {
-        // Find the datafield with matching tag
-        let tag_pattern = format!(r#"tag="{}""#, tag);
-        let mut search_from = 0;
-
-        while let Some(df_start) = xml[search_from..].find(&tag_pattern) {
-            let df_abs = search_from + df_start;
-
-            // Find the end of this datafield
-            let df_end = match xml[df_abs..].find("</datafield>") {
-                Some(pos) => df_abs + pos,
-                None => {
-                    // Try namespace-prefixed variant
-                    match xml[df_abs..].find("</mxc:datafield>") {
-                        Some(pos) => df_abs + pos,
-                        None => break,
-                    }
-                }
-            };
-
-            let datafield_content = &xml[df_abs..df_end];
-
-            // Find subfield with matching code
-            let code_pattern = format!(r#"code="{}""#, code);
-            if let Some(sf_start) = datafield_content.find(&code_pattern) {
-                // Find the > after the code attribute
-                let after_code = &datafield_content[sf_start..];
-                if let Some(gt_pos) = after_code.find('>') {
-                    let value_start = sf_start + gt_pos + 1;
-                    let value_content = &datafield_content[value_start..];
-                    // Find closing </subfield>
-                    let end_tag = if value_content.contains("</subfield>") {
-                        "</subfield>"
-                    } else {
-                        "</mxc:subfield>"
-                    };
-                    if let Some(end_pos) = value_content.find(end_tag) {
-                        let value = value_content[..end_pos].trim().to_string();
-                        if !value.is_empty() {
-                            return Some(value);
-                        }
-                    }
-                }
-            }
-
-            search_from = df_end;
-        }
-
-        None
+        crate::metadata::marc::extract_subfield(xml, tag, code)
     }
+
 }
 
 #[async_trait]

--- a/src/metadata/bnf.rs
+++ b/src/metadata/bnf.rs
@@ -153,6 +153,12 @@ impl MetadataProvider for BnfProvider {
         true
     }
 
+    /// The BnF's UNIMARC zones already ride along with its normal lookup, so
+    /// completion reuses it rather than issuing a second SRU request (#439).
+    async fn lookup_marc_zones(&self, isbn: &str) -> Option<MetadataResult> {
+        self.lookup_by_isbn(isbn).await.ok().flatten()
+    }
+
     fn supports_media_type(&self, media_type: &MediaType) -> bool {
         matches!(
             media_type,

--- a/src/metadata/bnf.rs
+++ b/src/metadata/bnf.rs
@@ -147,6 +147,12 @@ impl MetadataProvider for BnfProvider {
         "BnF"
     }
 
+    /// #439 — this provider serves structured MARC zones, so the chain's
+    /// zone-completion pass may consult it.
+    fn supplies_marc_zones(&self) -> bool {
+        true
+    }
+
     fn supports_media_type(&self, media_type: &MediaType) -> bool {
         matches!(
             media_type,

--- a/src/metadata/chain.rs
+++ b/src/metadata/chain.rs
@@ -205,13 +205,24 @@ impl ChainExecutor {
                                     tokio::time::timeout(filler_timeout, fut).await
                                 {
                                     let extra = extra.normalize_empty_strings();
-                                    let before = winner.has_missing_unimarc_zones();
+                                    let before = winner.filled_unimarc_zone_count();
                                     winner.fill_unimarc_zones_from(&extra);
-                                    if before && !winner.has_missing_unimarc_zones() {
+                                    let gained = winner.filled_unimarc_zone_count() - before;
+                                    // Log on any gain, not only when all six
+                                    // end up filled: 490 and 240 are absent
+                                    // from most records, so "all six" almost
+                                    // never happens and a completion-only log
+                                    // gated on it would be silent in practice.
+                                    // Production backfills are audited from the
+                                    // log file (#434), so a pass that
+                                    // contributed must say so.
+                                    if gained > 0 {
                                         tracing::info!(
                                             code = %code,
                                             filler = filler.name(),
-                                            "Zone completion filled the remaining UNIMARC zones"
+                                            zones_gained = gained,
+                                            zones_filled_total = winner.filled_unimarc_zone_count(),
+                                            "Zone completion contributed UNIMARC zones"
                                         );
                                     }
                                 }

--- a/src/metadata/chain.rs
+++ b/src/metadata/chain.rs
@@ -162,7 +162,59 @@ impl ChainExecutor {
                         // `Some("")` from a sloppy upstream response
                         // would otherwise displace a real value via
                         // COALESCE / `manually_edited_fields` updates.
-                        return Some(metadata.normalize_empty_strings());
+                        let mut winner = metadata.normalize_empty_strings();
+
+                        // #439 — zone-completion pass. The chain otherwise
+                        // stops at the first provider that answers, which
+                        // leaves a title described by BnF permanently missing
+                        // the zones BnF does not carry (and vice versa for an
+                        // anglophone title answered by Google Books before LoC
+                        // is ever reached). Consult the REMAINING providers for
+                        // the six UNIMARC-aligned zones only, first-source-wins,
+                        // and stop as soon as all six are filled.
+                        //
+                        // Deliberately narrow: no other field is merged, so a
+                        // record's title / authors / cover still come from one
+                        // provider and cannot become a chimera. Runs inside the
+                        // global timeout, so a slow completion cannot extend the
+                        // overall budget.
+                        if winner.has_missing_unimarc_zones() {
+                            let already_used = provider_name;
+                            for filler in &chain {
+                                if filler.name() == already_used || !filler.supplies_marc_zones() {
+                                    continue;
+                                }
+                                if !winner.has_missing_unimarc_zones() {
+                                    break;
+                                }
+                                if let Some(limiter) = filler.rate_limiter() {
+                                    limiter.acquire().await;
+                                }
+                                let filler_timeout = Duration::from_secs(
+                                    per_provider_timeouts.for_provider(filler.name()),
+                                );
+                                let fut = match code_type {
+                                    CodeType::Upc => filler.lookup_by_upc(code),
+                                    CodeType::Isbn | CodeType::Issn => filler.lookup_by_isbn(code),
+                                };
+                                if let Ok(Ok(Some(extra))) =
+                                    tokio::time::timeout(filler_timeout, fut).await
+                                {
+                                    let extra = extra.normalize_empty_strings();
+                                    let before = winner.has_missing_unimarc_zones();
+                                    winner.fill_unimarc_zones_from(&extra);
+                                    if before && !winner.has_missing_unimarc_zones() {
+                                        tracing::info!(
+                                            code = %code,
+                                            filler = filler.name(),
+                                            "Zone completion filled the remaining UNIMARC zones"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                        return Some(winner);
                     }
                     Ok(Ok(None)) => {
                         tracing::info!(
@@ -277,6 +329,68 @@ mod tests {
         ) -> Result<Option<MetadataResult>, MetadataError> {
             Ok(Some(MetadataResult {
                 title: Some("Test Title".to_string()),
+                ..MetadataResult::default()
+            }))
+        }
+    }
+
+    /// #439 — a national-library-style provider that answers with a partial set
+    /// of MARC zones. Used to exercise the zone-completion pass.
+    struct ZoneProvider {
+        name: &'static str,
+        title: Option<&'static str>,
+        sor: Option<&'static str>,
+        edition: Option<&'static str>,
+        note: Option<&'static str>,
+    }
+
+    #[async_trait]
+    impl MetadataProvider for ZoneProvider {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn supports_media_type(&self, _media_type: &MediaType) -> bool {
+            true
+        }
+        fn supplies_marc_zones(&self) -> bool {
+            true
+        }
+        async fn lookup_by_isbn(
+            &self,
+            _isbn: &str,
+        ) -> Result<Option<MetadataResult>, MetadataError> {
+            Ok(Some(MetadataResult {
+                title: self.title.map(str::to_string),
+                statement_of_responsibility: self.sor.map(str::to_string),
+                edition_statement: self.edition.map(str::to_string),
+                general_note: self.note.map(str::to_string),
+                ..MetadataResult::default()
+            }))
+        }
+    }
+
+    /// A provider that answers but carries no MARC zones — the chain must never
+    /// consult it during zone completion, however many zones are still empty.
+    struct FlatCountingProvider {
+        calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl MetadataProvider for FlatCountingProvider {
+        fn name(&self) -> &str {
+            "flat_counting"
+        }
+        fn supports_media_type(&self, _media_type: &MediaType) -> bool {
+            true
+        }
+        async fn lookup_by_isbn(
+            &self,
+            _isbn: &str,
+        ) -> Result<Option<MetadataResult>, MetadataError> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(Some(MetadataResult {
+                title: Some("Flat".to_string()),
                 ..MetadataResult::default()
             }))
         }
@@ -732,5 +846,106 @@ mod tests {
             }
         }
         assert!(result.is_none());
+    }
+
+    // ─── #439 — zone completion across providers ──────────────────────
+
+    /// The chain stops at the first provider that answers. Before #439 that
+    /// left a title described by the leading provider permanently missing any
+    /// zone that provider does not carry. The completion pass fills the gaps
+    /// from later MARC-capable providers, first-source-wins.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn zone_completion_fills_gaps_from_a_later_marc_provider(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) {
+        let mut registry = ProviderRegistry::new();
+        // First answers with a title + statement of responsibility only.
+        registry.register(Box::new(ZoneProvider {
+            name: "first_library",
+            title: Some("Le petit prince"),
+            sor: Some("Antoine de Saint-Exupéry"),
+            edition: None,
+            note: None,
+        }));
+        // Second carries an edition statement and a note the first lacks, and a
+        // COMPETING statement of responsibility that must NOT win.
+        registry.register(Box::new(ZoneProvider {
+            name: "second_library",
+            title: Some("Ignored title"),
+            sor: Some("SHOULD NOT WIN"),
+            edition: Some("2e édition"),
+            note: Some("Fac-similé"),
+        }));
+
+        let result = ChainExecutor::execute(
+            &registry,
+            &pool,
+            "9782070360246",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await
+        .expect("the first provider answers");
+
+        assert_eq!(
+            result.title.as_deref(),
+            Some("Le petit prince"),
+            "non-zone fields must come from the winning provider alone"
+        );
+        assert_eq!(
+            result.statement_of_responsibility.as_deref(),
+            Some("Antoine de Saint-Exupéry"),
+            "first source wins on a contested zone"
+        );
+        assert_eq!(
+            result.edition_statement.as_deref(),
+            Some("2e édition"),
+            "an empty zone must be completed from the later provider"
+        );
+        assert_eq!(result.general_note.as_deref(), Some("Fac-similé"));
+    }
+
+    /// The completion pass must never sweep providers that carry no zones.
+    /// `has_missing_unimarc_zones` is true whenever ANY of the six is empty,
+    /// and 490/240 are legitimately absent from most records — so without the
+    /// `supplies_marc_zones` gate this would fire on nearly every lookup and
+    /// turn each scan into a full-chain sweep.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn zone_completion_skips_providers_without_marc_zones(
+        pool: sqlx::Pool<sqlx::MySql>,
+    ) {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(ZoneProvider {
+            name: "first_library",
+            title: Some("Only title"),
+            sor: None,
+            edition: None,
+            note: None,
+        }));
+        registry.register(Box::new(FlatCountingProvider {
+            calls: calls.clone(),
+        }));
+
+        let result = ChainExecutor::execute(
+            &registry,
+            &pool,
+            "9782070360246",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.title.as_deref(), Some("Only title"));
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a provider that carries no MARC zones must not be consulted for them"
+        );
     }
 }

--- a/src/metadata/chain.rs
+++ b/src/metadata/chain.rs
@@ -193,11 +193,15 @@ impl ChainExecutor {
                                 let filler_timeout = Duration::from_secs(
                                     per_provider_timeouts.for_provider(filler.name()),
                                 );
-                                let fut = match code_type {
-                                    CodeType::Upc => filler.lookup_by_upc(code),
-                                    CodeType::Isbn | CodeType::Issn => filler.lookup_by_isbn(code),
-                                };
-                                if let Ok(Ok(Some(extra))) =
+                                // #439 — the dedicated zone entry point, not
+                                // `lookup_by_isbn`. LoC's normal lookup vetoes
+                                // itself when its flat JSON search misses, but
+                                // the SRU catalogue is a different index and
+                                // may well hold the record; routing completion
+                                // through the normal lookup would discard
+                                // those zones.
+                                let fut = filler.lookup_marc_zones(code);
+                                if let Ok(Some(extra)) =
                                     tokio::time::timeout(filler_timeout, fut).await
                                 {
                                     let extra = extra.normalize_empty_strings();
@@ -367,6 +371,9 @@ mod tests {
                 ..MetadataResult::default()
             }))
         }
+        async fn lookup_marc_zones(&self, isbn: &str) -> Option<MetadataResult> {
+            self.lookup_by_isbn(isbn).await.ok().flatten()
+        }
     }
 
     /// A provider that answers but carries no MARC zones — the chain must never
@@ -393,6 +400,37 @@ mod tests {
                 title: Some("Flat".to_string()),
                 ..MetadataResult::default()
             }))
+        }
+    }
+
+    /// #439 — a provider whose primary lookup finds nothing but whose MARC
+    /// catalogue does hold the record. This is the Library of Congress shape:
+    /// its flat JSON search and its SRU catalogue are different indexes, and
+    /// the normal lookup vetoes itself when the JSON side misses.
+    struct ZonesOnlyOnSruProvider;
+
+    #[async_trait]
+    impl MetadataProvider for ZonesOnlyOnSruProvider {
+        fn name(&self) -> &str {
+            "zones_only_on_sru"
+        }
+        fn supports_media_type(&self, _media_type: &MediaType) -> bool {
+            true
+        }
+        fn supplies_marc_zones(&self) -> bool {
+            true
+        }
+        async fn lookup_by_isbn(
+            &self,
+            _isbn: &str,
+        ) -> Result<Option<MetadataResult>, MetadataError> {
+            Ok(None)
+        }
+        async fn lookup_marc_zones(&self, _isbn: &str) -> Option<MetadataResult> {
+            Some(MetadataResult {
+                edition_statement: Some("Reprint.".to_string()),
+                ..MetadataResult::default()
+            })
         }
     }
 
@@ -946,6 +984,43 @@ mod tests {
             calls.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "a provider that carries no MARC zones must not be consulted for them"
+        );
+    }
+
+    /// Completion must go through `lookup_marc_zones`, not `lookup_by_isbn`.
+    /// Routing it through the normal lookup would discard the zones of any
+    /// provider that vetoes itself on a primary miss — which is exactly what
+    /// the LoC provider does when its JSON search and its SRU catalogue
+    /// disagree.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn zone_completion_uses_the_dedicated_entry_point(pool: sqlx::Pool<sqlx::MySql>) {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Box::new(ZoneProvider {
+            name: "first_library",
+            title: Some("A title"),
+            sor: Some("Someone"),
+            edition: None,
+            note: None,
+        }));
+        registry.register(Box::new(ZonesOnlyOnSruProvider));
+
+        let result = ChainExecutor::execute(
+            &registry,
+            &pool,
+            "9780999999992",
+            &CodeType::Isbn,
+            &MediaType::Book,
+            10,
+            &ProviderTimeouts::uniform(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.edition_statement.as_deref(),
+            Some("Reprint."),
+            "#439: zones must be collected even when the provider's primary \
+             lookup returns None"
         );
     }
 }

--- a/src/metadata/library_of_congress.rs
+++ b/src/metadata/library_of_congress.rs
@@ -53,25 +53,165 @@ use crate::models::media_type::MediaType;
 
 use super::provider::{MetadataError, MetadataProvider, MetadataResult};
 
+/// #439 — how many times to re-issue an SRU request that died at the transport
+/// layer, and how long to wait between attempts.
+///
+/// Measured against the live endpoint on 2026-07-28: at ~0.35 s spacing, 79 of
+/// 113 requests failed; at 2 s spacing, 6 of 26 still did. **Every failure was
+/// a dropped connection, never an HTTP status** — the server hangs up instead
+/// of answering 429, so `MetadataError::RateLimited` (and with it the #419
+/// back-off, which keys on 429/503) never fires. Retrying the transport error
+/// is the only way to see those records.
+const SRU_MAX_ATTEMPTS: u32 = 3;
+const SRU_RETRY_BASE_DELAY_MS: u64 = 2000;
+
 pub struct LibraryOfCongressProvider {
     client: reqwest::Client,
     base_url: String,
+    sru_base_url: String,
 }
 
 impl LibraryOfCongressProvider {
     pub fn new(client: reqwest::Client) -> Self {
         let base_url = std::env::var("LOC_API_BASE_URL")
             .unwrap_or_else(|_| "https://www.loc.gov/books/".to_string());
-        LibraryOfCongressProvider { client, base_url }
+        let sru_base_url = std::env::var("LOC_SRU_BASE_URL")
+            .unwrap_or_else(|_| "http://lx2.loc.gov:210/LCDB".to_string());
+        LibraryOfCongressProvider {
+            client,
+            base_url,
+            sru_base_url,
+        }
     }
 
     /// Construct with a custom base URL — used by integration tests
     /// pointing at the e2e mock server.
+    ///
+    /// The SRU endpoint follows the same base by default so a mock server can
+    /// serve both; override it with [`Self::with_sru_base_url`] when they
+    /// differ.
     pub fn with_base_url(client: reqwest::Client, base_url: &str) -> Self {
         LibraryOfCongressProvider {
             client,
             base_url: base_url.to_string(),
+            sru_base_url: base_url.to_string(),
         }
+    }
+
+    pub fn with_sru_base_url(mut self, sru_base_url: &str) -> Self {
+        self.sru_base_url = sru_base_url.to_string();
+        self
+    }
+
+    /// Fetch the MARC 21 record for an ISBN over SRU and read the six
+    /// UNIMARC-aligned zones out of it (#439).
+    ///
+    /// **Supplementary, never fatal.** The flat `?fo=json` search remains the
+    /// primary call — it is what supplies title, authors, date, language,
+    /// description and, crucially, the cover URL, none of which the MARC record
+    /// carries. This second request only adds the structured zones, so any
+    /// failure here degrades to "no zones" rather than failing the lookup.
+    ///
+    /// MARC 21 → internal mapping (semantic equivalents of the UNIMARC zones in
+    /// `docs/unimarc-mapping.md`):
+    ///
+    /// | internal | UNIMARC (BnF) | MARC 21 (LoC) |
+    /// |---|---|---|
+    /// | statement_of_responsibility | 200$f | 245$c |
+    /// | edition_statement | 205$a | 250$a |
+    /// | collection_title / number | 225$a / 225$v | 490$a / 490$v |
+    /// | general_note | 300$a | 500$a |
+    /// | original_title | 500$a | 240$a (uniform title) |
+    ///
+    /// Note the collision worth keeping in mind when reading both tables: `500`
+    /// means "general note" in MARC 21 but "original title" in UNIMARC.
+    async fn fetch_marc_zones(&self, safe_isbn: &str) -> Option<MetadataResult> {
+        let url = format!(
+            "{}?version=1.1&operation=searchRetrieve&query=bath.isbn={}&recordSchema=marcxml&maximumRecords=1",
+            self.sru_base_url, safe_isbn
+        );
+
+        let mut attempt = 0;
+        let body = loop {
+            attempt += 1;
+            match self
+                .client
+                .get(&url)
+                .header("User-Agent", "mybibli/1.14.0")
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => match response.text().await {
+                    Ok(text) => break text,
+                    Err(e) => {
+                        tracing::debug!(isbn = %safe_isbn, error = %e, "LoC SRU body read failed");
+                        return None;
+                    }
+                },
+                Ok(response) => {
+                    // A real HTTP status — not the dropped-connection case, so
+                    // retrying buys nothing.
+                    tracing::debug!(
+                        isbn = %safe_isbn,
+                        status = %response.status(),
+                        "LoC SRU returned a non-success status; skipping zones"
+                    );
+                    return None;
+                }
+                Err(e) if attempt < SRU_MAX_ATTEMPTS => {
+                    // The dropped-connection case. Linear back-off: the server
+                    // is throttling by connection count, so spacing matters
+                    // more than exponential growth.
+                    let delay = SRU_RETRY_BASE_DELAY_MS * attempt as u64;
+                    tracing::debug!(
+                        isbn = %safe_isbn,
+                        attempt = attempt,
+                        delay_ms = delay,
+                        error = %e,
+                        "LoC SRU transport failure, retrying"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                }
+                Err(e) => {
+                    tracing::info!(
+                        isbn = %safe_isbn,
+                        attempts = attempt,
+                        error = %e,
+                        "LoC SRU unreachable after retries; continuing without MARC zones"
+                    );
+                    return None;
+                }
+            }
+        };
+
+        Self::parse_marcxml_response(&body)
+    }
+
+    /// Read the six zones out of an SRU `searchRetrieve` MARCXML response.
+    ///
+    /// Returns `None` when the response carries no record at all, so the caller
+    /// can distinguish "LoC does not hold this ISBN" from "it does, but the
+    /// record has none of the zones we map".
+    pub fn parse_marcxml_response(body: &str) -> Option<MetadataResult> {
+        // `numberOfRecords` is namespace-prefixed in the live feed
+        // (`<zs:numberOfRecords>`), so match on the local name.
+        if !body.contains("numberOfRecords") || body.contains("numberOfRecords>0<") {
+            return None;
+        }
+        if !body.contains("<record") {
+            return None;
+        }
+
+        use super::marc::extract_subfield;
+        Some(MetadataResult {
+            statement_of_responsibility: extract_subfield(body, "245", "c"),
+            edition_statement: extract_subfield(body, "250", "a"),
+            collection_title: extract_subfield(body, "490", "a"),
+            collection_number: extract_subfield(body, "490", "v"),
+            general_note: extract_subfield(body, "500", "a"),
+            original_title: extract_subfield(body, "240", "a"),
+            ..MetadataResult::default()
+        })
     }
 
     /// Parse a `?fo=json` response into a [`MetadataResult`]. Returns
@@ -192,6 +332,12 @@ impl MetadataProvider for LibraryOfCongressProvider {
         "Library of Congress"
     }
 
+    /// #439 — this provider serves structured MARC zones, so the chain's
+    /// zone-completion pass may consult it.
+    fn supplies_marc_zones(&self) -> bool {
+        true
+    }
+
     fn supports_media_type(&self, media_type: &MediaType) -> bool {
         // LoC catalogs books + periodicals. BD / CD / DVD belong to other
         // providers in the chain (BDGest / MusicBrainz / TMDb / OMDb).
@@ -230,7 +376,24 @@ impl MetadataProvider for LibraryOfCongressProvider {
             .await
             .map_err(|e| MetadataError::Parse(e.to_string()))?;
 
-        Ok(Self::parse_json_response(&body))
+        // #439 — the JSON search stays primary (it alone carries the cover
+        // URL); the SRU MARC record adds the six structured zones on top. Both
+        // calls run for every ISBN rather than SRU-on-miss, because the target
+        // case is exactly an anglophone title where the JSON answers perfectly
+        // well and simply has no structured bibliographic data.
+        let zones = self.fetch_marc_zones(&safe_isbn).await;
+
+        Ok(match (Self::parse_json_response(&body), zones) {
+            (Some(mut json), Some(marc)) => {
+                json.fill_unimarc_zones_from(&marc);
+                Some(json)
+            }
+            (Some(json), None) => Some(json),
+            // The JSON search found nothing but the catalog holds a MARC
+            // record. Zones alone are not a usable result — there is no title
+            // to attach them to — so report the miss honestly.
+            (None, _) => None,
+        })
     }
 
     fn health_check_url(&self) -> Option<&str> {
@@ -390,5 +553,94 @@ mod tests {
         assert!(LibraryOfCongressProvider::parse_json_response("not json at all").is_none());
         assert!(LibraryOfCongressProvider::parse_json_response("{").is_none());
         assert!(LibraryOfCongressProvider::parse_json_response("").is_none());
+    }
+
+    // ─── #439 — SRU MARC 21 zones ─────────────────────────────────────
+
+    /// Trimmed from the live `lx2.loc.gov:210/LCDB` response for ISBN
+    /// 9780134685991, captured 2026-07-28. Keeps the `zs:` namespace prefix and
+    /// the two repeated 500 fields exactly as the server sends them.
+    const SRU_MARCXML: &str = r#"<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordSchema>marcxml</zs:recordSchema><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Effective Java /</subfield>
+    <subfield code="c">Joshua Bloch.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Third edition.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">"Updated for Java 9"--Cover.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">"Best practices for the Java Platform" --Cover.</subfield>
+  </datafield>
+</record></zs:recordData></zs:record></zs:records></zs:searchRetrieveResponse>"#;
+
+    /// The shape returned for an ISBN the catalog does not hold.
+    const SRU_EMPTY: &str = r#"<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:version>1.1</zs:version><zs:numberOfRecords>0</zs:numberOfRecords><zs:records></zs:records></zs:searchRetrieveResponse>"#;
+
+    #[test]
+    fn marcxml_maps_the_marc21_tags_onto_the_internal_zones() {
+        let r = LibraryOfCongressProvider::parse_marcxml_response(SRU_MARCXML)
+            .expect("a record is present");
+        assert_eq!(
+            r.statement_of_responsibility.as_deref(),
+            Some("Joshua Bloch."),
+            "245$c"
+        );
+        assert_eq!(r.edition_statement.as_deref(), Some("Third edition."), "250$a");
+        assert_eq!(
+            r.general_note.as_deref(),
+            Some(r#""Updated for Java 9"--Cover."#),
+            "500$a, first of two"
+        );
+        // Absent from this record — must be None, not an empty string.
+        assert_eq!(r.collection_title, None, "490$a absent");
+        assert_eq!(r.original_title, None, "240$a absent");
+    }
+
+    /// A MARC record carries no cover and no usable description, which is
+    /// exactly why the SRU call complements the JSON search instead of
+    /// replacing it.
+    #[test]
+    fn marcxml_never_supplies_a_cover_or_title() {
+        let r = LibraryOfCongressProvider::parse_marcxml_response(SRU_MARCXML).unwrap();
+        assert_eq!(r.cover_url, None);
+        assert_eq!(r.title, None);
+    }
+
+    #[test]
+    fn marcxml_zero_records_is_none() {
+        assert!(LibraryOfCongressProvider::parse_marcxml_response(SRU_EMPTY).is_none());
+    }
+
+    #[test]
+    fn marcxml_garbage_is_none_not_a_panic() {
+        assert!(LibraryOfCongressProvider::parse_marcxml_response("").is_none());
+        assert!(LibraryOfCongressProvider::parse_marcxml_response("<html>oops</html>").is_none());
+    }
+
+    /// The merge the provider performs internally: JSON supplies the record,
+    /// MARC supplies the zones, and neither clobbers the other.
+    #[test]
+    fn json_result_keeps_its_fields_when_marc_zones_are_merged_in() {
+        let mut json = LibraryOfCongressProvider::parse_json_response(SAMPLE_LOC_RESPONSE)
+            .expect("sample parses");
+        let cover_before = json.cover_url.clone();
+        let title_before = json.title.clone();
+        assert!(cover_before.is_some(), "fixture must carry a cover");
+
+        let marc = LibraryOfCongressProvider::parse_marcxml_response(SRU_MARCXML).unwrap();
+        json.fill_unimarc_zones_from(&marc);
+
+        assert_eq!(json.cover_url, cover_before, "the cover must survive");
+        assert_eq!(json.title, title_before, "the title must survive");
+        assert_eq!(
+            json.statement_of_responsibility.as_deref(),
+            Some("Joshua Bloch."),
+            "and the zones must land"
+        );
     }
 }

--- a/src/metadata/library_of_congress.rs
+++ b/src/metadata/library_of_congress.rs
@@ -338,6 +338,17 @@ impl MetadataProvider for LibraryOfCongressProvider {
         true
     }
 
+    /// Zones straight from SRU — deliberately independent of the flat JSON
+    /// search, which indexes different records and would otherwise veto
+    /// perfectly good MARC data (#439).
+    async fn lookup_marc_zones(&self, isbn: &str) -> Option<MetadataResult> {
+        let safe_isbn: String = isbn.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+        if safe_isbn.is_empty() {
+            return None;
+        }
+        self.fetch_marc_zones(&safe_isbn).await
+    }
+
     fn supports_media_type(&self, media_type: &MediaType) -> bool {
         // LoC catalogs books + periodicals. BD / CD / DVD belong to other
         // providers in the chain (BDGest / MusicBrainz / TMDb / OMDb).

--- a/src/metadata/marc.rs
+++ b/src/metadata/marc.rs
@@ -1,0 +1,184 @@
+//! Shared MARC datafield/subfield reader (#439).
+//!
+//! UNIMARC (BnF, `unimarcXchange`) and MARC 21 (Library of Congress, `marcxml`)
+//! disagree on which tag carries which meaning, but they share the same
+//! serialisation:
+//!
+//! ```xml
+//! <datafield tag="245" ind1="1" ind2="0">
+//!   <subfield code="a">Effective Java /</subfield>
+//!   <subfield code="c">Joshua Bloch.</subfield>
+//! </datafield>
+//! ```
+//!
+//! So the *reader* is common and only the tag table differs. This module was
+//! lifted out of `bnf.rs` when the LoC provider needed the same traversal
+//! (Foundation Rule #1) — behaviour is unchanged, including the two quirks the
+//! BnF feed made necessary:
+//!
+//! 1. **Namespace-prefixed closing tags.** The BnF emits `</mxc:datafield>` and
+//!    `</mxc:subfield>` in some responses, plain `</datafield>` in others.
+//! 2. **Empty subfields are treated as absent**, so a present-but-blank
+//!    `<subfield code="a"></subfield>` does not shadow a later datafield
+//!    carrying a real value.
+//!
+//! The parser is deliberately a string scan rather than a real XML parse: it
+//! only ever reads a handful of known tags out of a single record, and pulling
+//! an XML dependency in for that was not worth it. It is tolerant of unknown
+//! attributes and attribute order, but it does NOT decode entities — callers
+//! that need that must handle it.
+
+/// First non-empty `subfield[@code=code]` inside any `datafield[@tag=tag]`.
+///
+/// Datafields are scanned in document order and the first match wins. When a
+/// tag legitimately repeats — MARC 21 `500` (general note) routinely does —
+/// this returns the first occurrence only. That is the deliberate choice: a
+/// joined blob reads badly in the title-detail UI, and the first note is the
+/// principal one in practice.
+pub fn extract_subfield(xml: &str, tag: &str, code: &str) -> Option<String> {
+    extract_subfields(xml, tag, code).into_iter().next()
+}
+
+/// Every non-empty `subfield[@code=code]` across all `datafield[@tag=tag]`, in
+/// document order.
+///
+/// Exposed for callers that genuinely want the repeats (e.g. collecting all
+/// authors from repeated author datafields) without re-implementing the scan.
+pub fn extract_subfields(xml: &str, tag: &str, code: &str) -> Vec<String> {
+    let tag_pattern = format!(r#"tag="{tag}""#);
+    let code_pattern = format!(r#"code="{code}""#);
+    let mut out = Vec::new();
+    let mut search_from = 0;
+
+    while let Some(df_start) = xml[search_from..].find(&tag_pattern) {
+        let df_abs = search_from + df_start;
+
+        // End of this datafield — plain or namespace-prefixed.
+        let df_end = match xml[df_abs..].find("</datafield>") {
+            Some(pos) => df_abs + pos,
+            None => match xml[df_abs..].find("</mxc:datafield>") {
+                Some(pos) => df_abs + pos,
+                None => break,
+            },
+        };
+
+        let datafield = &xml[df_abs..df_end];
+        if let Some(sf_start) = datafield.find(&code_pattern) {
+            let after_code = &datafield[sf_start..];
+            if let Some(gt_pos) = after_code.find('>') {
+                let value_start = sf_start + gt_pos + 1;
+                let value_content = &datafield[value_start..];
+                let end_tag = if value_content.contains("</subfield>") {
+                    "</subfield>"
+                } else {
+                    "</mxc:subfield>"
+                };
+                if let Some(end_pos) = value_content.find(end_tag) {
+                    let value = value_content[..end_pos].trim();
+                    if !value.is_empty() {
+                        out.push(value.to_string());
+                    }
+                }
+            }
+        }
+
+        search_from = df_end;
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A trimmed real MARC 21 record from lx2.loc.gov for ISBN 9780134685991,
+    // captured 2026-07-28. Note the two repeated 500 fields — the shape that
+    // motivated `extract_subfields`.
+    const MARC21: &str = r#"<record xmlns="http://www.loc.gov/MARC21/slim">
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Effective Java /</subfield>
+    <subfield code="c">Joshua Bloch.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Third edition.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">"Updated for Java 9"--Cover.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">"Best practices for the Java Platform" --Cover.</subfield>
+  </datafield>
+</record>"#;
+
+    // The BnF's namespace-prefixed variant, which the shared reader must keep
+    // handling — this is the quirk that made a plain XML parser look expensive.
+    const UNIMARC_PREFIXED: &str = r#"<mxc:record>
+  <mxc:datafield tag="200" ind1="1" ind2=" ">
+    <mxc:subfield code="a">Le petit prince</mxc:subfield>
+    <mxc:subfield code="f">Antoine de Saint-Exupéry</mxc:subfield>
+  </mxc:datafield>
+</mxc:record>"#;
+
+    #[test]
+    fn reads_a_marc21_subfield() {
+        assert_eq!(
+            extract_subfield(MARC21, "245", "c"),
+            Some("Joshua Bloch.".to_string())
+        );
+        assert_eq!(
+            extract_subfield(MARC21, "250", "a"),
+            Some("Third edition.".to_string())
+        );
+    }
+
+    #[test]
+    fn reads_a_namespace_prefixed_unimarc_subfield() {
+        assert_eq!(
+            extract_subfield(UNIMARC_PREFIXED, "200", "f"),
+            Some("Antoine de Saint-Exupéry".to_string())
+        );
+    }
+
+    #[test]
+    fn repeated_tag_yields_the_first_for_extract_subfield() {
+        assert_eq!(
+            extract_subfield(MARC21, "500", "a"),
+            Some(r#""Updated for Java 9"--Cover."#.to_string())
+        );
+    }
+
+    #[test]
+    fn repeated_tag_yields_all_for_extract_subfields() {
+        let notes = extract_subfields(MARC21, "500", "a");
+        assert_eq!(notes.len(), 2, "both 500 fields must be reachable");
+        assert!(notes[1].contains("Best practices"));
+    }
+
+    #[test]
+    fn absent_tag_and_absent_code_are_none() {
+        assert_eq!(extract_subfield(MARC21, "490", "a"), None);
+        assert_eq!(extract_subfield(MARC21, "245", "z"), None);
+    }
+
+    /// An empty subfield must not shadow a later datafield that has content —
+    /// otherwise a blank leading record silently suppresses a good one.
+    #[test]
+    fn empty_subfield_is_skipped_in_favour_of_a_later_one() {
+        let xml = r#"<record>
+  <datafield tag="500"><subfield code="a">   </subfield></datafield>
+  <datafield tag="500"><subfield code="a">Real note.</subfield></datafield>
+</record>"#;
+        assert_eq!(
+            extract_subfield(xml, "500", "a"),
+            Some("Real note.".to_string())
+        );
+    }
+
+    #[test]
+    fn malformed_input_does_not_panic_or_hang() {
+        assert_eq!(extract_subfield(r#"<datafield tag="245">"#, "245", "a"), None);
+        assert_eq!(extract_subfield("", "245", "a"), None);
+        assert_eq!(extract_subfield(r#"tag="245" tag="245""#, "245", "a"), None);
+    }
+}

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -4,6 +4,7 @@ pub mod chain;
 pub mod comic_vine;
 pub mod google_books;
 pub mod library_of_congress;
+pub mod marc;
 pub mod musicbrainz;
 pub mod omdb;
 pub mod open_library;

--- a/src/metadata/provider.rs
+++ b/src/metadata/provider.rs
@@ -98,6 +98,27 @@ impl MetadataResult {
             || self.original_title.is_none()
     }
 
+    /// How many of the six UNIMARC-aligned zones currently carry a value (#439).
+    ///
+    /// Used by the chain to report what a completion pass actually contributed.
+    /// A boolean "are any missing" is useless for that: 490 (collection) and
+    /// 240 (uniform title) are absent from most records, so a log gated on
+    /// "all six now filled" would stay silent even on a pass that recovered
+    /// two zones.
+    pub fn filled_unimarc_zone_count(&self) -> usize {
+        [
+            &self.statement_of_responsibility,
+            &self.edition_statement,
+            &self.collection_title,
+            &self.collection_number,
+            &self.general_note,
+            &self.original_title,
+        ]
+        .iter()
+        .filter(|z| z.is_some())
+        .count()
+    }
+
     /// Fill this result's *empty* UNIMARC zones from `other`, leaving every
     /// value already present untouched (#439).
     ///

--- a/src/metadata/provider.rs
+++ b/src/metadata/provider.rs
@@ -193,6 +193,24 @@ pub trait MetadataProvider: Send + Sync {
         false
     }
 
+    /// Fetch **only** the six MARC zones for an ISBN, for the chain's
+    /// zone-completion pass (#439).
+    ///
+    /// Separate from [`Self::lookup_by_isbn`] on purpose. The LoC provider's
+    /// normal lookup returns `None` when its flat JSON search finds nothing,
+    /// because zones with no title are not a usable primary result — but for
+    /// completion they are exactly what is wanted, and the JSON search and the
+    /// SRU catalogue are different indexes that do not always agree. Routing
+    /// completion through `lookup_by_isbn` would therefore silently discard
+    /// recoverable zones whenever the two disagree.
+    ///
+    /// Only providers whose [`Self::supplies_marc_zones`] is true need
+    /// implement this; the chain uses that as the cheap gate before calling.
+    /// The returned result is read for its six zone fields and nothing else.
+    async fn lookup_marc_zones(&self, _isbn: &str) -> Option<MetadataResult> {
+        None
+    }
+
     /// Return the rate limiter for this provider, if any.
     /// ChainExecutor calls `acquire()` before each lookup when present.
     fn rate_limiter(&self) -> Option<Arc<RateLimiter>> {

--- a/src/metadata/provider.rs
+++ b/src/metadata/provider.rs
@@ -84,6 +84,48 @@ impl MetadataResult {
             .collect();
         self
     }
+
+    /// Do any of the six UNIMARC-aligned zones still have no value? (#439)
+    ///
+    /// Drives the chain's zone-completion pass: a result that already carries
+    /// all six needs no second provider consulted.
+    pub fn has_missing_unimarc_zones(&self) -> bool {
+        self.statement_of_responsibility.is_none()
+            || self.edition_statement.is_none()
+            || self.collection_title.is_none()
+            || self.collection_number.is_none()
+            || self.general_note.is_none()
+            || self.original_title.is_none()
+    }
+
+    /// Fill this result's *empty* UNIMARC zones from `other`, leaving every
+    /// value already present untouched (#439).
+    ///
+    /// This encodes the settled merge policy: field-by-field, **first source
+    /// wins**. Because the chain consults BnF before the Library of Congress
+    /// for books, that means BnF takes precedence where both answer, while a
+    /// French title the BnF only partly described can still have its remaining
+    /// zones completed from LoC. Provenance therefore becomes mixed within a
+    /// single record, which is accepted.
+    pub fn fill_unimarc_zones_from(&mut self, other: &MetadataResult) {
+        fn fill(target: &mut Option<String>, source: &Option<String>) {
+            if target.is_none()
+                && let Some(v) = source
+                && !v.trim().is_empty()
+            {
+                *target = Some(v.clone());
+            }
+        }
+        fill(
+            &mut self.statement_of_responsibility,
+            &other.statement_of_responsibility,
+        );
+        fill(&mut self.edition_statement, &other.edition_statement);
+        fill(&mut self.collection_title, &other.collection_title);
+        fill(&mut self.collection_number, &other.collection_number);
+        fill(&mut self.general_note, &other.general_note);
+        fill(&mut self.original_title, &other.original_title);
+    }
 }
 
 /// CR #396 — normalize a provider's display name into the slug used as
@@ -131,6 +173,24 @@ pub trait MetadataProvider: Send + Sync {
     /// Search by title string.
     async fn search_by_title(&self, _title: &str) -> Result<Option<MetadataResult>, MetadataError> {
         Ok(None) // Default: not supported
+    }
+
+    /// Does this provider serve structured MARC bibliographic zones? (#439)
+    ///
+    /// Only the two national-library providers do — BnF over UNIMARC and the
+    /// Library of Congress over MARC 21. Everything else (Google Books, Open
+    /// Library, MusicBrainz, OMDb, TMDb, Comic Vine) returns flat metadata with
+    /// no statement of responsibility, edition statement, collection or
+    /// uniform title.
+    ///
+    /// The chain's zone-completion pass consults **only** providers that return
+    /// `true` here. Without this gate the pass would sweep the entire chain on
+    /// almost every lookup: `has_missing_unimarc_zones` is true whenever any of
+    /// the six is empty, and 490 (collection) and 240 (uniform title) are
+    /// legitimately absent from most records — so "all six present" is the rare
+    /// case, not the common one.
+    fn supplies_marc_zones(&self) -> bool {
+        false
     }
 
     /// Return the rate limiter for this provider, if any.

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -432,7 +432,7 @@ fn spawn_bulk_bnf_worker(
                             title_id = title.id,
                             attempt = attempts_done,
                             backoff_secs = backoff.as_secs(),
-                            "Bulk BnF task: provider throttled (429/503), backing off before retry"
+                            "Bulk metadata task: provider throttled (429/503), backing off before retry"
                         );
                         tokio::time::sleep(backoff).await;
                     }
@@ -458,7 +458,7 @@ fn spawn_bulk_bnf_worker(
             provider_failed = summary.provider_failed,
             not_found = summary.not_found,
             total = summary.total,
-            "Bulk BnF task completed"
+            "Bulk metadata task completed"
         );
     });
 }

--- a/tests/e2e/docker-compose.test.yml
+++ b/tests/e2e/docker-compose.test.yml
@@ -26,6 +26,11 @@ services:
       INVENTAIRE_API_BASE_URL: "http://mock-metadata:9090"
       GOOGLE_BOOKS_API_BASE_URL: "http://mock-metadata:9090"
       OPEN_LIBRARY_API_BASE_URL: "http://mock-metadata:9090"
+      # #439 — the Library of Congress needs BOTH endpoints stubbed: the flat
+      # JSON search and the SRU MARC 21 catalogue live on different paths.
+      # Without these the E2E stack would reach out to the real loc.gov.
+      LOC_API_BASE_URL: "http://mock-metadata:9090/books/"
+      LOC_SRU_BASE_URL: "http://mock-metadata:9090/LCDB"
       MUSICBRAINZ_API_BASE_URL: "http://mock-metadata:9090"
       OMDB_API_BASE_URL: "http://mock-metadata:9090"
       OMDB_API_KEY: "test-omdb-key"

--- a/tests/e2e/mock-metadata-server/server.py
+++ b/tests/e2e/mock-metadata-server/server.py
@@ -147,6 +147,15 @@ class MockMetadataHandler(http.server.BaseHTTPRequestHandler):
         elif path == "/" or path == "" or "SRU" in path:
             self._handle_bnf(params)
 
+        # --- Library of Congress SRU (MARC 21) — #439 ---
+        elif path == "/LCDB":
+            self._handle_loc_sru(params)
+
+        # --- Library of Congress flat JSON search — #439 ---
+        # Must precede the Google Books arm: "/books/" vs "/books/v1/volumes".
+        elif path == "/books/":
+            self._handle_loc_json(params)
+
         # --- Google Books endpoint ---
         elif path == "/books/v1/volumes":
             self._handle_google_books(params)
@@ -357,6 +366,57 @@ class MockMetadataHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
 
         self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    # --- Library of Congress mocks (#439) ---------------------------
+    # catalog-marc-zones.spec.ts scans this spec-unique ISBN. The BnF
+    # catch-all resolves it first (it answers for any ISBN) and supplies
+    # 200$f but no edition statement and no note — so the chain's
+    # zone-completion pass must reach LoC for those. That is exactly the
+    # cross-provider path the spec exercises.
+    LOC_MARC_ISBN = "9780449000014"
+
+    def _handle_loc_json(self, params):
+        """Flat ?fo=json search. Carries the cover URL; no MARC zones."""
+        q = params.get("q", [""])[0]
+        if q == self.LOC_MARC_ISBN:
+            body = json.dumps({"results": [{
+                "title": "Zone Completion Sample",
+                "contributor": ["Sample Author"],
+                "date": "2020",
+                "language": ["english"],
+            }]})
+        else:
+            body = json.dumps({"results": []})
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def _handle_loc_sru(self, params):
+        """SRU searchRetrieve returning MARC 21. Supplies 250$a and 500$a."""
+        query = params.get("query", [""])[0]
+        isbn = query.replace("bath.isbn=", "")
+        if isbn == self.LOC_MARC_ISBN:
+            body = """<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:numberOfRecords>1</zs:numberOfRecords><zs:records><zs:record><zs:recordData><record xmlns="http://www.loc.gov/MARC21/slim">
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Zone Completion Sample /</subfield>
+    <subfield code="c">Sample Author.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Congress Third edition.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Congress general note.</subfield>
+  </datafield>
+</record></zs:recordData></zs:record></zs:records></zs:searchRetrieveResponse>"""
+        else:
+            body = """<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/"><zs:numberOfRecords>0</zs:numberOfRecords><zs:records/></zs:searchRetrieveResponse>"""
+        self.send_response(200)
+        self.send_header("Content-Type", "application/xml; charset=utf-8")
         self.end_headers()
         self.wfile.write(body.encode("utf-8"))
 

--- a/tests/e2e/mock-metadata-server/server.py
+++ b/tests/e2e/mock-metadata-server/server.py
@@ -502,7 +502,14 @@ class MockMetadataHandler(http.server.BaseHTTPRequestHandler):
 
 if __name__ == "__main__":
     port = 9090
-    server = http.server.HTTPServer(("0.0.0.0", port), MockMetadataHandler)
+    # ThreadingHTTPServer, not HTTPServer (#439). The suite runs two Playwright
+    # workers, each scan spawns a background metadata fetch, and #439 added a
+    # second request per ISBN (the LoC SRU call) on top of the BnF one. A
+    # single-threaded server serialises all of that, and the added latency
+    # pushed the already-marginal 10 s waits in title-detail-volumes.spec.ts
+    # over budget — measured as a hard failure on the #439 branch where main
+    # only flaked. Threading removes the queue rather than papering over it.
+    server = http.server.ThreadingHTTPServer(("0.0.0.0", port), MockMetadataHandler)
     print(f"Mock metadata server running on port {port}")
     print(f"  BnF ISBNs: {list(BNF_KNOWN_ISBNS.keys())}")
     print(f"  Google Books ISBNs: {list(GOOGLE_BOOKS_KNOWN_ISBNS.keys())}")

--- a/tests/e2e/specs/journeys/admin-metadata-backfill.spec.ts
+++ b/tests/e2e/specs/journeys/admin-metadata-backfill.spec.ts
@@ -2,13 +2,17 @@ import { test, expect } from "@playwright/test";
 import { loginAs } from "../../helpers/auth";
 
 /**
- * #389 Palier 1 — admin "Backfill metadata from BnF" button.
+ * #389 Palier 1 — admin metadata-backfill button on the Health panel.
  *
  * Verifies the new admin action end-to-end: the button renders on the
  * Health panel (template + 4-locale label wiring) and POSTing to its
  * route runs the handler through CSRF and returns a valid feedback.
  *
- * The backfill shares the single stack-wide bulk-BnF status lock with
+ * #439 renamed the button: the action now draws on both national libraries
+ * (BnF and Library of Congress), so the copy no longer names a single one.
+ * The matcher below accepts the current wording in all four locales.
+ *
+ * The backfill shares the single stack-wide bulk-metadata status lock with
  * cover-refetch, so the button's enabled state is non-deterministic under
  * parallel execution. We therefore assert the button's PRESENCE via the UI
  * and drive the route via a direct POST (CSRF-authenticated) whose outcome
@@ -18,7 +22,7 @@ import { loginAs } from "../../helpers/auth";
  */
 test.describe("#389 — admin BnF metadata backfill", () => {
   const backfillButton =
-    /Backfill metadata from BnF|Compléter les métadonnées via BnF/i;
+    /Backfill metadata from libraries|Compléter les métadonnées via les bibliothèques|Metadaten von Bibliotheken nachladen|Recupera metadati dalle biblioteche/i;
 
   // Any of the three lock-state-dependent outcomes proves the handler ran.
   const validOutcome =

--- a/tests/e2e/specs/journeys/catalog-marc-zones.spec.ts
+++ b/tests/e2e/specs/journeys/catalog-marc-zones.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * #439 — MARC 21 zones from the Library of Congress complete what the BnF
+ * could not supply.
+ *
+ * The provider chain stops at the first provider that answers. In the test
+ * stack the BnF mock answers for any ISBN and supplies a statement of
+ * responsibility (UNIMARC 200$f) but no edition statement and no general note.
+ * Before #439 those two zones stayed empty forever, which is exactly the
+ * production symptom: the v1.13.0 backfill left anglophone titles at zero
+ * zones because the providers that answer for them carry no structured
+ * bibliographic data.
+ *
+ * The zone-completion pass must therefore reach past the winning provider to
+ * the Library of Congress and fill only the empty zones — without disturbing
+ * the ones already set.
+ *
+ * The ISBN is served by the LoC mocks in
+ * `tests/e2e/mock-metadata-server/server.py` (`LOC_MARC_ISBN`), which stub the
+ * flat JSON search and the SRU catalogue on separate paths.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../../helpers/auth";
+
+const ISBN = "9780449000014";
+
+test.describe("MARC 21 zone completion (#439)", () => {
+  test("a title resolved by another provider still gains LoC edition and note", async ({
+    page,
+  }) => {
+    await loginAs(page, "librarian");
+
+    await page.goto("/catalog");
+    const scanField = page.locator("#scan-field");
+    await scanField.fill(ISBN);
+    await scanField.press("Enter");
+    await page.waitForSelector(".feedback-skeleton, .feedback-entry", {
+      timeout: 10000,
+    });
+
+    // The metadata fetch is a background task, so poll the title page rather
+    // than the scan feedback: the zones land after the chain completes.
+    await page.goto(`/?q=${ISBN}`);
+    const titleLink = page
+      .locator('#browse-results table.browse-table tbody tr td a[href^="/title/"]')
+      .first();
+    await expect(titleLink).toBeVisible({ timeout: 15000 });
+    const href = (await titleLink.getAttribute("href"))!;
+
+    // Zone completion runs inside the async fetch; reload until the page
+    // shows it rather than sleeping on a guessed duration.
+    await expect(async () => {
+      await page.goto(href);
+      await expect(page.locator("main")).toContainText(
+        "Congress Third edition.",
+      );
+    }).toPass({ timeout: 30000 });
+
+    const main = page.locator("main");
+    await expect(main).toContainText("Congress general note.");
+
+    // And the zone the winning provider DID supply must survive untouched —
+    // first source wins, the completion pass never overwrites.
+    await expect(main).toContainText(/Statement of responsibility|Mention de responsabilité/i);
+  });
+});


### PR DESCRIPTION
Second half of v1.14.0, after the #440/#441/#442 cataloging bundle (#444). Extends the Library of Congress provider to fetch full MARC 21 records over SRU, so the anglophone titles that came out of the v1.13.0 backfill with zero UNIMARC zones can be enriched.

**No migration** — reuses the six columns created by `20260724000000_titles_unimarc_zones.sql` (#389).

### Progress

- [x] Shared MARC datafield/subfield reader (`metadata::marc`), `bnf.rs` delegating to it
- [x] SRU MARC 21 fetch, transport-level retry, chain zone-completion pass
- [x] Health-tab backfill button label (no longer BnF-only)
- [x] `docs/unimarc-mapping.md` MARC 21 column + manual ch. 5
- [x] E2E journey

### Measured against the live endpoint before writing any code

`http://lx2.loc.gov:210/LCDB`, 2026-07-28. Three findings shaped the implementation.

**1. Rate limiting is severe, and invisible to the existing back-off.**

| pacing | queried | answered | failures |
|---|---|---|---|
| 0.35 s | 113 | 34 | 79 |
| 2.0 s | 26 | 20 | 6 |

Every failure was a dropped connection, never an HTTP status. The server hangs up instead of answering 429, so `MetadataError::RateLimited` — and with it the #419 back-off, which keys on 429/503 — never fires. Hence retry on the **transport error**: three attempts, linear 2 s / 4 s spacing.

**2. Recovery is real but bounded.** Stratified sample, 6 per ISBN prefix: 9780 → 6/6, 9781 → 4/6, and **zero** for 9782, 9783, 9791, 9798. LoC covers exactly the anglophone gap BnF cannot, and nothing else. Production has 113 titles with an ISBN and all six zones empty, of which 66 carry 9780/9781 prefixes — projecting roughly 50–55 recoverable, an order of magnitude rather than a forecast. **The 39 French-prefix titles BnF already failed to fill will stay empty**; that belongs in the release notes so the backfill numbers are not misread.

**3. MARC 21 `500` repeats.** Confirmed on a live record carrying two. The shared reader gained `extract_subfields` (plural); the singular helper keeps documented first-wins semantics, because a joined blob reads badly on the title-detail page.

### Design notes

**SRU complements the JSON search, it does not replace it.** The flat `?fo=json` call alone supplies the cover URL, which a MARC record never carries. Both run for every ISBN rather than SRU-on-miss, because the target case is precisely an anglophone title where the JSON answers fine and simply has no structured data. An SRU failure is never fatal — it degrades to "no zones".

**Zone completion is gated on `supplies_marc_zones()`.** The chain stops at the first provider that answers, so implementing the settled field-by-field / first-source-wins merge needed a completion pass over the remaining providers. The first version triggered whenever *any* of the six zones was empty — but 490 (collection) and 240 (uniform title) are legitimately absent from most records, so "all six present" is the rare case and the pass would have swept the entire chain on nearly every lookup, including providers that carry no zones at all. A new trait method, true only for BnF and LoC, bounds it. A test counts calls to prove a zone-less provider is never consulted.

Only the six zones are merged, so a record's title, authors and cover still come from one provider and cannot become a chimera.

### Verification so far

1452 unit/integration passed, 0 failed. Clippy `--all-targets -D warnings` clean. `cargo sqlx prepare --check` clean. Parser tests run against a real captured record, namespace prefix and repeated fields intact.

### Landed after the first draft

**A dedicated zone entry point.** The completion pass called `lookup_by_isbn`, but the LoC provider returns `None` from that when its flat JSON search misses — and the JSON search and the SRU catalogue are different indexes that do not always agree. Completion routed through the normal lookup would have silently discarded recoverable zones on every disagreement. A `lookup_marc_zones` trait method now serves completion regardless of the primary verdict.

**A silent log made audible.** The completion log fired only when all six zones ended up filled, which almost never happens. The E2E run proved the gap: two zones recovered, nothing logged. It now reports any gain with the contributing provider and the counts — production backfills are audited from the log file (#434).

**A flake this branch caused, found and fixed.** `title-detail-volumes.spec.ts:22` hard-failed twice in full-suite runs here while `main` only flaked twice under identical conditions. Root cause: the E2E mock server ran single-threaded, and this branch adds a second HTTP request per ISBN. `ThreadingHTTPServer` restored parity across two further full runs. This does **not** fix #422 — that spec still flakes at main's baseline — it removes the contention this branch introduced. Recorded in #422 along with the wider finding that these specs' latency budgets sit close enough to the edge that one extra mocked request tips them over.

### Verification

1453 unit/integration passed, 0 failed. Two full E2E runs on a freshly reset stack: 310 passed, 0 failed. Clippy `--all-targets -D warnings`, `cargo sqlx prepare --check` and locale parity all clean.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

